### PR TITLE
CPLYTM-386 - Initial infrastructure for openscap-plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ dist
 
 # Dependency directories (remove the comment below to include it)
 vendor/
+
+# testing workspace created by openscap-plugin
+user_workspace

--- a/cmd/openscap-plugin/README.md
+++ b/cmd/openscap-plugin/README.md
@@ -1,0 +1,62 @@
+# openscap-plugin
+
+## Overview
+
+**openscap-plugin** is a plugin which extends the **ComplyTime** capabilities to use OpenSCAP. The plugin communicates with **ComplyTime** via gRPC (not yet implemented), providing a standard and consistent communication mechanism that gives independence for plugins developers to choose their preferred languages. This plugin is structured to allow modular development, ease of packaging, and maintainability.
+
+For now, this plugin is developed together with ComplyTime for better collaboration during this phase of the project. In the future, this plugin will likely be decoupled into its own repository.
+
+## Plugin Structure
+
+```
+openscap-plugin/
+├── config/             # Package for plugin configuration
+│ ├── config_test.go    # Tests for functions in config.go
+│ └── config.go         # Main code used to process plugin configuration
+├── oscap/              # Package to interact with oscap command
+│ ├── oscap_test.go     # Tests for functions in oscap.go
+│ └── oscap.go          # Main code used to interact with oscap command
+├── scan/               # Package to process system scan instructions
+│ ├── scan_test.go      # Tests for functions in scan.go
+│ └── scan.go           # Main code used to process scan instructions
+├── openscap-config.yml # Example of plugin configuration file (still in development)
+└── README.md           # This file
+```
+
+## Installation
+
+### Prerequisites
+
+- **Go** version 1.20 or higher
+- **Make** (optional, for using the `Makefile` if included)
+- **scap-security-guide** package installed
+
+### Clone the repository
+
+```bash
+git clone https://github.com/complytime/complytime.git
+cd complytime
+```
+
+## Build Instructions
+To compile complytime and openscap-plugin:
+
+```bash
+make build
+```
+
+## Running
+Scan the current system using pci-dss profile:
+
+```bash
+./bin/openscap-plugin -config cmd/openscap-plugin/openscap-plugin.yml
+```
+
+After the scan, check the files in "user_workspace" directory.
+
+### Testing
+Tests are organized within each package. Run tests using:
+
+```bash
+make test-units
+```

