### PR TITLE
CPLYTM-476 - xccdf package for openscap-plugin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
+        exclude: "^internal/complytime/testdata/openscap/ssg-rhel-ds.xml$"
 -   repo: https://github.com/dnephin/pre-commit-golang
     rev: fb24a639f7c938759fe56eeebbb7713b69d60494 #v0.5.1
     hooks:

--- a/cmd/openscap-plugin/xccdf/datastream.go
+++ b/cmd/openscap-plugin/xccdf/datastream.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package xccdf
+
+import (
+	"github.com/antchfx/xmlquery"
+)
+
+// Getting rule information
+// Copied from https://github.com/ComplianceAsCode/compliance-operator/blob/fed54b4b761374578016d79d97bcb7636bf9d920/pkg/utils/parse_arf_result.go#L170
+
+func NewRuleHashTable(dsDom *xmlquery.Node) NodeByIdHashTable {
+	return newHashTableFromRootAndQuery(dsDom, "//ds:component/xccdf-1.2:Benchmark", "//xccdf-1.2:Rule")
+}
+
+func newHashTableFromRootAndQuery(dsDom *xmlquery.Node, root, query string) NodeByIdHashTable {
+	benchmarkDom := dsDom.SelectElement(root)
+	rules := benchmarkDom.SelectElements(query)
+	return newByIdHashTable(rules)
+}
+
+type NodeByIdHashTable map[string]*xmlquery.Node
+
+//type nodeByIdHashVariablesTable map[string][]string
+
+func newByIdHashTable(nodes []*xmlquery.Node) NodeByIdHashTable {
+	table := make(NodeByIdHashTable)
+	for i := range nodes {
+		ruleDefinition := nodes[i]
+		ruleId := ruleDefinition.SelectAttr("id")
+
+		table[ruleId] = ruleDefinition
+	}
+
+	return table
+}

--- a/cmd/openscap-plugin/xccdf/datastream.go
+++ b/cmd/openscap-plugin/xccdf/datastream.go
@@ -3,8 +3,49 @@
 package xccdf
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/antchfx/xmlquery"
 )
+
+func getDsProfileID(profileId string) string {
+	return fmt.Sprintf("xccdf_org.ssgproject.content_profile_%s", profileId)
+}
+
+func getDsElement(dsDom *xmlquery.Node, dsElement string) (*xmlquery.Node, error) {
+	return xmlquery.Query(dsDom, dsElement)
+}
+
+func loadDataStream(dsPath string) (*xmlquery.Node, error) {
+	file, err := os.Open(dsPath)
+	if err != nil {
+		return nil, fmt.Errorf("error opening datastream file: %s", err)
+	}
+	defer file.Close()
+
+	dsDom, err := xmlquery.Parse(file)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing datastream file: %s", err)
+	}
+
+	return dsDom, nil
+}
+
+func getDsProfileTitle(profileId string, dsPath string) (string, error) {
+	dsDom, err := loadDataStream(dsPath)
+	if err != nil {
+		return "", fmt.Errorf("error loading datastream: %s", err)
+	}
+
+	dsProfileID := getDsProfileID(profileId)
+	profile, err := getDsElement(dsDom, fmt.Sprintf("//xccdf-1.2:Profile[@id='%s']", dsProfileID))
+	if err != nil {
+		return "", fmt.Errorf("error finding profile %s in datastream: %s", dsProfileID, err)
+	}
+	profileTitle := profile.SelectElement("xccdf-1.2:title")
+	return profileTitle.InnerText(), nil
+}
 
 // Getting rule information
 // Copied from https://github.com/ComplianceAsCode/compliance-operator/blob/fed54b4b761374578016d79d97bcb7636bf9d920/pkg/utils/parse_arf_result.go#L170

