### PR TITLE
feat: CPLYTM-432 add workflow for sonarcloud scans

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,25 @@
+---
+name: SonarCloud
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - '**.go'
+
+jobs:
+  sonarcloud:
+    if: ${{ github.event.pull_request.base.repo.url == github.event.pull_request.head.repo.url }}
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v4
+        with:
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@49e6cd3b187936a73b8280d59ffd9da69df63ec9 # pin@49e6cd3b187936a73b8280d59ffd9da69df63ec9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -9,6 +9,8 @@ on:
     paths:
       - '**.go'
 
+permissions: read-all
+
 jobs:
   sonarcloud:
     if: ${{ github.event.pull_request.base.repo.url == github.event.pull_request.head.repo.url }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,13 @@
+sonar.projectKey=rh-psce_complytime
+sonar.organization=rh-psce
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectName=complytime
+#sonar.projectVersion=1.0
+
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+#sonar.sources=.
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
This PR adds a basic GitHub workflow and config file for SonarCloud.  Additional Sonar scanning, such as code coverage, can be added in future PRs once this initial setup is complete.

SonarCloud results will be available at https://sonarcloud.io/project/configuration?id=rh-psce_complytime.