--- a/cmd/openscap-plugin/config/config.go
+++ b/cmd/openscap-plugin/config/config.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/cmd/openscap-plugin/config/config.go
+++ b/cmd/openscap-plugin/config/config.go
@@ -81,7 +81,12 @@ func EnsureDirectory(path string) error {
 func EnsureWorkspace(cfg *Config) (map[string]string, error) {
 	workspace, err := SanitizeAndValidatePath(cfg.Files.Workspace, true)
 	if err != nil {
-		return nil, err
+		if workspace == "" {
+			log.Printf("Informed workspace is not present. It will be created")
+			workspace = SanitizePath(cfg.Files.Workspace)
+		} else {
+			return nil, err
+		}
 	}
 
 	directories := map[string]string{

--- a/cmd/openscap-plugin/config/config.go
+++ b/cmd/openscap-plugin/config/config.go
@@ -1,0 +1,150 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Config struct {
+	Server struct {
+		Socket string `yaml:"socket"`
+	} `yaml:"server"`
+	Files struct {
+		PluginDir  string `yaml:"plugindir"`
+		Workspace  string `yaml:"workspace"`
+		Datastream string `yaml:"datastream"`
+		Results    string `yaml:"results"`
+		ARF        string `yaml:"arf"`
+		Policy     string `yaml:"policy"`
+	} `yaml:"files"`
+}
+
+func SanitizeInput(input string) (string, error) {
+	safePattern := regexp.MustCompile(`^[a-zA-Z0-9-_.]+$`)
+	if !safePattern.MatchString(input) {
+		return "", fmt.Errorf("input contains unexpected characters: %s", input)
+	}
+	return input, nil
+}
+
+func SanitizePath(path string) string {
+	return filepath.Clean(path)
+}
+
+func ValidatePath(path string, shouldBeDir bool) (string, error) {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+
+	if shouldBeDir && !stat.IsDir() {
+		return "", fmt.Errorf("expected a directory, but found a file at path: %s", path)
+	}
+	if !shouldBeDir && stat.IsDir() {
+		return "", fmt.Errorf("expected a file, but found a directory at path: %s", path)
+	}
+
+	return path, nil
+}
+
+func SanitizeAndValidatePath(path string, shouldBeDir bool) (string, error) {
+	cleanPath := SanitizePath(path)
+	validPath, err := ValidatePath(cleanPath, shouldBeDir)
+	if err != nil {
+		return "", err
+	}
+	return validPath, nil
+}
+
+func EnsureDirectory(path string) error {
+	_, err := os.Stat(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		err := os.MkdirAll(path, 0750)
+		if err != nil {
+			return fmt.Errorf("failed to create directory: %w", err)
+		}
+		log.Printf("Directory created: %s\n", path)
+	} else if err != nil {
+		return fmt.Errorf("error checking directory: %w", err)
+	}
+
+	return nil
+}
+
+func EnsureWorkspace(cfg *Config) (map[string]string, error) {
+	workspace, err := SanitizeAndValidatePath(cfg.Files.Workspace, true)
+	if err != nil {
+		return nil, err
+	}
+
+	directories := map[string]string{
+		"workspace":  workspace,
+		"pluginDir":  SanitizePath(workspace + "/" + cfg.Files.PluginDir),
+		"policyDir":  SanitizePath(workspace + "/" + cfg.Files.PluginDir + "/policy"),
+		"resultsDir": SanitizePath(workspace + "/" + cfg.Files.PluginDir + "/results"),
+	}
+
+	for key, dir := range directories {
+		if err := EnsureDirectory(dir); err != nil {
+			return nil, fmt.Errorf("failed to ensure directory %s (%s): %w", dir, key, err)
+		}
+	}
+
+	return directories, nil
+}
+
+func DefineFilesPaths(cfg *Config) (map[string]string, error) {
+	directories, err := EnsureWorkspace(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	files := map[string]string{
+		"datastream": SanitizePath(cfg.Files.Datastream),
+		"policy":     SanitizePath(directories["policyDir"] + "/" + cfg.Files.Policy),
+		"results":    SanitizePath(directories["resultsDir"] + "/" + cfg.Files.Results),
+		"arf":        SanitizePath(directories["resultsDir"] + "/" + cfg.Files.ARF),
+	}
+
+	return files, nil
+}
+
+func ReadConfig(configFile string) (*Config, error) {
+	config := &Config{}
+
+	file, err := os.Open(configFile)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	d := yaml.NewDecoder(file)
+	if err := d.Decode(&config); err != nil {
+		return nil, err
+	}
+
+	// String fields to sanitize
+	paths := []*string{
+		&config.Files.PluginDir,
+		&config.Files.Policy,
+		&config.Files.Results,
+		&config.Files.ARF,
+	}
+
+	for _, path := range paths {
+		sanitized, err := SanitizeInput(*path)
+		if err != nil {
+			return nil, err
+		}
+		*path = sanitized
+	}
+
+	return config, nil
+}

--- a/cmd/openscap-plugin/config/config_test.go
+++ b/cmd/openscap-plugin/config/config_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/cmd/openscap-plugin/config/config_test.go
+++ b/cmd/openscap-plugin/config/config_test.go
@@ -1,0 +1,140 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+// TestSanitizeInput tests the SanitizeInput function with various valid and invalid inputs.
+func TestSanitizeInput(t *testing.T) {
+	tests := []struct {
+		input       string
+		expected    string
+		expectError bool
+	}{
+		// Valid inputs
+		{"valid-input", "valid-input", false},
+		{"another_valid.input", "another_valid.input", false},
+		{"CAPS_and_numbers123", "CAPS_and_numbers123", false},
+		{"mixed-123.UP_case", "mixed-123.UP_case", false},
+
+		// Invalid inputs
+		{"invalid/input", "", true},     // contains /
+		{"input with spaces", "", true}, // contains spaces
+		{"invalid@input", "", true},     // contains @
+		{"<invalid>", "", true},         // contains < >
+		{";ls", "", true},               // contains ;
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result, err := SanitizeInput(tt.input)
+			if (err != nil) != tt.expectError {
+				t.Errorf("Expected error: %v, got: %v", tt.expectError, err)
+			}
+			if result != tt.expected {
+				t.Errorf("Expected result: %s, got: %s", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestSanitizePath tests the SanitizePath function with various inputs.
+func TestSanitizePath(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		// Normalizing paths
+		{"/foo/bar/../baz", "/foo/baz"},
+		{"./foo/bar", "foo/bar"},
+		{"foo/./bar", "foo/bar"},
+		{"foo/bar/..", "foo"},
+		{"/foo//bar", "/foo/bar"},
+		{"foo//bar//baz", "foo/bar/baz"},
+		{"foo/bar/../../baz", "baz"},
+		{"./../foo", "../foo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := SanitizePath(tt.input)
+			if result != tt.expected {
+				t.Errorf("Expected result: %s, got: %s", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestSanitizeAndValidatePath tests the SanitizeAndValidatePath function with various
+// valid and invalid paths.
+func TestSanitizeAndValidatePath(t *testing.T) {
+	tempDir := os.TempDir() + "/test_sanitize_and_validate_path"
+	tempFile := tempDir + "/testfile"
+
+	// Setup: create temporary directory and file
+	if err := os.MkdirAll(tempDir, 0750); err != nil {
+		t.Fatalf("Failed to create temporary directory: %v", err)
+	}
+	file, err := os.Create(tempFile)
+	if err != nil {
+		t.Fatalf("Failed to create temporary file: %v", err)
+	}
+	file.Close()
+	defer os.RemoveAll(tempDir)
+
+	tests := []struct {
+		path        string
+		shouldBeDir bool
+		expectError bool
+		expected    string
+	}{
+		// Valid cases
+		{tempDir, true, false, tempDir},    // directory exists
+		{tempFile, false, false, tempFile}, // file exists
+		{"/nonexistent", true, true, ""},   // directory does not exist
+		{"/nonexistent", false, true, ""},  // file does not exist
+
+		// Invalid cases
+		{tempFile, true, true, ""},          // expected directory but found file
+		{tempDir, false, true, ""},          // expected file but found directory
+		{"/foo/bar/../baz", true, true, ""}, // normalized path does not exist
+		{"./foo/bar", true, true, ""},       // relative path does not exist
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			result, err := SanitizeAndValidatePath(tt.path, tt.shouldBeDir)
+			if (err != nil) != tt.expectError {
+				t.Errorf("Expected error: %v, got: %v", tt.expectError, err)
+			}
+			if result != tt.expected {
+				t.Errorf("Expected result: %s, got: %s", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestEnsureDirectory tests that EnsureDirectory creates a directory if it doesn't exist
+// and handles errors correctly.
+func TestEnsureDirectory(t *testing.T) {
+	tempDir := os.TempDir() + "/test_ensure_directory"
+
+	if _, err := os.Stat(tempDir); err == nil {
+		os.RemoveAll(tempDir)
+	}
+
+	err := EnsureDirectory(tempDir)
+	if err != nil {
+		t.Fatalf("Expected no error, but got: %v", err)
+	}
+
+	if _, err := os.Stat(tempDir); err != nil {
+		t.Errorf("Expected directory to exist, but got error: %v", err)
+	}
+
+	defer os.RemoveAll(tempDir)
+}
+
+// Tests for ReadConfig, EnsureWorkspace, DefineFilesPaths and ReadConfig functions
+// must be created once the configuration file definition is stable.

--- a/cmd/openscap-plugin/main.go
+++ b/cmd/openscap-plugin/main.go
@@ -2,8 +2,47 @@
 
 package main
 
-import "fmt"
+import (
+	"flag"
+	"fmt"
+	"log"
+
+	"github.com/complytime/complytime/cmd/openscap-plugin/config"
+)
+
+func parseFlags() (string, error) {
+	var configPath string
+
+	flag.StringVar(&configPath, "config", "./openscap-plugin.yml", "Path to config file")
+	flag.Parse()
+
+	configFile, err := config.SanitizeAndValidatePath(configPath, false)
+	if err != nil {
+		return "", err
+	}
+
+	return configFile, nil
+}
+
+func initializeConfig() (*config.Config, error) {
+	configFile, err := parseFlags()
+	if err != nil {
+		return nil, fmt.Errorf("error parsing flags: %w", err)
+	}
+
+	config, err := config.ReadConfig(configFile)
+	if err != nil {
+		return nil, fmt.Errorf("error reading config from %s: %w", configFile, err)
+	}
+
+	return config, nil
+}
 
 func main() {
-	fmt.Print("OpenSCAP Plugin")
+	config, err := initializeConfig()
+	if err != nil {
+		log.Fatalf("Failed to initialize config: %v", err)
+	}
+
+	fmt.Print(config)
 }

--- a/cmd/openscap-plugin/main.go
+++ b/cmd/openscap-plugin/main.go
@@ -8,6 +8,7 @@ import (
 	"log"
 
 	"github.com/complytime/complytime/cmd/openscap-plugin/config"
+	"github.com/complytime/complytime/cmd/openscap-plugin/scan"
 )
 
 func parseFlags() (string, error) {
@@ -44,5 +45,12 @@ func main() {
 		log.Fatalf("Failed to initialize config: %v", err)
 	}
 
-	fmt.Print(config)
+	output, err := scan.ScanSystem(config, "cis")
+	if err != nil {
+		log.Printf("%v", err)
+	}
+
+	if output != nil {
+		fmt.Printf("Scan command output:\n%s", output)
+	}
 }

--- a/cmd/openscap-plugin/openscap-plugin.yml
+++ b/cmd/openscap-plugin/openscap-plugin.yml
@@ -3,7 +3,7 @@ server:
   socket: server_socket.sock
 files:
   datastream: /usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml
-  workspace: /tmp/comply/user_workspace
+  workspace: ./user_workspace
   plugindir: openscap
   policy: tailoring_policy.xml
   results: results.xml

--- a/cmd/openscap-plugin/openscap-plugin.yml
+++ b/cmd/openscap-plugin/openscap-plugin.yml
@@ -1,0 +1,10 @@
+server:
+  # For tests it is currently created in the homeDir
+  socket: server_socket.sock
+files:
+  datastream: /usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml
+  workspace: /tmp/comply/user_workspace
+  plugindir: openscap
+  policy: tailoring_policy.xml
+  results: results.xml
+  arf: arf.xml

--- a/cmd/openscap-plugin/oscap/oscap.go
+++ b/cmd/openscap-plugin/oscap/oscap.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package oscap
 
 import (

--- a/cmd/openscap-plugin/oscap/oscap.go
+++ b/cmd/openscap-plugin/oscap/oscap.go
@@ -1,0 +1,67 @@
+package oscap
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+
+	"github.com/complytime/complytime/cmd/openscap-plugin/config"
+)
+
+func constructScanCommand(openscapFiles map[string]string, profile string) ([]string, error) {
+	profileName, err := config.SanitizeInput(profile)
+	if err != nil {
+		return nil, err
+	}
+
+	datastream := openscapFiles["datastream"]
+	tailoringFile := openscapFiles["policy"]
+	resultsFile := openscapFiles["results"]
+	arfFile := openscapFiles["arf"]
+
+	cmd := []string{
+		"oscap",
+		"xccdf",
+		"eval",
+		"--profile",
+		profileName,
+		"--results",
+		resultsFile,
+		"--results-arf",
+		arfFile,
+	}
+
+	if tailoringFile != "" {
+		cmd = append(cmd, "--tailoring-file", tailoringFile)
+	}
+	cmd = append(cmd, datastream)
+	return cmd, nil
+}
+
+func OscapScan(openscapFiles map[string]string, profile string) ([]byte, error) {
+	command, err := constructScanCommand(openscapFiles, profile)
+	if err != nil {
+		return nil, err
+	}
+
+	cmdPath, err := exec.LookPath(command[0])
+	if err != nil {
+		return nil, fmt.Errorf("command not found: %s", command[0])
+	}
+
+	log.Printf("Executing the command: '%v'", command)
+	cmd := exec.Command(cmdPath, command[1:]...)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if err.Error() == "exit status 1" {
+			return output, fmt.Errorf("%s: error during evaluation", err)
+		} else if err.Error() == "exit status 2" {
+			return output, fmt.Errorf("%s: at least one rule resulted in fail or unknown", err)
+		} else {
+			return output, fmt.Errorf("all rules passed")
+		}
+	}
+
+	return output, nil
+}

--- a/cmd/openscap-plugin/oscap/oscap_test.go
+++ b/cmd/openscap-plugin/oscap/oscap_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package oscap
 
 import (

--- a/cmd/openscap-plugin/oscap/oscap_test.go
+++ b/cmd/openscap-plugin/oscap/oscap_test.go
@@ -1,0 +1,95 @@
+package oscap
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestConstructScanCommand(t *testing.T) {
+	tests := []struct {
+		name          string
+		openscapFiles map[string]string
+		profile       string
+		expectedCmd   []string
+		expectedErr   bool
+	}{
+		{
+			name: "Valid input with tailoring file",
+			openscapFiles: map[string]string{
+				"datastream": "test-datastream.xml",
+				"policy":     "test-policy.xml",
+				"results":    "test-results.xml",
+				"arf":        "test-arf.xml",
+			},
+			profile: "test-profile",
+			expectedCmd: []string{
+				"oscap",
+				"xccdf",
+				"eval",
+				"--profile",
+				"test-profile",
+				"--results",
+				"test-results.xml",
+				"--results-arf",
+				"test-arf.xml",
+				"--tailoring-file",
+				"test-policy.xml",
+				"test-datastream.xml",
+			},
+			expectedErr: false,
+		},
+		{
+			name: "Valid input without tailoring file",
+			openscapFiles: map[string]string{
+				"datastream": "test-datastream.xml",
+				"policy":     "",
+				"results":    "test-results.xml",
+				"arf":        "test-arf.xml",
+			},
+			profile: "test-profile",
+			expectedCmd: []string{
+				"oscap",
+				"xccdf",
+				"eval",
+				"--profile",
+				"test-profile",
+				"--results",
+				"test-results.xml",
+				"--results-arf",
+				"test-arf.xml",
+				"test-datastream.xml",
+			},
+			expectedErr: false,
+		},
+		// oscap command validates the profile existence during execution, so here the focus is
+		// more the provided input.
+		{
+			name: "Invalid profile input",
+			openscapFiles: map[string]string{
+				"datastream": "test-datastream.xml",
+				"policy":     "test-policy.xml",
+				"results":    "test-results.xml",
+				"arf":        "test-arf.xml",
+			},
+			profile:     "invalid-profile!",
+			expectedCmd: nil,
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, err := constructScanCommand(tt.openscapFiles, tt.profile)
+			if (err != nil) != tt.expectedErr {
+				t.Errorf("constructScanCommand() error = %v, expectedErr %v", err, tt.expectedErr)
+				return
+			}
+			if !reflect.DeepEqual(cmd, tt.expectedCmd) {
+				t.Errorf("constructScanCommand() = %v, expected %v", cmd, tt.expectedCmd)
+			}
+		})
+	}
+}
+
+// In a more advanced stage we could add tests for the OscapScan function using a minimalistic
+// version of a OpenSCAP Datastream, but for now it's not implemented.

--- a/cmd/openscap-plugin/scan/scan.go
+++ b/cmd/openscap-plugin/scan/scan.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package scan
 
 import (

--- a/cmd/openscap-plugin/scan/scan.go
+++ b/cmd/openscap-plugin/scan/scan.go
@@ -1,0 +1,90 @@
+package scan
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+
+	"github.com/complytime/complytime/cmd/openscap-plugin/config"
+	"github.com/complytime/complytime/cmd/openscap-plugin/oscap"
+)
+
+func isXMLFile(filePath string) (bool, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return false, fmt.Errorf("error opening file: %w", err)
+	}
+	defer file.Close()
+
+	decoder := xml.NewDecoder(file)
+	for {
+		_, err := decoder.Token()
+		if err != nil {
+			if err.Error() == "EOF" {
+				return true, nil
+			}
+			return false, fmt.Errorf("invalid XML: %w", err)
+		}
+	}
+}
+
+func validateDataStream(path string) (string, error) {
+	datastream, err := config.ValidatePath(path, false)
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := isXMLFile(datastream); err != nil {
+		return "", err
+	}
+	return datastream, nil
+}
+
+func validateTailoringFile(path string) (string, error) {
+	tailoringFile, err := config.ValidatePath(path, false)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", nil
+		} else {
+			return "", err
+		}
+	}
+
+	if _, err := isXMLFile(tailoringFile); err != nil {
+		return "", err
+	}
+	return tailoringFile, nil
+}
+
+func ScanSystem(cfg *config.Config, profile string) ([]byte, error) {
+	openscapFiles, err := config.DefineFilesPaths(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = validateDataStream(openscapFiles["datastream"])
+	if err != nil {
+		return nil, err
+	}
+
+	policy, err := validateTailoringFile(openscapFiles["policy"])
+	if err != nil {
+		return nil, err
+	}
+	if policy == "" {
+		openscapFiles["policy"] = ""
+	}
+
+	output, err := oscap.OscapScan(openscapFiles, profile)
+	if err != nil {
+		if output == nil {
+			return nil, err
+		} else {
+			return output, err
+		}
+	}
+
+	return output, nil
+}

--- a/cmd/openscap-plugin/scan/scan_test.go
+++ b/cmd/openscap-plugin/scan/scan_test.go
@@ -1,0 +1,186 @@
+package scan
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestIsXMLFile(t *testing.T) {
+	tests := []struct {
+		name      string
+		filePath  string
+		want      bool
+		expectErr bool
+	}{
+		{
+			name:      "Valid XML file",
+			filePath:  "testdata/valid.xml",
+			want:      true,
+			expectErr: false,
+		},
+		{
+			name:      "Invalid XML file",
+			filePath:  "testdata/invalid.xml",
+			want:      false,
+			expectErr: true,
+		},
+		{
+			name:      "Non-existent file",
+			filePath:  "testdata/nonexistent.xml",
+			want:      false,
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := isXMLFile(tt.filePath)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("isXMLFile() error = %v, expectErr %v", err, tt.expectErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("isXMLFile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateDataStream(t *testing.T) {
+	tests := []struct {
+		name      string
+		filePath  string
+		setup     func()
+		want      string
+		expectErr bool
+	}{
+		{
+			name:     "Valid datastream file",
+			filePath: "testdata/valid.xml",
+			setup: func() {
+				if err := os.WriteFile("testdata/valid.xml", []byte(`<root></root>`), 0600); err != nil {
+					t.Fatalf("Failed to write valid.xml: %v", err)
+				}
+			},
+			want:      "testdata/valid.xml",
+			expectErr: false,
+		},
+		{
+			name:     "Invalid datastream file",
+			filePath: "testdata/invalid.xml",
+			setup: func() {
+				if err := os.WriteFile("testdata/invalid.xml", []byte(`<root>`), 0600); err != nil {
+					t.Fatalf("Failed to write invalid.xml: %v", err)
+				}
+			},
+			want:      "",
+			expectErr: true,
+		},
+		{
+			name:      "Non-existent datastream file",
+			filePath:  "testdata/nonexistent.xml",
+			setup:     func() {},
+			want:      "",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setup()
+			got, err := validateDataStream(tt.filePath)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("validateDataStream() error = %v, expectErr %v", err, tt.expectErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("validateDataStream() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+func TestValidateTailoringFile(t *testing.T) {
+	tests := []struct {
+		name      string
+		filePath  string
+		setup     func()
+		want      string
+		expectErr bool
+	}{
+		{
+			name:     "Valid tailoring file",
+			filePath: "testdata/valid.xml",
+			setup: func() {
+				if err := os.WriteFile("testdata/valid.xml", []byte(`<root></root>`), 0600); err != nil {
+					t.Fatalf("Failed to write valid.xml: %v", err)
+				}
+			},
+			want:      "testdata/valid.xml",
+			expectErr: false,
+		},
+		{
+			name:     "Invalid tailoring file",
+			filePath: "testdata/invalid.xml",
+			setup: func() {
+				if err := os.WriteFile("testdata/invalid.xml", []byte(`<root>`), 0600); err != nil {
+					t.Fatalf("Failed to write invalid.xml: %v", err)
+				}
+			},
+			want:      "",
+			expectErr: true,
+		},
+		{
+			name:      "Non-existent tailoring file",
+			filePath:  "testdata/nonexistent.xml",
+			setup:     func() {},
+			want:      "",
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setup()
+			got, err := validateTailoringFile(tt.filePath)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("validateTailoringFile() error = %v, expectErr %v", err, tt.expectErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("validateTailoringFile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func setupTestFiles() error {
+	if err := os.MkdirAll("testdata", os.ModePerm); err != nil {
+		return err
+	}
+
+	if err := os.WriteFile("testdata/valid.xml", []byte(`<root></root>`), 0600); err != nil {
+		return err
+	}
+	if err := os.WriteFile("testdata/invalid.xml", []byte(`<root>`), 0600); err != nil {
+		return err
+	}
+	return nil
+}
+
+func teardownTestFiles() {
+	os.RemoveAll("testdata")
+}
+
+func TestMain(m *testing.M) {
+	if err := setupTestFiles(); err != nil {
+		fmt.Printf("Failed to setup test files: %v\n", err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	teardownTestFiles()
+	os.Exit(code)
+}
+
+// ScanSystem function is not tested because it is a high-level function that uses other functions
+// already tested above or in other packages.

--- a/cmd/openscap-plugin/scan/scan_test.go
+++ b/cmd/openscap-plugin/scan/scan_test.go
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package scan
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.10.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -30,7 +31,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240903143218-8af14fe29dc1 // indirect
 	google.golang.org/grpc v1.68.1 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/oscal-compass/compliance-to-policy-go/v2 => github.com/complytime/compliance-to-policy-go/v2 v2.0.0-20241218180447-536929e175fb


### PR DESCRIPTION
This PR introduces an initial infrastructure for `openscap-plugin` with an initial documentation about its structure.

It is a very initial stage and considerable changes are still expected in future PRs.
For now, it is providing the basic functionality to execute a scan using a hard-coded profile (cis).

Once this initial structure is merged, a separate PR will be proposed to bring more flexibility on arguments passed to the plugin. In the future, some of these arguments, such as the profile to be checked, are also expected to be provided by `complytime` CLI through gRPC.

So, many improvements are already planned for this initial plugin infrastructure.

### Review Hints

The commits are organized in a chronological sequence to make the review process easier.
In the README.md file introduced by this PR there are also some examples on how to test the plugin in the current state.