### PR TITLE
Add go lint

### DIFF
--- a/.github/workflows/go_lint.yml
+++ b/.github/workflows/go_lint.yml
@@ -1,0 +1,23 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5
+        with:
+          go-version-file: './go.mod'
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 #v6
+        with:
+          version: v1.60

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,10 @@
+linters:
+  enable:
+    - errcheck        # Checks for unchecked errors
+    - gosimple        # Finds code simplifications
+    - govet           # Vet checks for various errors
+    - ineffassign     # Finds useless assignments
+    - staticcheck     # Comprehensive static analysis
+    - unused          # Finds unused variables, functions, etc.
+    - gosec           # Security checks for Go code
+    - goimports       # Checks import statements are formatted


### PR DESCRIPTION
This is the simple use of [golangci-lint-action](https://github.com/golangci/golangci-lint-action).

The enabled by default linters as follows: 
errcheck, gosimple, govet, ineffassign, staticcheck, unused.

I propose to add more linters from the list of [Disabled by default](https://golangci-lint.run/usage/linters/#disabled-by-default).

Your thoughts about which linters should be added is always appreciated.