### PR TITLE
Include template for new PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+_Please include a summary of the changes and the context of this PR._
+
+## Related Issues
+_Inform any issues relevant to this PR. For example:_
+
+- _Closes #ISSUE_NUMBER_
+
+## Review Hints
+
+- _Review hints here. Replace this text. Don't use the italics format!_
+
+- _Use this optional section to give any relevant information that could help the reviewer to more quickly and assertively understand and test the changes._
+
+- _Good examples are useful commands, if it is better to review all commits together or in a suggested sequence, any relevant discussion in other PRs or issues, etc._


### PR DESCRIPTION
## Summary
It is a minimalist PR template intended to remind authors to provide relevant information that can help reviewers to more quickly review, test and provide feedback on PRs.

## Related Issue
- There is no file issue for this PR.

## Review Hints

- [GitHub documentation](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) about PR templates
- The template needs to be merged in order to be properly tested, but I created this PR already using the template structure so you can have a better idea on how it would look like.