### PR TITLE
chore: bump action version for sonarcloud

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -37,12 +37,10 @@ jobs:
         with:
           name: coverage
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@49e6cd3b187936a73b8280d59ffd9da69df63ec9 # pin@49e6cd3b187936a73b8280d59ffd9da69df63ec9
+        uses: SonarSource/sonarcloud-github-action@02ef91109b2d589e757aefcfb2854c2783fd7b19 # pin@02ef91109b2d589e757aefcfb2854c2783fd7b19
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-	with:
+        with:
           args: >
-            -Dsonar.go.coverage.reportPaths=coverage.out
-            -Dsonar.projectKey=rh-psce_complytime
-            -Dsonar.organization=rh-psce
+            -Dsonar.go.coverage.reportPaths=coverage.out -Dsonar.projectKey=rh-psce_complytime -Dsonar.organization=rh-psce


### PR DESCRIPTION
Bumping the action version for SonarCloud based on the dependabot finding https://github.com/complytime/trestle-bot/pull/393