--- a/cmd/openscap-plugin/xccdf/datastream.go
+++ b/cmd/openscap-plugin/xccdf/datastream.go
@@ -14,6 +14,7 @@ func getDsProfileID(profileId string) string {
 }
 
 func getDsElement(dsDom *xmlquery.Node, dsElement string) (*xmlquery.Node, error) {
+	// Returns nil if the element is not found
 	return xmlquery.Query(dsDom, dsElement)
 }
 
@@ -32,7 +33,7 @@ func loadDataStream(dsPath string) (*xmlquery.Node, error) {
 	return dsDom, nil
 }
 
-func getDsProfileTitle(profileId string, dsPath string) (string, error) {
+func GetDsProfileTitle(profileId string, dsPath string) (string, error) {
 	dsDom, err := loadDataStream(dsPath)
 	if err != nil {
 		return "", fmt.Errorf("error loading datastream: %s", err)
@@ -41,9 +42,17 @@ func getDsProfileTitle(profileId string, dsPath string) (string, error) {
 	dsProfileID := getDsProfileID(profileId)
 	profile, err := getDsElement(dsDom, fmt.Sprintf("//xccdf-1.2:Profile[@id='%s']", dsProfileID))
 	if err != nil {
-		return "", fmt.Errorf("error finding profile %s in datastream: %s", dsProfileID, err)
+		return "", fmt.Errorf("error processing profile %s in datastream: %s", dsProfileID, err)
 	}
-	profileTitle := profile.SelectElement("xccdf-1.2:title")
+
+	if profile == nil {
+		return "", fmt.Errorf("profile not found: %s", dsProfileID)
+	}
+
+	profileTitle, err := xmlquery.Query(profile, "xccdf-1.2:title")
+	if err != nil || profileTitle == nil {
+		return "", fmt.Errorf("error finding title element in profile %s: %s", dsProfileID, err)
+	}
 	return profileTitle.InnerText(), nil
 }
 

--- a/cmd/openscap-plugin/xccdf/datastream_test.go
+++ b/cmd/openscap-plugin/xccdf/datastream_test.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package xccdf
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/antchfx/xmlquery"
+)
+
+// TestGetDsProfileID tests the getDsProfileID function.
+func TestGetDsProfileID(t *testing.T) {
+	tests := []struct {
+		profileId string
+		expected  string
+	}{
+		{"test", "xccdf_org.ssgproject.content_profile_test"},
+		{"profile1", "xccdf_org.ssgproject.content_profile_profile1"},
+		{"", "xccdf_org.ssgproject.content_profile_"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.profileId, func(t *testing.T) {
+			result := getDsProfileID(tt.profileId)
+			if result != tt.expected {
+				t.Errorf("got %s, want %s", result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestGetDsElement tests the getDsElement function with the Profile "description" element.
+func TestGetDsElement(t *testing.T) {
+	dsFile := filepath.Join("..", "..", "..", "internal", "complytime", "testdata", "openscap", "ssg-rhel-ds.xml")
+	dsData, err := os.ReadFile(dsFile)
+	if err != nil {
+		t.Fatalf("failed to read Datastream file: %v", err)
+	}
+
+	doc, err := xmlquery.Parse(strings.NewReader(string(dsData)))
+	if err != nil {
+		t.Fatalf("failed to parse Datastream: %v", err)
+	}
+
+	tests := []struct {
+		dsElement string
+		expected  string
+		wantErr   bool
+	}{
+		{"//xccdf-1.2:Profile[@id='xccdf_org.ssgproject.content_profile_test_profile']", "This profile is only used for Unit Tests", false},
+		{"//xccdf-1.2:Profile[@id='xccdf_org.ssgproject.content_profile_absent']", "", false},
+		{"//invalid:Profile[@id='xccdf_org.ssgproject.content_profile_test_profile']", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.dsElement, func(t *testing.T) {
+			result, err := getDsElement(doc, tt.dsElement)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getDsElement() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if result != nil && err == nil {
+				profileDescription := result.SelectElement("xccdf-1.2:description")
+				if profileDescription.InnerText() != tt.expected {
+					t.Errorf("got %s, want %s", profileDescription.InnerText(), tt.expected)
+				}
+			}
+		})
+	}
+}
+
+// TestLoadDataStream tests the loadDataStream function.
+// Errors are expected for nonexistent and invalid XML files that cannot be parsed.
+func TestLoadDataStream(t *testing.T) {
+	testDataDir := filepath.Join("..", "..", "..", "internal", "complytime", "testdata", "openscap")
+
+	tests := []struct {
+		dsPath  string
+		wantErr bool
+	}{
+		{filepath.Join(testDataDir, "ssg-rhel-ds.xml"), false},
+		{filepath.Join(testDataDir, "nonexistent.xml"), true},
+		{filepath.Join(testDataDir, "invalid.xml"), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.dsPath, func(t *testing.T) {
+			_, err := loadDataStream(tt.dsPath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("loadDataStream() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestGetDsProfileTitle tests the GetDsProfileTitle function.
+// It also uses the getDsElement function with some additional logic specific for profile titles.
+func TestGetDsProfileTitle(t *testing.T) {
+	testDataDir := filepath.Join("..", "..", "..", "internal", "complytime", "testdata", "openscap")
+
+	tests := []struct {
+		profileId string
+		dsPath    string
+		expected  string
+		wantErr   bool
+	}{
+		{"test_profile", filepath.Join(testDataDir, "ssg-rhel-ds.xml"), "Test Profile", false},
+		{"test_profile_no_title", filepath.Join(testDataDir, "ssg-rhel-ds.xml"), "", true},
+		{"nonexistent_profile", filepath.Join(testDataDir, "ssg-rhel-ds.xml"), "", true},
+		{"invalid_profile", filepath.Join(testDataDir, "nonexistent.xml"), "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.profileId, func(t *testing.T) {
+			result, err := GetDsProfileTitle(tt.profileId, tt.dsPath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetDsProfileTitle() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if result != tt.expected {
+				t.Errorf("got %s, want %s", result, tt.expected)
+			}
+		})
+	}
+}

--- a/cmd/openscap-plugin/xccdf/tailoring.go
+++ b/cmd/openscap-plugin/xccdf/tailoring.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package xccdf
+
+import (
+	"encoding/xml"
+	"fmt"
+	"time"
+
+	"github.com/ComplianceAsCode/compliance-operator/pkg/xccdf"
+	"github.com/oscal-compass/compliance-to-policy-go/v2/policy"
+
+	"github.com/complytime/complytime/cmd/openscap-plugin/config"
+)
+
+const (
+	XCCDFNamespace       string = "complytime.openscapplugin"
+	XCCDFTailoringSuffix string = "complytime-tailoring-profile"
+)
+
+func getTailoringID() string {
+	return fmt.Sprintf("xccdf_%s_tailoring_%s", xccdf.XCCDFNamespace, XCCDFTailoringSuffix)
+}
+
+func getTailoringProfileID(profileId string) string {
+	return fmt.Sprintf(
+		"xccdf_%s_profile_%s_%s", xccdf.XCCDFNamespace, profileId, XCCDFTailoringSuffix)
+}
+
+func getTailoringProfileTitle(profileId string) string {
+	// TODO: Read the Datastream file to collect the title of the profile
+	// Include a prefix to the original title
+	// This field is expected to be read by humans, so the title here is better than the ID
+	return fmt.Sprintf("Complytime Tailoring Profile based on %s", profileId)
+}
+
+func getTailoringVersion() xccdf.VersionElement {
+	return xccdf.VersionElement{
+		Time:  time.Now().Format(time.RFC3339),
+		Value: "1",
+	}
+}
+
+func getTailoringBenchmarkHref(datastreamPath string) xccdf.BenchmarkElement {
+	return xccdf.BenchmarkElement{
+		Href: datastreamPath,
+	}
+}
+
+func getTailoringProfile(profileId string, tailoringPolicy policy.Policy) xccdf.ProfileElement {
+	return xccdf.ProfileElement{
+		ID: getTailoringProfileID(profileId),
+		Title: &xccdf.TitleOrDescriptionElement{
+			Value: getTailoringProfileTitle(profileId),
+		},
+		// TODO: Should include only the diff from the original profile in Datastream
+		Selections: getPolicySelections(tailoringPolicy),
+		Values:     getValuesFromPolicyVariables(tailoringPolicy),
+	}
+}
+
+func getPolicySelections(tailoringPolicy policy.Policy) []xccdf.SelectElement {
+	var selections []xccdf.SelectElement
+	for _, rule := range tailoringPolicy {
+		selections = append(selections, xccdf.SelectElement{
+			IDRef:    rule.Rule.ID,
+			Selected: true,
+		})
+	}
+	return selections
+}
+
+func getValuesFromPolicyVariables(tp policy.Policy) []xccdf.SetValueElement {
+	var values []xccdf.SetValueElement
+	if len(tp) != 0 {
+		for _, rule := range tp {
+			if rule.Rule.Parameter == nil {
+				continue
+			}
+
+			values = append(values, xccdf.SetValueElement{
+				IDRef: rule.Rule.Parameter.ID,
+				Value: rule.Rule.Parameter.Value,
+			})
+		}
+		return values
+	}
+
+	return nil
+}
+
+func PolicyToXML(tailoringPolicy policy.Policy, config *config.Config) (string, error) {
+	datastreamPath := config.Files.Datastream
+	profileId := config.Parameters.Profile
+
+	tailoring := xccdf.TailoringElement{
+		XMLNamespaceURI: xccdf.XCCDFURI,
+		ID:              getTailoringID(),
+		Version:         getTailoringVersion(),
+		Benchmark:       getTailoringBenchmarkHref(datastreamPath),
+		Profile:         getTailoringProfile(profileId, tailoringPolicy),
+	}
+
+	output, err := xml.MarshalIndent(tailoring, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return xccdf.XMLHeader + "\n" + string(output), nil
+}

--- a/cmd/openscap-plugin/xccdf/tailoring.go
+++ b/cmd/openscap-plugin/xccdf/tailoring.go
@@ -19,20 +19,21 @@ const (
 )
 
 func getTailoringID() string {
-	return fmt.Sprintf("xccdf_%s_tailoring_%s", xccdf.XCCDFNamespace, XCCDFTailoringSuffix)
+	return fmt.Sprintf("xccdf_%s_tailoring_%s", XCCDFNamespace, XCCDFTailoringSuffix)
 }
 
 func getTailoringProfileID(profileId string) string {
 	return fmt.Sprintf(
-		"xccdf_%s_profile_%s_%s", xccdf.XCCDFNamespace, profileId, XCCDFTailoringSuffix)
+		"xccdf_%s_profile_%s_%s", XCCDFNamespace, profileId, XCCDFTailoringSuffix)
 }
 
 func getTailoringProfileTitle(profileId string, dsPath string) string {
-	dsProfileTitle, err := getDsProfileTitle(profileId, dsPath)
+	dsProfileTitle, err := GetDsProfileTitle(profileId, dsPath)
 	if err != nil {
-		return fmt.Sprintf("Complytime Tailoring Profile based on %s", profileId)
+		// log error
+		dsProfileTitle = profileId
 	}
-	return fmt.Sprintf("ComplyTime Tailoring - %s", dsProfileTitle)
+	return fmt.Sprintf("ComplyTime Tailoring Profile - %s", dsProfileTitle)
 }
 
 func getTailoringVersion() xccdf.VersionElement {

--- a/cmd/openscap-plugin/xccdf/tailoring_test.go
+++ b/cmd/openscap-plugin/xccdf/tailoring_test.go
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package xccdf
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ComplianceAsCode/compliance-operator/pkg/xccdf"
+	"github.com/complytime/complytime/cmd/openscap-plugin/config"
+	"github.com/oscal-compass/compliance-to-policy-go/v2/policy"
+	"github.com/oscal-compass/oscal-sdk-go/extensions"
+)
+
+// TestGetTailoringID tests the getTailoringID function.
+func TestGetTailoringID(t *testing.T) {
+	expected := "xccdf_complytime.openscapplugin_tailoring_complytime-tailoring-profile"
+	result := getTailoringID()
+
+	if result != expected {
+		t.Errorf("getTailoringID() = %v; want %v", result, expected)
+	}
+}
+
+// TestGetTailoringProfileID tests the getTailoringProfileID function.
+func TestGetTailoringProfileID(t *testing.T) {
+	profileId := "test-profile"
+	expected := "xccdf_complytime.openscapplugin_profile_test-profile_complytime-tailoring-profile"
+	result := getTailoringProfileID(profileId)
+
+	if result != expected {
+		t.Errorf("getTailoringProfileID(%v) = %v; want %v", profileId, result, expected)
+	}
+}
+
+// TestGetTailoringProfileTitle tests the getTailoringProfileTitle function.
+func TestGetTailoringProfileTitle(t *testing.T) {
+	dsPath := filepath.Join("..", "..", "..", "internal", "complytime", "testdata", "openscap", "ssg-rhel-ds.xml")
+
+	tests := []struct {
+		profileId string
+		dsPath    string
+		expected  string
+	}{
+		{"test_profile", dsPath, "ComplyTime Tailoring Profile - Test Profile"},
+		{"no-ds-profile", dsPath, "ComplyTime Tailoring Profile - no-ds-profile"},
+		{"test_profile_no_title", dsPath, "ComplyTime Tailoring Profile - test_profile_no_title"},
+	}
+
+	for _, tt := range tests {
+		result := getTailoringProfileTitle(tt.profileId, tt.dsPath)
+		if result != tt.expected {
+			t.Errorf("getTailoringProfileTitle(%v, %v) = %v; want %v", tt.profileId, tt.dsPath, result, tt.expected)
+		}
+	}
+}
+
+// TestGetTailoringVersion tests the getTailoringVersion function.
+func TestGetTailoringVersion(t *testing.T) {
+	result := getTailoringVersion()
+
+	if result.Value != "1" {
+		t.Errorf("getTailoringVersion().Value = %v; want %v", result.Value, "1")
+	}
+
+	_, err := time.Parse(time.RFC3339, result.Time)
+	if err != nil {
+		t.Errorf("getTailoringVersion().Time = %v; not in RFC3339 format", result.Time)
+	}
+}
+
+// TestGetTailoringBenchmarkHref tests the getTailoringBenchmarkHref function.
+func TestGetTailoringBenchmarkHref(t *testing.T) {
+	dsPath := filepath.Join("..", "..", "..", "internal", "complytime", "testdata", "openscap", "ssg-rhel-ds.xml")
+	expected := xccdf.BenchmarkElement{
+		Href: dsPath,
+	}
+	result := getTailoringBenchmarkHref(dsPath)
+
+	if result != expected {
+		t.Errorf("getTailoringBenchmarkHref(%v) = %v; want %v", dsPath, result, expected)
+	}
+}
+
+// TestGetTailoringProfile tests the getTailoringProfile function.
+func TestGetTailoringProfile(t *testing.T) {
+	profileId := "test-profile"
+	dsPath := filepath.Join("..", "..", "..", "internal", "complytime", "testdata", "openscap", "ssg-rhel-ds.xml")
+	tailoringPolicy := policy.Policy{
+		{
+			Rule: extensions.Rule{
+				ID:          "rule1",
+				Description: "rule1_description",
+				Parameter: &extensions.Parameter{
+					ID:          "param1",
+					Description: "param1_description",
+					Value:       "value1",
+				},
+			},
+		},
+	}
+
+	expected := xccdf.ProfileElement{
+		ID: getTailoringProfileID(profileId),
+		Title: &xccdf.TitleOrDescriptionElement{
+			Value: getTailoringProfileTitle(profileId, dsPath),
+		},
+		Selections: []xccdf.SelectElement{
+			{IDRef: "rule1", Selected: true},
+		},
+		Values: []xccdf.SetValueElement{
+			{IDRef: "param1", Value: "value1"},
+		},
+	}
+
+	result := getTailoringProfile(profileId, tailoringPolicy, dsPath)
+
+	if result.ID != expected.ID {
+		t.Errorf("getTailoringProfile().ID = %v; want %v", result.ID, expected.ID)
+	}
+	if result.Title.Value != expected.Title.Value {
+		t.Errorf("getTailoringProfile().Title.Value = %v; want %v", result.Title.Value, expected.Title.Value)
+	}
+	if len(result.Selections) != len(expected.Selections) {
+		t.Errorf("getTailoringProfile().Selections = %v; want %v", result.Selections, expected.Selections)
+	}
+	if len(result.Values) != len(expected.Values) {
+		t.Errorf("getTailoringProfile().Values = %v; want %v", result.Values, expected.Values)
+	}
+}
+
+// TestGetPolicySelections tests the getPolicySelections function.
+func TestGetPolicySelections(t *testing.T) {
+	tailoringPolicy := policy.Policy{
+		{
+			Rule: extensions.Rule{
+				ID:          "rule1",
+				Description: "rule1_description",
+			},
+		},
+		{
+			Rule: extensions.Rule{
+				ID:          "rule2",
+				Description: "rule2_description",
+			},
+		},
+	}
+
+	expected := []xccdf.SelectElement{
+		{IDRef: "rule1", Selected: true},
+		{IDRef: "rule2", Selected: true},
+	}
+
+	result := getPolicySelections(tailoringPolicy)
+
+	if len(result) != len(expected) {
+		t.Errorf("getPolicySelections() length = %v; want %v", len(result), len(expected))
+	}
+
+	for i, selection := range result {
+		if selection.IDRef != expected[i].IDRef || selection.Selected != expected[i].Selected {
+			t.Errorf("getPolicySelections()[%d] = %v; want %v", i, selection, expected[i])
+		}
+	}
+}
+
+// TestGetValuesFromPolicyVariables tests the getValuesFromPolicyVariables function.
+func TestGetValuesFromPolicyVariables(t *testing.T) {
+	tests := []struct {
+		name            string
+		tailoringPolicy policy.Policy
+		expected        []xccdf.SetValueElement
+	}{
+		{
+			name: "Single rule with parameter",
+			tailoringPolicy: policy.Policy{
+				{
+					Rule: extensions.Rule{
+						ID:          "rule1",
+						Description: "rule1_description",
+						Parameter: &extensions.Parameter{
+							ID:          "param1",
+							Description: "param1_description",
+							Value:       "value1",
+						},
+					},
+				},
+			},
+			expected: []xccdf.SetValueElement{
+				{IDRef: "param1", Value: "value1"},
+			},
+		},
+		{
+			name: "Multiple rules with parameters",
+			tailoringPolicy: policy.Policy{
+				{
+					Rule: extensions.Rule{
+						ID:          "rule1",
+						Description: "rule1_description",
+						Parameter: &extensions.Parameter{
+							ID:          "param1",
+							Description: "param1_description",
+							Value:       "value1",
+						},
+					},
+				},
+				{
+					Rule: extensions.Rule{
+						ID:          "rule2",
+						Description: "rule2_description",
+						Parameter: &extensions.Parameter{
+							ID:          "param2",
+							Description: "param2_description",
+							Value:       "value2",
+						},
+					},
+				},
+			},
+			expected: []xccdf.SetValueElement{
+				{IDRef: "param1", Value: "value1"},
+				{IDRef: "param2", Value: "value2"},
+			},
+		},
+		{
+			name: "Rule without parameter",
+			tailoringPolicy: policy.Policy{
+				{
+					Rule: extensions.Rule{
+						ID:          "rule1",
+						Description: "rule1_description",
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name:            "Empty policy",
+			tailoringPolicy: policy.Policy{},
+			expected:        nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getValuesFromPolicyVariables(tt.tailoringPolicy)
+			if len(result) != len(tt.expected) {
+				t.Errorf("getValuesFromPolicyVariables() length = %v; want %v", len(result), len(tt.expected))
+			}
+			for i, value := range result {
+				if value.IDRef != tt.expected[i].IDRef || value.Value != tt.expected[i].Value {
+					t.Errorf("getValuesFromPolicyVariables()[%d] = %v; want %v", i, value, tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+// TestPolicyToXML tests the PolicyToXML function.
+func TestPolicyToXML(t *testing.T) {
+	tempDir := t.TempDir()
+	dsPath := filepath.Join("..", "..", "..", "internal", "complytime", "testdata", "openscap", "ssg-rhel-ds.xml")
+	profileId := "test_profile"
+
+	tailoringPolicy := policy.Policy{
+		{
+			Rule: extensions.Rule{
+				ID:          "rule1",
+				Description: "rule1_description",
+				Parameter: &extensions.Parameter{
+					ID:          "param1",
+					Description: "param1_description",
+					Value:       "value1",
+				},
+			},
+		},
+	}
+
+	cfg := &config.Config{
+		Files: struct {
+			PluginDir  string "yaml:\"plugindir\""
+			Workspace  string "yaml:\"workspace\""
+			Datastream string "yaml:\"datastream\""
+			Results    string "yaml:\"results\""
+			ARF        string "yaml:\"arf\""
+			Policy     string "yaml:\"policy\""
+		}{
+			PluginDir:  "plugins",
+			Workspace:  filepath.Join(tempDir, "workspace"),
+			Datastream: dsPath,
+			Results:    "results.xml",
+			ARF:        "arf.xml",
+			Policy:     "absent_policy.yaml",
+		},
+		Parameters: struct {
+			Profile string `yaml:"profile"`
+		}{
+			Profile: profileId,
+		},
+	}
+
+	expectedXML := `<?xml version="1.0" encoding="UTF-8"?>
+<xccdf-1.2:Tailoring xmlns:xccdf-1.2="http://checklists.nist.gov/xccdf/1.2" id="xccdf_complytime.openscapplugin_tailoring_complytime-tailoring-profile">
+  <xccdf-1.2:benchmark href="` + dsPath + `"></xccdf-1.2:benchmark>
+  <xccdf-1.2:version time="` + getTailoringVersion().Time + `">1</xccdf-1.2:version>
+  <xccdf-1.2:Profile id="xccdf_complytime.openscapplugin_profile_test_profile_complytime-tailoring-profile">
+    <xccdf-1.2:title override="false">ComplyTime Tailoring Profile - Test Profile</xccdf-1.2:title>
+    <xccdf-1.2:select idref="rule1" selected="true"></xccdf-1.2:select>
+    <xccdf-1.2:set-value idref="param1">value1</xccdf-1.2:set-value>
+  </xccdf-1.2:Profile>
+</xccdf-1.2:Tailoring>`
+
+	result, err := PolicyToXML(tailoringPolicy, cfg)
+	if err != nil {
+		t.Fatalf("PolicyToXML() error = %v", err)
+	}
+
+	if result != expectedXML {
+		t.Errorf("PolicyToXML() = %v; want %v", result, expectedXML)
+	}
+}

--- a/cmd/openscap-plugin/xccdf/tailoring_test.go
+++ b/cmd/openscap-plugin/xccdf/tailoring_test.go
@@ -258,7 +258,6 @@ func TestGetValuesFromPolicyVariables(t *testing.T) {
 
 // TestPolicyToXML tests the PolicyToXML function.
 func TestPolicyToXML(t *testing.T) {
-	tempDir := t.TempDir()
 	dsPath := filepath.Join("..", "..", "..", "internal", "complytime", "testdata", "openscap", "ssg-rhel-ds.xml")
 	profileId := "test_profile"
 
@@ -276,28 +275,9 @@ func TestPolicyToXML(t *testing.T) {
 		},
 	}
 
-	cfg := &config.Config{
-		Files: struct {
-			PluginDir  string "yaml:\"plugindir\""
-			Workspace  string "yaml:\"workspace\""
-			Datastream string "yaml:\"datastream\""
-			Results    string "yaml:\"results\""
-			ARF        string "yaml:\"arf\""
-			Policy     string "yaml:\"policy\""
-		}{
-			PluginDir:  "plugins",
-			Workspace:  filepath.Join(tempDir, "workspace"),
-			Datastream: dsPath,
-			Results:    "results.xml",
-			ARF:        "arf.xml",
-			Policy:     "absent_policy.yaml",
-		},
-		Parameters: struct {
-			Profile string `yaml:"profile"`
-		}{
-			Profile: profileId,
-		},
-	}
+	cfg := new(config.Config)
+	cfg.Files.Datastream = dsPath
+	cfg.Parameters.Profile = profileId
 
 	expectedXML := `<?xml version="1.0" encoding="UTF-8"?>
 <xccdf-1.2:Tailoring xmlns:xccdf-1.2="http://checklists.nist.gov/xccdf/1.2" id="xccdf_complytime.openscapplugin_tailoring_complytime-tailoring-profile">

--- a/internal/complytime/testdata/openscap/invalid.xml
+++ b/internal/complytime/testdata/openscap/invalid.xml
@@ -1,0 +1,12 @@
+<[?xml version="1.0" encoding="utf-8"?>
+<ds:data-stream-collection xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog" xmlns:cpe-dict="http://cpe.mitre.org/dictionary/2.0" xmlns:cpe-lang="http://cpe.mitre.org/language/2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ds="http://scap.nist.gov/schema/scap/source/1.2" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:ind="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:linux="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" xmlns:ocil="http://scap.nist.gov/schema/ocil/2.0" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:sce="http://open-scap.org/page/SCE_xccdf_stream" xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" xmlns:xccdf-1.2="http://checklists.nist.gov/xccdf/1.2" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="scap_org.open-scap_collection_from_xccdf_ssg-rhel10-xccdf.xml" schematron-version="1.3">
+  <ds:data-stream id="scap_org.open-scap_datastream_from_xccdf_ssg-rhel10-xccdf.xml" scap-version="1.3" use-case="OTHER">
+    <ds:dictionaries>
+      <ds:component-ref id="scap_org.open-scap_cref_ssg-rhel10-cpe-dictionary.xml" xlink:href="#scap_org.open-scap_comp_ssg-rhel10-cpe-dictionary.xml">
+        <cat:catalog>
+          <cat:uri name="ssg-rhel10-cpe-oval.xml" uri="#scap_org.open-scap_cref_ssg-rhel10-cpe-oval.xml"/>
+        </cat:catalog>
+      </ds:component-ref>
+    </ds:dictionaries>
+  </ds:data-stream>
+</ds:data-stream-collection>


### PR DESCRIPTION
## Summary

With openscap-plugins the system will be scanned with the Datastream files provided by `scap-security-guide` package.
However, the OSCAL profile may select different rules and parameters from the Datastream profile.
In this scenario, the openscap-plugin will use a tailoring file based on the OSCAL Profile to scan the system.

This PR introduces the `xccdf` package for openscap-plugin to create the initial structure to manage OpenSCAP Tailoring files. The existing code in `server.go` that was related to tailoring and XCCDF was also moved to the new package.

## Related Issues

- Relates to CPLYTM-476

## Review Hints

Take a look at the commit descriptions for more details.
Also take into consideration that more code is expected for this package, so this PR includes the minimal working structure to enable more changes in separate PRs.

For unit tests
`make test-unit`

