### PR TITLE
CPLYTM-474 - Allow openscap-plugin to collect variables and options from Datastream

### DIFF
--- a/cmd/openscap-plugin/xccdf/datastream.go
+++ b/cmd/openscap-plugin/xccdf/datastream.go
@@ -10,15 +10,6 @@ import (
 	"github.com/antchfx/xmlquery"
 )
 
-func getDsProfileID(profileId string) string {
-	return fmt.Sprintf("xccdf_org.ssgproject.content_profile_%s", profileId)
-}
-
-func getDsElement(dsDom *xmlquery.Node, dsElement string) (*xmlquery.Node, error) {
-	// Returns nil if the element is not found
-	return xmlquery.Query(dsDom, dsElement)
-}
-
 func loadDataStream(dsPath string) (*xmlquery.Node, error) {
 	file, err := os.Open(dsPath)
 	if err != nil {
@@ -32,6 +23,15 @@ func loadDataStream(dsPath string) (*xmlquery.Node, error) {
 	}
 
 	return dsDom, nil
+}
+
+func getDsProfileID(profileId string) string {
+	return fmt.Sprintf("xccdf_org.ssgproject.content_profile_%s", profileId)
+}
+
+func getDsElement(dsDom *xmlquery.Node, dsElement string) (*xmlquery.Node, error) {
+	// Returns nil if the element is not found
+	return xmlquery.Query(dsDom, dsElement)
 }
 
 func getDsProfile(dsDom *xmlquery.Node, dsProfileID string) (*xmlquery.Node, error) {
@@ -103,15 +103,6 @@ func initProfile(dsProfile *xmlquery.Node, dsProfileId string) (*xccdf.ProfileEl
 	return parsedProfile, nil
 }
 
-func GetDsProfileTitle(profileId string, dsPath string) (string, error) {
-	profile, err := GetDsProfile(profileId, dsPath)
-	if err != nil {
-		return "", fmt.Errorf("error processing profile %s in datastream: %s", profileId, err)
-	}
-
-	return profile.Title.Value, nil
-}
-
 func GetDsProfile(profileId string, dsPath string) (*xccdf.ProfileElement, error) {
 	dsDom, err := loadDataStream(dsPath)
 	if err != nil {
@@ -134,6 +125,17 @@ func GetDsProfile(profileId string, dsPath string) (*xccdf.ProfileElement, error
 	}
 
 	return parsedProfile, nil
+}
+
+func GetDsProfileTitle(profileId string, dsPath string) (string, error) {
+	// TODO: This function can likely be removed with the introduction of the GetDsProfile function.
+	// Keeping it for now to avoid out of scope changes.
+	profile, err := GetDsProfile(profileId, dsPath)
+	if err != nil {
+		return "", fmt.Errorf("error processing profile %s in datastream: %s", profileId, err)
+	}
+
+	return profile.Title.Value, nil
 }
 
 // Getting rule information

--- a/cmd/openscap-plugin/xccdf/datastream.go
+++ b/cmd/openscap-plugin/xccdf/datastream.go
@@ -10,6 +10,19 @@ import (
 	"github.com/antchfx/xmlquery"
 )
 
+// The following structs can later be proposed to compliance-operator/pkg/xccdf
+type DsVariableOptions struct {
+	Selector string `xml:"selector,attr"`
+	Value    string `xml:",chardata"`
+}
+
+type DsVariables struct {
+	ID          string `xml:"idref,attr"`
+	Title       string `xml:",chardata"`
+	Description string `xml:",chardata"`
+	Options     []DsVariableOptions
+}
+
 func loadDataStream(dsPath string) (*xmlquery.Node, error) {
 	file, err := os.Open(dsPath)
 	if err != nil {
@@ -30,32 +43,59 @@ func getDsProfileID(profileId string) string {
 }
 
 func getDsElement(dsDom *xmlquery.Node, dsElement string) (*xmlquery.Node, error) {
-	// Returns nil if the element is not found
+	if dsDom == nil {
+		return nil, fmt.Errorf("dsDom is nil")
+	}
+	// NOTE: If the element is not found in dsDom, returns nil and not an error
 	return xmlquery.Query(dsDom, dsElement)
+}
+
+func getDsElementAttrValue(dsElement *xmlquery.Node, attrName string) (string, error) {
+	for _, attr := range dsElement.Attr {
+		if attr.Name.Local == attrName {
+			return dsElement.SelectAttr(attrName), nil
+		}
+	}
+	return "", fmt.Errorf("attribute not found")
+}
+
+func getDsOptionalAttrValue(dsElement *xmlquery.Node, optionalAttrName string) string {
+	attrValue, err := getDsElementAttrValue(dsElement, optionalAttrName)
+	if err != nil {
+		return ""
+	}
+	return attrValue
+}
+
+func getDsElements(dsDom *xmlquery.Node, dsElement string) ([]*xmlquery.Node, error) {
+	if dsDom == nil {
+		return nil, fmt.Errorf("dsDom is nil")
+	}
+	return xmlquery.QueryAll(dsDom, dsElement)
 }
 
 func getDsProfile(dsDom *xmlquery.Node, dsProfileID string) (*xmlquery.Node, error) {
 	return getDsElement(dsDom, fmt.Sprintf("//xccdf-1.2:Profile[@id='%s']", dsProfileID))
 }
 
-func getDsProfileTitle(dsProfile *xmlquery.Node) (*xmlquery.Node, error) {
+func getDsElementTitle(dsProfile *xmlquery.Node) (*xmlquery.Node, error) {
 	profileTitle, err := getDsElement(dsProfile, "xccdf-1.2:title")
 	if err != nil {
-		return nil, fmt.Errorf("error finding title element in profile: %s", err)
+		return nil, fmt.Errorf("error finding 'title' element: %s", err)
 	}
 	return profileTitle, nil
 }
 
-func getDsProfileDescription(dsProfile *xmlquery.Node) (*xmlquery.Node, error) {
+func getDsElementDescription(dsProfile *xmlquery.Node) (*xmlquery.Node, error) {
 	profileDescription, err := getDsElement(dsProfile, "xccdf-1.2:description")
-	if err != nil || profileDescription == nil {
-		return nil, fmt.Errorf("error finding description element in profile: %s", err)
+	if err != nil {
+		return nil, fmt.Errorf("error finding 'description' element: %s", err)
 	}
 	return profileDescription, nil
 }
 
 func populateProfileInfo(dsProfile *xmlquery.Node, parsedProfile *xccdf.ProfileElement) (*xccdf.ProfileElement, error) {
-	profileTitle, err := getDsProfileTitle(dsProfile)
+	profileTitle, err := getDsElementTitle(dsProfile)
 	if err != nil {
 		return parsedProfile, fmt.Errorf("error populating profile title: %s", err)
 	}
@@ -64,7 +104,7 @@ func populateProfileInfo(dsProfile *xmlquery.Node, parsedProfile *xccdf.ProfileE
 	}
 	if profileTitle == nil {
 		// log that profile title was not found.
-		// It is a valid case therefore but better to log it.
+		// It is a valid case but may not be expected so better to log it.
 		parsedProfile.Title.Override = false
 		parsedProfile.Title.Value = ""
 	} else {
@@ -72,7 +112,7 @@ func populateProfileInfo(dsProfile *xmlquery.Node, parsedProfile *xccdf.ProfileE
 		parsedProfile.Title.Value = profileTitle.InnerText()
 	}
 
-	profileDescription, err := getDsProfileDescription(dsProfile)
+	profileDescription, err := getDsElementDescription(dsProfile)
 	if err != nil {
 		return parsedProfile, fmt.Errorf("error populating profile description: %s", err)
 	}
@@ -81,6 +121,7 @@ func populateProfileInfo(dsProfile *xmlquery.Node, parsedProfile *xccdf.ProfileE
 	}
 	if profileDescription == nil {
 		// log that profile description was not found.
+		// It is a valid case but may not be expected so better to log it.
 		parsedProfile.Description.Override = false
 		parsedProfile.Description.Value = ""
 	} else {
@@ -91,6 +132,34 @@ func populateProfileInfo(dsProfile *xmlquery.Node, parsedProfile *xccdf.ProfileE
 	return parsedProfile, nil
 }
 
+func populateProfileVariables(dsProfile *xmlquery.Node, parsedProfile *xccdf.ProfileElement) (*xccdf.ProfileElement, error) {
+	if parsedProfile.Values == nil {
+		parsedProfile.Values = []xccdf.SetValueElement{}
+	}
+
+	profileVariables, err := getDsElements(dsProfile, "xccdf-1.2:refine-value")
+	if err != nil {
+		return parsedProfile, fmt.Errorf("error finding 'refine-value' elements in profile: %s", err)
+	}
+
+	for _, variable := range profileVariables {
+		varIdRef, err := getDsElementAttrValue(variable, "idref")
+		if err != nil {
+			return parsedProfile, fmt.Errorf("error getting value of 'idref' attribute: %s", err)
+		}
+		varSelector, err := getDsElementAttrValue(variable, "selector")
+		if err != nil {
+			return parsedProfile, fmt.Errorf("error getting value of 'selector' attribute: %s", err)
+		}
+
+		parsedProfile.Values = append(parsedProfile.Values, xccdf.SetValueElement{
+			IDRef: varIdRef,
+			Value: varSelector,
+		})
+	}
+	return parsedProfile, nil
+}
+
 func initProfile(dsProfile *xmlquery.Node, dsProfileId string) (*xccdf.ProfileElement, error) {
 	parsedProfile := new(xccdf.ProfileElement)
 	parsedProfile.ID = dsProfileId
@@ -98,6 +167,13 @@ func initProfile(dsProfile *xmlquery.Node, dsProfileId string) (*xccdf.ProfileEl
 	parsedProfile, err := populateProfileInfo(dsProfile, parsedProfile)
 	if err != nil {
 		return parsedProfile, fmt.Errorf("error populating profile title and description: %s", err)
+	}
+
+	// Here we can add the logic to populate profile rules in a separate PR
+
+	parsedProfile, err = populateProfileVariables(dsProfile, parsedProfile)
+	if err != nil {
+		return parsedProfile, fmt.Errorf("error populating profile variables: %s", err)
 	}
 
 	return parsedProfile, nil
@@ -121,21 +197,101 @@ func GetDsProfile(profileId string, dsPath string) (*xccdf.ProfileElement, error
 
 	parsedProfile, err := initProfile(dsProfile, dsProfileID)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing profile %s in datastream: %s", profileId, err)
+		return nil, fmt.Errorf("error initializing a parsed profile for %s: %s", profileId, err)
 	}
 
 	return parsedProfile, nil
 }
 
 func GetDsProfileTitle(profileId string, dsPath string) (string, error) {
-	// TODO: This function can likely be removed with the introduction of the GetDsProfile function.
-	// Keeping it for now to avoid out of scope changes.
+	// TODO: This function can likely be removed with the introduction of the GetDsProfile
+	// function. Keeping it for now to avoid out of scope changes.
 	profile, err := GetDsProfile(profileId, dsPath)
 	if err != nil {
 		return "", fmt.Errorf("error processing profile %s in datastream: %s", profileId, err)
 	}
 
 	return profile.Title.Value, nil
+}
+
+func GetDsVariablesValues(dsPath string) ([]DsVariables, error) {
+	dsDom, err := loadDataStream(dsPath)
+	if err != nil {
+		return nil, fmt.Errorf("error loading datastream: %s", err)
+	}
+
+	dsVariables, err := getDsElements(dsDom, "//xccdf-1.2:Value")
+	if err != nil {
+		return nil, fmt.Errorf("error getting variables from datastream: %s", err)
+	}
+
+	dsVariablesValues := []DsVariables{}
+	for _, variable := range dsVariables {
+		varId, err := getDsElementAttrValue(variable, "id")
+		if err != nil {
+			return nil, fmt.Errorf("error getting value of 'id' attribute: %s", err)
+		}
+
+		varTitle, err := getDsElementTitle(variable)
+		if err != nil {
+			return nil, fmt.Errorf("error getting variable title: %s", err)
+		}
+
+		varDescription, err := getDsElementDescription(variable)
+		if err != nil {
+			return nil, fmt.Errorf("error getting variable description: %s", err)
+		}
+
+		varOptions, err := getDsElements(variable, "xccdf-1.2:value")
+		if err != nil {
+			return nil, fmt.Errorf("error getting variable options: %s", err)
+		}
+
+		dsVarOptions := []DsVariableOptions{}
+		for _, option := range varOptions {
+			selectorId := getDsOptionalAttrValue(option, "selector")
+			if selectorId == "" {
+				selectorId = "default"
+			}
+			selectorValue := option.InnerText()
+			dsVarOptions = append(dsVarOptions, DsVariableOptions{
+				Selector: selectorId,
+				Value:    selectorValue,
+			})
+		}
+
+		dsVariablesValues = append(dsVariablesValues, DsVariables{
+			ID:          varId,
+			Title:       varTitle.InnerText(),
+			Description: varDescription.InnerText(),
+			Options:     dsVarOptions,
+		})
+	}
+	return dsVariablesValues, nil
+}
+
+func getValueFromOption(variables []DsVariables, variableId string, selector string) (string, error) {
+	for _, variable := range variables {
+		if variable.ID == variableId {
+			for _, option := range variable.Options {
+				if option.Selector == selector {
+					return option.Value, nil
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("variable not found")
+}
+
+func ResolveDsVariableOptions(profile *xccdf.ProfileElement, variables []DsVariables) (*xccdf.ProfileElement, error) {
+	for i, value := range profile.Values {
+		resolvedValue, err := getValueFromOption(variables, value.IDRef, value.Value)
+		if err != nil {
+			return profile, fmt.Errorf("error resolving variable options: %s", err)
+		}
+		profile.Values[i].Value = resolvedValue
+	}
+	return profile, nil
 }
 
 // Getting rule information

--- a/cmd/openscap-plugin/xccdf/datastream_test.go
+++ b/cmd/openscap-plugin/xccdf/datastream_test.go
@@ -108,7 +108,7 @@ func TestGetDsProfileTitle(t *testing.T) {
 		wantErr   bool
 	}{
 		{"test_profile", filepath.Join(testDataDir, "ssg-rhel-ds.xml"), "Test Profile", false},
-		{"test_profile_no_title", filepath.Join(testDataDir, "ssg-rhel-ds.xml"), "", true},
+		{"test_profile_no_title", filepath.Join(testDataDir, "ssg-rhel-ds.xml"), "", false},
 		{"nonexistent_profile", filepath.Join(testDataDir, "ssg-rhel-ds.xml"), "", true},
 		{"invalid_profile", filepath.Join(testDataDir, "nonexistent.xml"), "", true},
 	}

--- a/cmd/openscap-plugin/xccdf/datastream_test.go
+++ b/cmd/openscap-plugin/xccdf/datastream_test.go
@@ -8,8 +8,52 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ComplianceAsCode/compliance-operator/pkg/xccdf"
 	"github.com/antchfx/xmlquery"
 )
+
+var testDataDir = filepath.Join("..", "..", "..", "internal", "complytime", "testdata", "openscap")
+
+// Helper function to load Datastream XML file.
+func LoadDsTest(t *testing.T, dsTestFile string) (*xmlquery.Node, error) {
+	dsTestFilePath := filepath.Join(testDataDir, dsTestFile)
+	file, err := os.Open(dsTestFilePath)
+	if err != nil {
+		t.Fatalf("error opening datastream file: %s", err)
+		return nil, err
+	}
+	defer file.Close()
+
+	dsDom, err := xmlquery.Parse(file)
+	if err != nil {
+		t.Fatalf("error parsing datastream file: %s", err)
+		return nil, err
+	}
+
+	return dsDom, nil
+}
+
+// TestLoadDataStream tests the loadDataStream function.
+// Errors are expected for absent and invalid XML files that cannot be parsed.
+func TestLoadDataStream(t *testing.T) {
+	tests := []struct {
+		dsPath  string
+		wantErr bool
+	}{
+		{filepath.Join(testDataDir, "ssg-rhel-ds.xml"), false},
+		{filepath.Join(testDataDir, "absent.xml"), true},
+		{filepath.Join(testDataDir, "invalid.xml"), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.dsPath, func(t *testing.T) {
+			_, err := loadDataStream(tt.dsPath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("loadDataStream() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
 
 // TestGetDsProfileID tests the getDsProfileID function.
 func TestGetDsProfileID(t *testing.T) {
@@ -34,16 +78,7 @@ func TestGetDsProfileID(t *testing.T) {
 
 // TestGetDsElement tests the getDsElement function with the Profile "description" element.
 func TestGetDsElement(t *testing.T) {
-	dsFile := filepath.Join("..", "..", "..", "internal", "complytime", "testdata", "openscap", "ssg-rhel-ds.xml")
-	dsData, err := os.ReadFile(dsFile)
-	if err != nil {
-		t.Fatalf("failed to read Datastream file: %v", err)
-	}
-
-	doc, err := xmlquery.Parse(strings.NewReader(string(dsData)))
-	if err != nil {
-		t.Fatalf("failed to parse Datastream: %v", err)
-	}
+	doc, _ := LoadDsTest(t, "ssg-rhel-ds.xml")
 
 	tests := []struct {
 		dsElement string
@@ -72,25 +107,647 @@ func TestGetDsElement(t *testing.T) {
 	}
 }
 
-// TestLoadDataStream tests the loadDataStream function.
-// Errors are expected for nonexistent and invalid XML files that cannot be parsed.
-func TestLoadDataStream(t *testing.T) {
-	testDataDir := filepath.Join("..", "..", "..", "internal", "complytime", "testdata", "openscap")
-
+// TestGetDsElementAttrValue tests the getDsElementAttrValue function.
+func TestGetDsElementAttrValue(t *testing.T) {
 	tests := []struct {
-		dsPath  string
-		wantErr bool
+		xmlContent    string
+		attributeName string
+		expected      string
+		wantErr       bool
 	}{
-		{filepath.Join(testDataDir, "ssg-rhel-ds.xml"), false},
-		{filepath.Join(testDataDir, "nonexistent.xml"), true},
-		{filepath.Join(testDataDir, "invalid.xml"), true},
+		{
+			xmlContent:    `<Element id="xccdf_org.ssgproject.content_profile_test_profile"/>`,
+			attributeName: "id",
+			expected:      "xccdf_org.ssgproject.content_profile_test_profile",
+			wantErr:       false,
+		},
+		{
+			xmlContent:    `<Element id="test_id" name="test_name"/>`,
+			attributeName: "name",
+			expected:      "test_name",
+			wantErr:       false,
+		},
+		{
+			xmlContent:    `<Element id="test_id" name="test_name"/>`,
+			attributeName: "nonexistent",
+			expected:      "",
+			wantErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.attributeName, func(t *testing.T) {
+			doc, err := xmlquery.Parse(strings.NewReader(tt.xmlContent))
+			if err != nil {
+				t.Fatalf("failed to parse XML: %v", err)
+			}
+
+			element := doc.SelectElement("Element")
+			if element == nil {
+				t.Fatalf("failed to select element")
+			}
+
+			result, err := getDsElementAttrValue(element, tt.attributeName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getDsElementAttrValue() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if result != tt.expected {
+				t.Errorf("got %s, want %s", result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestGetDsOptionalAttrValue tests the getDsOptionalAttrValue function.
+// The getDsOptionalAttrValue function depends on getDsElementAttrValue and most of this test
+// seems redundant but still has value as it tests the function in isolation.
+func TestGetDsOptionalAttrValue(t *testing.T) {
+	tests := []struct {
+		xmlContent    string
+		attributeName string
+		expected      string
+	}{
+		{
+			xmlContent:    `<Element id="xccdf_org.ssgproject.content_profile_test_profile"/>`,
+			attributeName: "id",
+			expected:      "xccdf_org.ssgproject.content_profile_test_profile",
+		},
+		{
+			xmlContent:    `<Element id="test_id" name="test_name"/>`,
+			attributeName: "name",
+			expected:      "test_name",
+		},
+		{
+			xmlContent:    `<Element id="test_id" name="test_name"/>`,
+			attributeName: "nonexistent",
+			expected:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.attributeName, func(t *testing.T) {
+			doc, err := xmlquery.Parse(strings.NewReader(tt.xmlContent))
+			if err != nil {
+				t.Fatalf("failed to parse XML: %v", err)
+			}
+
+			element := doc.SelectElement("Element")
+			if element == nil {
+				t.Fatalf("failed to select element")
+			}
+
+			result := getDsOptionalAttrValue(element, tt.attributeName)
+			if result != tt.expected {
+				t.Errorf("got %s, want %s", result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestGetDsElements tests the getDsElements function.
+func TestGetDsElements(t *testing.T) {
+	doc, _ := LoadDsTest(t, "ssg-rhel-ds.xml")
+	tests := []struct {
+		dsElement string
+		expected  int
+		wantErr   bool
+	}{
+		{"//xccdf-1.2:Profile", 4, false},
+		{"//xccdf-1.2:Value", 71, false},
+		{"//invalid:Element", 0, false},
+		{"", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.dsElement, func(t *testing.T) {
+			result, err := getDsElements(doc, tt.dsElement)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getDsElements() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if len(result) != tt.expected {
+				t.Errorf("got %d elements, want %d", len(result), tt.expected)
+			}
+		})
+	}
+}
+
+// TestGetDsProfileInternal tests the getDsProfile function.
+func TestGetDsProfileInternal(t *testing.T) {
+	doc, _ := LoadDsTest(t, "ssg-rhel-ds.xml")
+	tests := []struct {
+		dsProfileID string
+		expected    string
+		wantErr     bool
+	}{
+		{"xccdf_org.ssgproject.content_profile_test_profile", "This profile is only used for Unit Tests", false},
+		{"xccdf_org.ssgproject.content_profile_absent", "", false},
+		{"invalid_profile", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.dsProfileID, func(t *testing.T) {
+			result, err := getDsProfile(doc, tt.dsProfileID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getDsProfile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if result != nil && err == nil {
+				profileDescription := result.SelectElement("xccdf-1.2:description")
+				if profileDescription.InnerText() != tt.expected {
+					t.Errorf("got %s, want %s", profileDescription.InnerText(), tt.expected)
+				}
+			}
+		})
+	}
+}
+
+// TestGetDsElementTitleNode tests the getDsElementTitle function.
+func TestGetDsElementTitleNode(t *testing.T) {
+	doc, _ := LoadDsTest(t, "ssg-rhel-ds.xml")
+	tests := []struct {
+		dsProfileID string
+		expected    string
+		wantErr     bool
+	}{
+		{"xccdf_org.ssgproject.content_profile_test_profile", "Test Profile", false},
+		{"xccdf_org.ssgproject.content_profile_test_profile_no_title", "", false},
+		{"xccdf_org.ssgproject.content_profile_absent", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.dsProfileID, func(t *testing.T) {
+			dsProfile, err := getDsProfile(doc, tt.dsProfileID)
+			if err != nil {
+				t.Fatalf("failed to get profile: %v", err)
+			}
+
+			result, err := getDsElementTitle(dsProfile)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getDsElementTitle() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if result != nil && err == nil {
+				if result.InnerText() != tt.expected {
+					t.Errorf("got %s, want %s", result.InnerText(), tt.expected)
+				}
+			}
+		})
+	}
+}
+
+// TestGetDsElementDescriptionNode tests the getDsElementDescription function.
+func TestGetDsElementDescriptionNode(t *testing.T) {
+	doc, _ := LoadDsTest(t, "ssg-rhel-ds.xml")
+	tests := []struct {
+		dsProfileID string
+		expected    string
+		wantErr     bool
+	}{
+		{"xccdf_org.ssgproject.content_profile_test_profile", "This profile is only used for Unit Tests", false},
+		{"xccdf_org.ssgproject.content_profile_test_profile_no_description", "", false},
+		{"xccdf_org.ssgproject.content_profile_absent", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.dsProfileID, func(t *testing.T) {
+			dsProfile, err := getDsProfile(doc, tt.dsProfileID)
+			if err != nil {
+				t.Fatalf("failed to get profile: %v", err)
+			}
+
+			result, err := getDsElementDescription(dsProfile)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getDsElementDescription() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if result != nil && err == nil {
+				if result.InnerText() != tt.expected {
+					t.Errorf("got %s, want %s", result.InnerText(), tt.expected)
+				}
+			}
+		})
+	}
+}
+
+// TestPopulateProfileInfo tests the populateProfileInfo function.
+func TestPopulateProfileInfo(t *testing.T) {
+	doc, _ := LoadDsTest(t, "ssg-rhel-ds.xml")
+	tests := []struct {
+		dsProfileID         string
+		expectedTitle       string
+		expectedDescription string
+		wantErr             bool
+	}{
+		{"xccdf_org.ssgproject.content_profile_test_profile", "Test Profile", "This profile is only used for Unit Tests", false},
+		{"xccdf_org.ssgproject.content_profile_test_profile_no_title", "", "This profile is only used for Unit Tests", false},
+		{"xccdf_org.ssgproject.content_profile_test_profile_no_description", "Test Profile No Description", "", false},
+		{"xccdf_org.ssgproject.content_profile_absent", "", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.dsProfileID, func(t *testing.T) {
+			dsProfile, err := getDsProfile(doc, tt.dsProfileID)
+			if err != nil {
+				t.Fatalf("failed to get profile: %v", err)
+			}
+
+			parsedProfile := &xccdf.ProfileElement{}
+			result, err := populateProfileInfo(dsProfile, parsedProfile)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("populateProfileInfo() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if result.Title != nil && result.Title.Value != tt.expectedTitle {
+				t.Errorf("got title %s, want %s", result.Title.Value, tt.expectedTitle)
+			}
+			if result.Description != nil && result.Description.Value != tt.expectedDescription {
+				t.Errorf("got description %s, want %s", result.Description.Value, tt.expectedDescription)
+			}
+		})
+	}
+}
+
+// TestPopulateProfileVariables tests the populateProfileVariables function.
+func TestPopulateProfileVariables(t *testing.T) {
+	doc, _ := LoadDsTest(t, "ssg-rhel-ds.xml")
+	tests := []struct {
+		dsProfileID string
+		wantErr     bool
+	}{
+		{"xccdf_org.ssgproject.content_profile_test_profile", false},
+		{"xccdf_org.ssgproject.content_profile_absent", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.dsProfileID, func(t *testing.T) {
+			dsProfile, err := getDsProfile(doc, tt.dsProfileID)
+			if err != nil {
+				t.Fatalf("failed to get profile: %v", err)
+			}
+
+			parsedProfile := &xccdf.ProfileElement{}
+			result, err := populateProfileVariables(dsProfile, parsedProfile)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("populateProfileVariables() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if result != nil && result.Values == nil {
+				t.Errorf("got nil values, want non-nil")
+			}
+		})
+	}
+}
+
+// TestInitProfile tests the initProfile function.
+func TestInitProfile(t *testing.T) {
+	doc, _ := LoadDsTest(t, "ssg-rhel-ds.xml")
+	tests := []struct {
+		dsProfileID         string
+		expectedTitle       string
+		expectedDescription string
+		wantErr             bool
+	}{
+		{"xccdf_org.ssgproject.content_profile_test_profile", "Test Profile", "This profile is only used for Unit Tests", false},
+		{"xccdf_org.ssgproject.content_profile_test_profile_no_title", "", "This profile is only used for Unit Tests", false},
+		{"xccdf_org.ssgproject.content_profile_test_profile_no_description", "Test Profile No Description", "", false},
+		{"xccdf_org.ssgproject.content_profile_absent", "", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.dsProfileID, func(t *testing.T) {
+			dsProfile, err := getDsProfile(doc, tt.dsProfileID)
+			if err != nil {
+				t.Fatalf("failed to get profile: %v", err)
+			}
+
+			result, err := initProfile(dsProfile, tt.dsProfileID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("initProfile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if result.ID != tt.dsProfileID {
+				t.Errorf("got ID %s, want %s", result.ID, tt.dsProfileID)
+			}
+			if result.Title != nil && result.Title.Value != tt.expectedTitle {
+				t.Errorf("got title %s, want %s", result.Title.Value, tt.expectedTitle)
+			}
+			if result.Description != nil && result.Description.Value != tt.expectedDescription {
+				t.Errorf("got description %s, want %s", result.Description.Value, tt.expectedDescription)
+			}
+		})
+	}
+}
+
+// TestGetDsVariablesValues tests the GetDsVariablesValues function.
+func TestGetDsVariablesValues(t *testing.T) {
+	tests := []struct {
+		dsPath   string
+		expected int
+		wantErr  bool
+	}{
+		{filepath.Join(testDataDir, "ssg-rhel-ds.xml"), 71, false},
+		{filepath.Join(testDataDir, "absent.xml"), 0, true},
+		{filepath.Join(testDataDir, "invalid.xml"), 0, true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.dsPath, func(t *testing.T) {
-			_, err := loadDataStream(tt.dsPath)
+			result, err := GetDsVariablesValues(tt.dsPath)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("loadDataStream() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("GetDsVariablesValues() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if len(result) != tt.expected {
+				t.Errorf("got %d variables, want %d", len(result), tt.expected)
+			}
+			for _, variable := range result {
+				if variable.Options == nil {
+					t.Errorf("got variable without options: %v", variable)
+				}
+				defaultOption := false
+				for _, option := range variable.Options {
+					if option.Selector == "default" {
+						defaultOption = true
+						break
+					}
+				}
+				if !defaultOption {
+					t.Errorf("default value was is not present: %v", variable)
+				}
+			}
+		})
+	}
+}
+
+// TestGetValueFromOption tests the getValueFromOption function.
+func TestGetValueFromOption(t *testing.T) {
+	tests := []struct {
+		variables  []DsVariables
+		variableId string
+		selector   string
+		expected   string
+		wantErr    bool
+	}{
+		{
+			variables: []DsVariables{
+				{
+					ID: "var1",
+					Options: []DsVariableOptions{
+						{
+							Selector: "selector1",
+							Value:    "value1",
+						},
+					},
+				},
+				{
+					ID: "var2",
+					Options: []DsVariableOptions{
+						{
+							Selector: "selector2",
+							Value:    "value2",
+						},
+					},
+				},
+			},
+			variableId: "var1",
+			selector:   "selector1",
+			expected:   "value1",
+			wantErr:    false,
+		},
+		{
+			variables: []DsVariables{
+				{
+					ID: "var1",
+					Options: []DsVariableOptions{
+						{
+							Selector: "selector1",
+							Value:    "value1",
+						},
+					},
+				},
+				{
+					ID: "var2",
+					Options: []DsVariableOptions{
+						{
+							Selector: "selector2",
+							Value:    "value2",
+						},
+					},
+				},
+			},
+			variableId: "var2",
+			selector:   "selector2",
+			expected:   "value2",
+			wantErr:    false,
+		},
+		{
+			variables: []DsVariables{
+				{
+					ID: "var1",
+					Options: []DsVariableOptions{
+						{
+							Selector: "selector1",
+							Value:    "value1",
+						},
+					},
+				},
+			},
+			variableId: "var1",
+			selector:   "nonexistent",
+			expected:   "",
+			wantErr:    true,
+		},
+		{
+			variables: []DsVariables{
+				{
+					ID: "var1",
+					Options: []DsVariableOptions{
+						{
+							Selector: "selector1",
+							Value:    "value1",
+						},
+					},
+				},
+			},
+			variableId: "nonexistent",
+			selector:   "selector1",
+			expected:   "",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.variableId+"_"+tt.selector, func(t *testing.T) {
+			result, err := getValueFromOption(tt.variables, tt.variableId, tt.selector)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getValueFromOption() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if result != tt.expected {
+				t.Errorf("got %s, want %s", result, tt.expected)
+			}
+		})
+	}
+}
+
+// compareProfileElements is a helper function for TestResolveDsVariableOptions.
+// It compares two ProfileElement objects.
+func compareProfileElements(a, b *xccdf.ProfileElement) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if len(a.Values) != len(b.Values) {
+		return false
+	}
+	for i := range a.Values {
+		if a.Values[i].IDRef != b.Values[i].IDRef || a.Values[i].Value != b.Values[i].Value {
+			return false
+		}
+	}
+	return true
+}
+
+// TestResolveDsVariableOptions tests the ResolveDsVariableOptions function.
+func TestResolveDsVariableOptions(t *testing.T) {
+	tests := []struct {
+		profile   *xccdf.ProfileElement
+		variables []DsVariables
+		expected  *xccdf.ProfileElement
+		wantErr   bool
+	}{
+		{
+			profile: &xccdf.ProfileElement{
+				Values: []xccdf.SetValueElement{
+					{IDRef: "var1", Value: "selector1"},
+					{IDRef: "var2", Value: "selector2"},
+				},
+			},
+			variables: []DsVariables{
+				{
+					ID: "var1",
+					Options: []DsVariableOptions{
+						{Selector: "selector1", Value: "value1"},
+					},
+				},
+				{
+					ID: "var2",
+					Options: []DsVariableOptions{
+						{Selector: "selector2", Value: "value2"},
+					},
+				},
+			},
+			expected: &xccdf.ProfileElement{
+				Values: []xccdf.SetValueElement{
+					{IDRef: "var1", Value: "value1"},
+					{IDRef: "var2", Value: "value2"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			profile: &xccdf.ProfileElement{
+				Values: []xccdf.SetValueElement{
+					{IDRef: "var1", Value: "selector1"},
+					{IDRef: "var3", Value: "selector3"},
+				},
+			},
+			variables: []DsVariables{
+				{
+					ID: "var1",
+					Options: []DsVariableOptions{
+						{Selector: "selector1", Value: "value1"},
+					},
+				},
+				{
+					ID: "var2",
+					Options: []DsVariableOptions{
+						{Selector: "selector2", Value: "value2"},
+					},
+				},
+			},
+			expected: &xccdf.ProfileElement{
+				Values: []xccdf.SetValueElement{
+					{IDRef: "var1", Value: "value1"},
+					{IDRef: "var3", Value: "selector3"},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.profile.ID, func(t *testing.T) {
+			result, err := ResolveDsVariableOptions(tt.profile, tt.variables)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ResolveDsVariableOptions() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !compareProfileElements(result, tt.expected) {
+				t.Errorf("got %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestGetDsProfile tests the GetDsProfile function.
+func TestGetDsProfile(t *testing.T) {
+	tests := []struct {
+		profileId string
+		dsPath    string
+		expected  *xccdf.ProfileElement
+		wantErr   bool
+	}{
+		{
+			profileId: "test_profile",
+			dsPath:    filepath.Join(testDataDir, "ssg-rhel-ds.xml"),
+			expected: &xccdf.ProfileElement{
+				ID: "xccdf_org.ssgproject.content_profile_test_profile",
+				Title: &xccdf.TitleOrDescriptionElement{
+					Override: true,
+					Value:    "Test Profile",
+				},
+				Description: &xccdf.TitleOrDescriptionElement{
+					Override: true,
+					Value:    "This profile is only used for Unit Tests",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			profileId: "absent_profile",
+			dsPath:    filepath.Join(testDataDir, "ssg-rhel-ds.xml"),
+			expected:  nil,
+			wantErr:   true,
+		},
+		{
+			profileId: "absent_datastream",
+			dsPath:    filepath.Join(testDataDir, "absent.xml"),
+			expected:  nil,
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.profileId, func(t *testing.T) {
+			result, err := GetDsProfile(tt.profileId, tt.dsPath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetDsProfile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if result != nil && tt.expected != nil {
+				if result.ID != tt.expected.ID {
+					t.Errorf("got ID %s, want %s", result.ID, tt.expected.ID)
+				}
+				if result.Title != nil && result.Title.Value != tt.expected.Title.Value {
+					t.Errorf("got title %s, want %s", result.Title.Value, tt.expected.Title.Value)
+				}
+				if result.Description != nil && result.Description.Value != tt.expected.Description.Value {
+					t.Errorf("got description %s, want %s", result.Description.Value, tt.expected.Description.Value)
+				}
+			} else if result != tt.expected {
+				t.Errorf("got %v, want %v", result, tt.expected)
 			}
 		})
 	}
@@ -99,8 +756,6 @@ func TestLoadDataStream(t *testing.T) {
 // TestGetDsProfileTitle tests the GetDsProfileTitle function.
 // It also uses the getDsElement function with some additional logic specific for profile titles.
 func TestGetDsProfileTitle(t *testing.T) {
-	testDataDir := filepath.Join("..", "..", "..", "internal", "complytime", "testdata", "openscap")
-
 	tests := []struct {
 		profileId string
 		dsPath    string
@@ -109,8 +764,8 @@ func TestGetDsProfileTitle(t *testing.T) {
 	}{
 		{"test_profile", filepath.Join(testDataDir, "ssg-rhel-ds.xml"), "Test Profile", false},
 		{"test_profile_no_title", filepath.Join(testDataDir, "ssg-rhel-ds.xml"), "", false},
-		{"nonexistent_profile", filepath.Join(testDataDir, "ssg-rhel-ds.xml"), "", true},
-		{"invalid_profile", filepath.Join(testDataDir, "nonexistent.xml"), "", true},
+		{"absent_profile", filepath.Join(testDataDir, "ssg-rhel-ds.xml"), "", true},
+		{"invalid_profile", filepath.Join(testDataDir, "absent.xml"), "", true},
 	}
 
 	for _, tt := range tests {

--- a/cmd/openscap-plugin/xccdf/tailoring.go
+++ b/cmd/openscap-plugin/xccdf/tailoring.go
@@ -29,8 +29,8 @@ func getTailoringProfileID(profileId string) string {
 
 func getTailoringProfileTitle(profileId string, dsPath string) string {
 	dsProfileTitle, err := GetDsProfileTitle(profileId, dsPath)
-	if err != nil {
-		// log error
+	if err != nil || dsProfileTitle == "" {
+		// log that the profile title was not found or is empty in Datastream
 		dsProfileTitle = profileId
 	}
 	return fmt.Sprintf("ComplyTime Tailoring Profile - %s", dsProfileTitle)


### PR DESCRIPTION
## Summary
As part of the tailoring file creation the plugin will collect all variables and respective values in Datastream and use this information to create a minimalist Tailoring file that includes only the differences between OSCAL profile and Datastream profile.

The logic to compare and report the differences is not in the scope of this PR and expected by separate PRs.

In Datastreams the profiles include variables and respective options relevant for each profile, but not the actual values for these options. The values are defined in the scope of a variable definition in Datastream. Since OSCAL is expected to work directly with values instead of options, this PR also introduces logic to resolve the Datastream profile options to actual values in order much easier compare the profiles later.

## Related Issues

- Relates to CPLYTM-474

## Review Hints

The commit descriptions should provide the context and more details about each change.
To make the code more readable, some aesthetic changes and refactoring were made along the commits.
Therefore, while the commit descriptions give context and details to clarify how the PR evolved, it could be easier to analyse the final result.

For unit tests
`make test-unit`
