### PR TITLE
Add complytime install and usage documentation to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,87 @@
 # complytime
 
+[![OpenSSF Best Practices status](https://www.bestpractices.dev/projects/9761/badge)](https://www.bestpractices.dev/projects/9761)
+[![GoDoc](https://img.shields.io/static/v1?label=godoc&message=reference&color=blue)](https://pkg.go.dev/github.com/complytime/complytime)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/helm/helm/badge)](https://scorecard.dev/viewer/?uri=github.com/complytime/complytime)
+
 ComplyTime leverages [OSCAL](https://github.com/usnistgov/OSCAL/) to perform compliance assessment activities, using plugins for each stage of the lifecycle.
 
-[![OpenSSF Best Practices status](https://www.bestpractices.dev/projects/9761/badge)](https://www.bestpractices.dev/projects/9761)
+## Install
+
+### Prerequisites
+
+- **Go** version 1.20 or higher
+- **Make** (optional, for using the `Makefile` if included)
+
+#### Using with the openscap-plugin
+- **openscap-scanner** package installed
+- **scap-security-guide** package installed
+
+### Clone the repository
+
+```bash
+git clone https://github.com/complytime/complytime.git
+cd complytime
+```
+
+### Build Instructions
+To compile complytime and openscap-plugin:
+
+```bash
+make build
+```
+
+The binaries can be found in the `bin/` directory in the local repo. Add it to your PATH and you are all set!
+
+## Usage
+
+### Install a plugin
+
+_Note: This is currently a manual process_
+
+```markdown
+After running complytime for the first time, the complytime
+directory should be created under $HOME/.config
+
+complytime
+├── bundles
+└── plugins
+```
+
+
+```bash
+cp myplugin ~/.config/complytime/plugins
+checksum=$(sha256sum ~/.config/complytime/plugins/myplugin | cut -d ' ' -f 1 )
+cat > ~/.config/complytime/plugins/c2p-myplugin-manifest.json << EOF
+{
+  "metadata": {
+    "id": "myplugin",
+    "description": "My complytime plugin",
+    "version": "0.0.1",
+    "types": ["pvp"]
+  },
+  "executablePath": "myplugin",
+  "sha256": "$checksum"
+}
+EOF
+```
+
+### Create configuration
+
+Plugin selection and input is configured through [OSCAL Component Definitions](https://pages.nist.gov/OSCAL-Reference/models/v1.1.3/component-definition/json-outline/).
+See `docs/samples/` for example configuration for the `myplugin` plugin.
+
+```bash
+cp docs/samples/sample-component-definition.json ~/.config/complytime/bundles
+```
+
+### Run ComplyTime
+```bash
+complytime generate
+complytime scan
+```
+
+## Community and Contribution
 
 - [Contributing](./docs/CONTRIBUTING.md)
 - [Style Guide](./docs/STYLE_GUIDE.md)

--- a/docs/samples/sample-component-definition.json
+++ b/docs/samples/sample-component-definition.json
@@ -49,7 +49,7 @@
           {
             "uuid": "bb6420f5-146c-44c0-b708-79b96e7a009e",
             "source": "profiles/example/profile.json",
-            "description": "My example profile/",
+            "description": "My example profile.",
             "implemented-requirements": [
               {
                 "uuid": "ed2ac4e9-d16a-4fc5-bd3a-13484b6d8fef",

--- a/docs/samples/sample-component-definition.json
+++ b/docs/samples/sample-component-definition.json
@@ -1,0 +1,109 @@
+{
+  "component-definition": {
+    "uuid": "7791eb3a-764a-41e0-8cd3-8d775c9e95bf",
+    "metadata": {
+      "title": "My sample component definition.",
+      "last-modified": "2023-02-21T06:53:42+00:00",
+      "version": "0.1.0",
+      "oscal-version": "1.1.2"
+    },
+    "components": [
+      {
+        "uuid": "7390f05c-d2b9-41d5-bf5f-3e6b17032d25",
+        "type": "software",
+        "title": "My Software",
+        "description": "My target software for validation.",
+        "props": [
+          {
+            "name": "Rule_Id",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "rule-1",
+            "remarks": "rule_set_00"
+          },
+          {
+            "name": "Rule_Description",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "My first rule",
+            "remarks": "rule_set_00"
+          },
+          {
+            "name": "Parameter_Id",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "param-1",
+            "remarks": "rule_set_00"
+          },
+          {
+            "name": "Parameter_Description",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "A parameter for a file name",
+            "remarks": "rule_set_00"
+          },
+          {
+            "name": "Parameter_Vault_Default",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "value-1",
+            "remarks": "rule_set_00"
+          }
+        ],
+        "control-implementations": [
+          {
+            "uuid": "bb6420f5-146c-44c0-b708-79b96e7a009e",
+            "source": "profiles/example/profile.json",
+            "description": "My example profile/",
+            "implemented-requirements": [
+              {
+                "uuid": "ed2ac4e9-d16a-4fc5-bd3a-13484b6d8fef",
+                "control-id": "example-1",
+                "description": "My example implemented requirement.",
+                "props": [
+                  {
+                    "name": "Rule_Id",
+                    "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+                    "value": "etcd_cert_file"
+                  },
+                  {
+                    "name": "Rule_Id",
+                    "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+                    "value": "etcd_key_file"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "b1c7a388-e8d4-4ff0-a249-0bb6686764cf",
+        "type": "validation",
+        "title": "myplugin",
+        "description": "An example validation component for myplugin",
+        "props": [
+          {
+            "name": "Rule_Id",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "rule-1",
+            "remarks": "rule_set_00"
+          },
+          {
+            "name": "Rule_Description",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "MY first rule",
+            "remarks": "rule_set_08"
+          },
+          {
+            "name": "Check_Id",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "check-1",
+            "remarks": "rule_set_00"
+          },
+          {
+            "name": "Check_Description",
+            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+            "value": "My first check",
+            "remarks": "rule_set_00"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds complytime install and usage documentation to README.md

## Related Issues

Related to #16 

## Review Hints

This contains testing steps and a sample configuration file for an example plugin called my `myplugin`. This example plugin is just used on the steps and was not created in this change.