### PR TITLE
CPLYTM-473: collect Datastream rules

### DIFF
--- a/cmd/openscap-plugin/xccdf/datastream.go
+++ b/cmd/openscap-plugin/xccdf/datastream.go
@@ -3,6 +3,7 @@
 package xccdf
 
 import (
+	"encoding/xml"
 	"fmt"
 	"os"
 
@@ -21,6 +22,12 @@ type DsVariables struct {
 	Title       string `xml:",chardata"`
 	Description string `xml:",chardata"`
 	Options     []DsVariableOptions
+}
+
+type SelectElement struct {
+	XMLName  xml.Name `xml:"xccdf-1.2:select"`
+	IDRef    string   `xml:"idref,attr"`
+	Selected bool     `xml:"selected,attr"`
 }
 
 func loadDataStream(dsPath string) (*xmlquery.Node, error) {
@@ -160,6 +167,32 @@ func populateProfileVariables(dsProfile *xmlquery.Node, parsedProfile *xccdf.Pro
 	return parsedProfile, nil
 }
 
+func populateProfileRules(dsProfile *xmlquery.Node, parsedProfile *xccdf.ProfileElement) (*xccdf.ProfileElement, error) {
+	if parsedProfile.Selections == nil {
+		parsedProfile.Selections = []xccdf.SelectElement{}
+	}
+	profileRules, err := getDsElements(dsProfile, "xccdf-1.2:select")
+	if err != nil {
+		return parsedProfile, fmt.Errorf("error finding 'select' elements in profile: %s", err)
+	}
+	for _, rule := range profileRules {
+		ruleIdRef, err := getDsElementAttrValue(rule, "idref")
+		if err != nil {
+			return parsedProfile, fmt.Errorf("error getting value of 'idref' attribute: %s", err)
+		}
+		// change occurrences of ruleSelector to ruleSelected for alignment with selected attribute
+		ruleSelected, err := getDsElementAttrValue(rule, "selected")
+		if err != nil {
+			return parsedProfile, fmt.Errorf("error getting value of 'selected' attribute: %s", err)
+		}
+
+		parsedProfile.Selections = append(parsedProfile.Selections, xccdf.SelectElement{
+			IDRef:    ruleIdRef,
+			Selected: ruleSelected,
+		})
+	}
+	return parsedProfile, nil
+}
 func initProfile(dsProfile *xmlquery.Node, dsProfileId string) (*xccdf.ProfileElement, error) {
 	parsedProfile := new(xccdf.ProfileElement)
 	parsedProfile.ID = dsProfileId
@@ -170,6 +203,12 @@ func initProfile(dsProfile *xmlquery.Node, dsProfileId string) (*xccdf.ProfileEl
 	}
 
 	// Here we can add the logic to populate profile rules in a separate PR
+	// TODO: Implement the profile rules logic - to extract the Selected
+
+	parsedProfile, err = populateProfileRules(dsProfile, parsedProfile)
+	if err != nil {
+		return parsedProfile, fmt.Errorf("error populating profile rules: %s", err)
+	}
 
 	parsedProfile, err = populateProfileVariables(dsProfile, parsedProfile)
 	if err != nil {
@@ -296,7 +335,38 @@ func ResolveDsVariableOptions(profile *xccdf.ProfileElement, variables []DsVaria
 
 // Getting rule information
 // Copied from https://github.com/ComplianceAsCode/compliance-operator/blob/fed54b4b761374578016d79d97bcb7636bf9d920/pkg/utils/parse_arf_result.go#L170
+func GetDsProfileRules(dsPath string) ([]SelectElement, error) {
+	dsDom, err := loadDataStream(dsPath)
+	if err != nil {
+		return nil, fmt.Errorf("error loading datastream: %s", err)
+	}
+	// TODO: Check if rule or selected (only will need idref and select boolean)
+	dsRules, err := getDsElements(dsDom, "//xccdf-1.2:Rule")
+	if err != nil {
+		return nil, fmt.Errorf("error getting selected rules from datastream: %s", err)
+	}
 
+	dsSelectedValues := []SelectElement{}
+	for _, rule := range dsRules {
+		ruleId, err := getDsElementAttrValue(rule, "id")
+		if err != nil {
+			return nil, fmt.Errorf("error getting value of 'id' attribute: %s", err)
+		}
+
+		ruleSelected, err := getDsElementAttrValue(rule, "xccdf-1.2:select")
+		if err != nil {
+			return nil, fmt.Errorf("error getting selected rule from datastream: %s", err)
+		}
+
+		dsSelectedValues = append(dsSelectedValues, SelectElement{
+			IDRef:    ruleId,
+			Selected: ruleSelected.InnerText(),
+		})
+	}
+	return dsSelectedValues, nil
+}
+
+// TODO: Fill in above to utilize the same information for just id and select
 func NewRuleHashTable(dsDom *xmlquery.Node) NodeByIdHashTable {
 	return newHashTableFromRootAndQuery(dsDom, "//ds:component/xccdf-1.2:Benchmark", "//xccdf-1.2:Rule")
 }

--- a/cmd/openscap-plugin/xccdf/datastream_test.go
+++ b/cmd/openscap-plugin/xccdf/datastream_test.go
@@ -400,6 +400,37 @@ func TestPopulateProfileVariables(t *testing.T) {
 	}
 }
 
+// TestPopulateProfileRules tests the populateProfileVariables function.
+func TestPopulateProfileRules(t *testing.T) {
+	doc, _ := LoadDsTest(t, "ssg-rhel-ds.xml")
+	tests := []struct {
+		dsProfileID string
+		wantErr     bool
+	}{
+		{"xccdf_org.ssgproject.content_profile_test_profile", false},
+		{"xccdf_org.ssgproject.content_profile_absent", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.dsProfileID, func(t *testing.T) {
+			dsProfile, err := getDsProfile(doc, tt.dsProfileID)
+			if err != nil {
+				t.Fatalf("failed to get profile: %v", err)
+			}
+
+			parsedProfile := &xccdf.ProfileElement{}
+			result, err := populateProfileRules(dsProfile, parsedProfile)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("populateProfileRules() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if result != nil && result.Selections == nil {
+				t.Errorf("got nil rules, want non-nil")
+			}
+		})
+	}
+}
+
 // TestInitProfile tests the initProfile function.
 func TestInitProfile(t *testing.T) {
 	doc, _ := LoadDsTest(t, "ssg-rhel-ds.xml")


### PR DESCRIPTION
## Summary

The implementation of `populateProfileRules` function is to extract selected rules from the OpenSCAP Datastream file. The selections are initialized in the `initProfile` command. The error handling will ensure that populated profile rules are accessible through the profile elements "idref" and their associated "selected" field is included from the OpenSCAP Datastream file. The `TestpopulateProfileRules` serves as the unit test associated with `populateProfileRules`.

## Review Hints

- The two commits included in this PR have descriptions that highlight their implementations. The only new introductions for this PR are the `populateProfileRules` function and `TestpopulateProfileRules` unit test.
