### PR TITLE
CPLYTM-475: Validate OSCAL rules and parameters used for openscap tailoring files

### DIFF
--- a/cmd/openscap-plugin/xccdf/datastream.go
+++ b/cmd/openscap-plugin/xccdf/datastream.go
@@ -40,13 +40,13 @@ type DsRules struct {
 func loadDataStream(dsPath string) (*xmlquery.Node, error) {
 	file, err := os.Open(dsPath)
 	if err != nil {
-		return nil, fmt.Errorf("error opening datastream file: %s", err)
+		return nil, fmt.Errorf("error opening datastream file: %w", err)
 	}
 	defer file.Close()
 
 	dsDom, err := xmlquery.Parse(file)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing datastream file: %s", err)
+		return nil, fmt.Errorf("error parsing datastream file: %w", err)
 	}
 
 	return dsDom, nil
@@ -78,7 +78,7 @@ func getDsElementAttrValue(dsElement *xmlquery.Node, attrName string) (string, e
 			return dsElement.SelectAttr(attrName), nil
 		}
 	}
-	return "", fmt.Errorf("attribute not found")
+	return "", fmt.Errorf("attribute not found: %s", attrName)
 }
 
 func getDsOptionalAttrValue(dsElement *xmlquery.Node, optionalAttrName string) string {
@@ -103,7 +103,7 @@ func getDsProfile(dsDom *xmlquery.Node, dsProfileID string) (*xmlquery.Node, err
 func getDsElementTitle(dsProfile *xmlquery.Node) (*xmlquery.Node, error) {
 	profileTitle, err := getDsElement(dsProfile, "xccdf-1.2:title")
 	if err != nil {
-		return nil, fmt.Errorf("error finding 'title' element: %s", err)
+		return nil, fmt.Errorf("error finding 'title' element: %w", err)
 	}
 	return profileTitle, nil
 }
@@ -111,7 +111,7 @@ func getDsElementTitle(dsProfile *xmlquery.Node) (*xmlquery.Node, error) {
 func getDsElementDescription(dsProfile *xmlquery.Node) (*xmlquery.Node, error) {
 	profileDescription, err := getDsElement(dsProfile, "xccdf-1.2:description")
 	if err != nil {
-		return nil, fmt.Errorf("error finding 'description' element: %s", err)
+		return nil, fmt.Errorf("error finding 'description' element: %w", err)
 	}
 	return profileDescription, nil
 }
@@ -119,7 +119,7 @@ func getDsElementDescription(dsProfile *xmlquery.Node) (*xmlquery.Node, error) {
 func populateProfileInfo(dsProfile *xmlquery.Node, parsedProfile *xccdf.ProfileElement) (*xccdf.ProfileElement, error) {
 	profileTitle, err := getDsElementTitle(dsProfile)
 	if err != nil {
-		return parsedProfile, fmt.Errorf("error populating profile title: %s", err)
+		return parsedProfile, fmt.Errorf("error populating profile title: %w", err)
 	}
 	if parsedProfile.Title == nil {
 		parsedProfile.Title = &xccdf.TitleOrDescriptionElement{}
@@ -136,7 +136,7 @@ func populateProfileInfo(dsProfile *xmlquery.Node, parsedProfile *xccdf.ProfileE
 
 	profileDescription, err := getDsElementDescription(dsProfile)
 	if err != nil {
-		return parsedProfile, fmt.Errorf("error populating profile description: %s", err)
+		return parsedProfile, fmt.Errorf("error populating profile description: %w", err)
 	}
 	if parsedProfile.Description == nil {
 		parsedProfile.Description = &xccdf.TitleOrDescriptionElement{}
@@ -161,17 +161,17 @@ func populateProfileVariables(dsProfile *xmlquery.Node, parsedProfile *xccdf.Pro
 
 	profileVariables, err := getDsElements(dsProfile, "xccdf-1.2:refine-value")
 	if err != nil {
-		return parsedProfile, fmt.Errorf("error finding 'refine-value' elements in profile: %s", err)
+		return parsedProfile, fmt.Errorf("error finding 'refine-value' elements in profile: %w", err)
 	}
 
 	for _, variable := range profileVariables {
 		varIdRef, err := getDsElementAttrValue(variable, "idref")
 		if err != nil {
-			return parsedProfile, fmt.Errorf("error getting value of 'idref' attribute: %s", err)
+			return parsedProfile, fmt.Errorf("error getting value of 'idref' attribute: %w", err)
 		}
 		varSelector, err := getDsElementAttrValue(variable, "selector")
 		if err != nil {
-			return parsedProfile, fmt.Errorf("error getting value of 'selector' attribute: %s", err)
+			return parsedProfile, fmt.Errorf("error getting value of 'selector' attribute: %w", err)
 		}
 
 		parsedProfile.Values = append(parsedProfile.Values, xccdf.SetValueElement{
@@ -189,21 +189,21 @@ func populateProfileRules(dsProfile *xmlquery.Node, parsedProfile *xccdf.Profile
 
 	profileRules, err := getDsElements(dsProfile, "xccdf-1.2:select")
 	if err != nil {
-		return parsedProfile, fmt.Errorf("error finding 'select' elements in profile: %s", err)
+		return parsedProfile, fmt.Errorf("error finding 'select' elements in profile: %w", err)
 	}
 
 	for _, rule := range profileRules {
 		ruleIdRef, err := getDsElementAttrValue(rule, "idref")
 		if err != nil {
-			return parsedProfile, fmt.Errorf("error getting value of 'idref' attribute: %s", err)
+			return parsedProfile, fmt.Errorf("error getting value of 'idref' attribute: %w", err)
 		}
 		ruleSelected, err := getDsElementAttrValue(rule, "selected")
 		if err != nil {
-			return nil, fmt.Errorf("error getting value of 'selected' attribute: %s", err)
+			return nil, fmt.Errorf("error getting value of 'selected' attribute: %w", err)
 		}
 		selectedBoolean, err := strconv.ParseBool(ruleSelected)
 		if err != nil {
-			return nil, fmt.Errorf("error converting the 'selected' attribute from string to boolean: %s", err)
+			return nil, fmt.Errorf("error converting the 'selected' attribute from string to boolean: %w", err)
 		}
 
 		parsedProfile.Selections = append(parsedProfile.Selections, xccdf.SelectElement{
@@ -220,17 +220,17 @@ func initProfile(dsProfile *xmlquery.Node, dsProfileId string) (*xccdf.ProfileEl
 
 	parsedProfile, err := populateProfileInfo(dsProfile, parsedProfile)
 	if err != nil {
-		return parsedProfile, fmt.Errorf("error populating profile title and description: %s", err)
+		return parsedProfile, fmt.Errorf("error populating profile title and description: %w", err)
 	}
 
 	parsedProfile, err = populateProfileRules(dsProfile, parsedProfile)
 	if err != nil {
-		return parsedProfile, fmt.Errorf("error populating profile rules: %s", err)
+		return parsedProfile, fmt.Errorf("error populating profile rules: %w", err)
 	}
 
 	parsedProfile, err = populateProfileVariables(dsProfile, parsedProfile)
 	if err != nil {
-		return parsedProfile, fmt.Errorf("error populating profile variables: %s", err)
+		return parsedProfile, fmt.Errorf("error populating profile variables: %w", err)
 	}
 
 	return parsedProfile, nil
@@ -239,13 +239,13 @@ func initProfile(dsProfile *xmlquery.Node, dsProfileId string) (*xccdf.ProfileEl
 func GetDsProfile(profileId string, dsPath string) (*xccdf.ProfileElement, error) {
 	dsDom, err := loadDataStream(dsPath)
 	if err != nil {
-		return nil, fmt.Errorf("error loading datastream: %s", err)
+		return nil, fmt.Errorf("error loading datastream: %w", err)
 	}
 
 	dsProfileID := getDsProfileID(profileId)
 	dsProfile, err := getDsProfile(dsDom, dsProfileID)
 	if err != nil {
-		return nil, fmt.Errorf("error processing profile %s in datastream: %s", profileId, err)
+		return nil, fmt.Errorf("error processing profile %s in datastream: %w", profileId, err)
 	}
 
 	if dsProfile == nil {
@@ -254,7 +254,7 @@ func GetDsProfile(profileId string, dsPath string) (*xccdf.ProfileElement, error
 
 	parsedProfile, err := initProfile(dsProfile, dsProfileID)
 	if err != nil {
-		return nil, fmt.Errorf("error initializing a parsed profile for %s: %s", profileId, err)
+		return nil, fmt.Errorf("error initializing a parsed profile for %s: %w", profileId, err)
 	}
 
 	return parsedProfile, nil
@@ -263,34 +263,34 @@ func GetDsProfile(profileId string, dsPath string) (*xccdf.ProfileElement, error
 func GetDsVariablesValues(dsPath string) ([]DsVariables, error) {
 	dsDom, err := loadDataStream(dsPath)
 	if err != nil {
-		return nil, fmt.Errorf("error loading datastream: %s", err)
+		return nil, fmt.Errorf("error loading datastream: %w", err)
 	}
 
 	dsVariables, err := getDsElements(dsDom, "//xccdf-1.2:Value")
 	if err != nil {
-		return nil, fmt.Errorf("error getting variables from datastream: %s", err)
+		return nil, fmt.Errorf("error getting variables from datastream: %w", err)
 	}
 
 	dsVariablesValues := []DsVariables{}
 	for _, variable := range dsVariables {
 		varId, err := getDsElementAttrValue(variable, "id")
 		if err != nil {
-			return nil, fmt.Errorf("error getting value of 'id' attribute: %s", err)
+			return nil, fmt.Errorf("error getting value of 'id' attribute: %w", err)
 		}
 
 		varTitle, err := getDsElementTitle(variable)
 		if err != nil {
-			return nil, fmt.Errorf("error getting variable title: %s", err)
+			return nil, fmt.Errorf("error getting variable title: %w", err)
 		}
 
 		varDescription, err := getDsElementDescription(variable)
 		if err != nil {
-			return nil, fmt.Errorf("error getting variable description: %s", err)
+			return nil, fmt.Errorf("error getting variable description: %w", err)
 		}
 
 		varOptions, err := getDsElements(variable, "xccdf-1.2:value")
 		if err != nil {
-			return nil, fmt.Errorf("error getting variable options: %s", err)
+			return nil, fmt.Errorf("error getting variable options: %w", err)
 		}
 
 		dsVarOptions := []DsVariableOptions{}

--- a/cmd/openscap-plugin/xccdf/datastream.go
+++ b/cmd/openscap-plugin/xccdf/datastream.go
@@ -11,6 +11,12 @@ import (
 	"github.com/antchfx/xmlquery"
 )
 
+const (
+	profileIDPrefix string = "xccdf_org.ssgproject.content_profile_"
+	ruleIDPrefix    string = "xccdf_org.ssgproject.content_rule_"
+	varIDPrefix     string = "xccdf_org.ssgproject.content_value_"
+)
+
 // The following structs can later be proposed to compliance-operator/pkg/xccdf
 type DsVariableOptions struct {
 	Selector string `xml:"selector,attr"`
@@ -47,11 +53,15 @@ func loadDataStream(dsPath string) (*xmlquery.Node, error) {
 }
 
 func getDsProfileID(profileId string) string {
-	return fmt.Sprintf("xccdf_org.ssgproject.content_profile_%s", profileId)
+	return profileIDPrefix + profileId
 }
 
 func getDsRuleID(ruleId string) string {
-	return fmt.Sprintf("xccdf_org.ssgproject.content_rule_%s", ruleId)
+	return ruleIDPrefix + ruleId
+}
+
+func getDsVarID(varId string) string {
+	return varIDPrefix + varId
 }
 
 func getDsElement(dsDom *xmlquery.Node, dsElement string) (*xmlquery.Node, error) {

--- a/cmd/openscap-plugin/xccdf/datastream_test.go
+++ b/cmd/openscap-plugin/xccdf/datastream_test.go
@@ -14,19 +14,19 @@ import (
 
 var testDataDir = filepath.Join("..", "..", "..", "internal", "complytime", "testdata", "openscap")
 
-// Helper function to load Datastream XML file.
+// Helper function to load Datastream XML file. It is used by multiple tests in xccdf package.
 func LoadDsTest(t *testing.T, dsTestFile string) (*xmlquery.Node, error) {
 	dsTestFilePath := filepath.Join(testDataDir, dsTestFile)
 	file, err := os.Open(dsTestFilePath)
 	if err != nil {
-		t.Fatalf("error opening datastream file: %s", err)
+		t.Fatalf("error opening datastream file: %v", err)
 		return nil, err
 	}
 	defer file.Close()
 
 	dsDom, err := xmlquery.Parse(file)
 	if err != nil {
-		t.Fatalf("error parsing datastream file: %s", err)
+		t.Fatalf("error parsing datastream file: %v", err)
 		return nil, err
 	}
 

--- a/cmd/openscap-plugin/xccdf/datastream_test.go
+++ b/cmd/openscap-plugin/xccdf/datastream_test.go
@@ -76,6 +76,48 @@ func TestGetDsProfileID(t *testing.T) {
 	}
 }
 
+// TestGetDsRuleID tests the getDsRuleID function.
+func TestGetDsRuleID(t *testing.T) {
+	tests := []struct {
+		ruleId   string
+		expected string
+	}{
+		{"test_rule", "xccdf_org.ssgproject.content_rule_test_rule"},
+		{"rule1", "xccdf_org.ssgproject.content_rule_rule1"},
+		{"", "xccdf_org.ssgproject.content_rule_"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ruleId, func(t *testing.T) {
+			result := getDsRuleID(tt.ruleId)
+			if result != tt.expected {
+				t.Errorf("got %s, want %s", result, tt.expected)
+			}
+		})
+	}
+}
+
+// TestGetDsVarID tests the getDsVarID function.
+func TestGetDsVarID(t *testing.T) {
+	tests := []struct {
+		varId    string
+		expected string
+	}{
+		{"test_var", "xccdf_org.ssgproject.content_value_test_var"},
+		{"var1", "xccdf_org.ssgproject.content_value_var1"},
+		{"", "xccdf_org.ssgproject.content_value_"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.varId, func(t *testing.T) {
+			result := getDsVarID(tt.varId)
+			if result != tt.expected {
+				t.Errorf("got %s, want %s", result, tt.expected)
+			}
+		})
+	}
+}
+
 // TestGetDsElement tests the getDsElement function with the Profile "description" element.
 func TestGetDsElement(t *testing.T) {
 	doc, _ := LoadDsTest(t, "ssg-rhel-ds.xml")
@@ -471,6 +513,68 @@ func TestInitProfile(t *testing.T) {
 	}
 }
 
+// TestGetDsProfile tests the GetDsProfile function.
+func TestGetDsProfile(t *testing.T) {
+	tests := []struct {
+		profileId string
+		dsPath    string
+		expected  *xccdf.ProfileElement
+		wantErr   bool
+	}{
+		{
+			profileId: "test_profile",
+			dsPath:    filepath.Join(testDataDir, "ssg-rhel-ds.xml"),
+			expected: &xccdf.ProfileElement{
+				ID: "xccdf_org.ssgproject.content_profile_test_profile",
+				Title: &xccdf.TitleOrDescriptionElement{
+					Override: true,
+					Value:    "Test Profile",
+				},
+				Description: &xccdf.TitleOrDescriptionElement{
+					Override: true,
+					Value:    "This profile is only used for Unit Tests",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			profileId: "absent_profile",
+			dsPath:    filepath.Join(testDataDir, "ssg-rhel-ds.xml"),
+			expected:  nil,
+			wantErr:   true,
+		},
+		{
+			profileId: "absent_datastream",
+			dsPath:    filepath.Join(testDataDir, "absent.xml"),
+			expected:  nil,
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.profileId, func(t *testing.T) {
+			result, err := GetDsProfile(tt.profileId, tt.dsPath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetDsProfile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if result != nil && tt.expected != nil {
+				if result.ID != tt.expected.ID {
+					t.Errorf("got ID %s, want %s", result.ID, tt.expected.ID)
+				}
+				if result.Title != nil && result.Title.Value != tt.expected.Title.Value {
+					t.Errorf("got title %s, want %s", result.Title.Value, tt.expected.Title.Value)
+				}
+				if result.Description != nil && result.Description.Value != tt.expected.Description.Value {
+					t.Errorf("got description %s, want %s", result.Description.Value, tt.expected.Description.Value)
+				}
+			} else if result != tt.expected {
+				t.Errorf("got %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
 // TestGetDsVariablesValues tests the GetDsVariablesValues function.
 func TestGetDsVariablesValues(t *testing.T) {
 	tests := []struct {
@@ -722,92 +826,40 @@ func TestResolveDsVariableOptions(t *testing.T) {
 	}
 }
 
-// TestGetDsProfile tests the GetDsProfile function.
-func TestGetDsProfile(t *testing.T) {
+// TestGetDsRules tests the GetDsRules function.
+func TestGetDsRules(t *testing.T) {
 	tests := []struct {
-		profileId string
-		dsPath    string
-		expected  *xccdf.ProfileElement
-		wantErr   bool
+		dsPath   string
+		expected int
+		wantErr  bool
 	}{
-		{
-			profileId: "test_profile",
-			dsPath:    filepath.Join(testDataDir, "ssg-rhel-ds.xml"),
-			expected: &xccdf.ProfileElement{
-				ID: "xccdf_org.ssgproject.content_profile_test_profile",
-				Title: &xccdf.TitleOrDescriptionElement{
-					Override: true,
-					Value:    "Test Profile",
-				},
-				Description: &xccdf.TitleOrDescriptionElement{
-					Override: true,
-					Value:    "This profile is only used for Unit Tests",
-				},
-			},
-			wantErr: false,
-		},
-		{
-			profileId: "absent_profile",
-			dsPath:    filepath.Join(testDataDir, "ssg-rhel-ds.xml"),
-			expected:  nil,
-			wantErr:   true,
-		},
-		{
-			profileId: "absent_datastream",
-			dsPath:    filepath.Join(testDataDir, "absent.xml"),
-			expected:  nil,
-			wantErr:   true,
-		},
+		{filepath.Join(testDataDir, "ssg-rhel-ds.xml"), 376, false},
+		{filepath.Join(testDataDir, "absent.xml"), 0, true},
+		{filepath.Join(testDataDir, "invalid.xml"), 0, true},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.profileId, func(t *testing.T) {
-			result, err := GetDsProfile(tt.profileId, tt.dsPath)
+		t.Run(tt.dsPath, func(t *testing.T) {
+			result, err := GetDsRules(tt.dsPath)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("GetDsProfile() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("GetDsRules() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if result != nil && tt.expected != nil {
-				if result.ID != tt.expected.ID {
-					t.Errorf("got ID %s, want %s", result.ID, tt.expected.ID)
-				}
-				if result.Title != nil && result.Title.Value != tt.expected.Title.Value {
-					t.Errorf("got title %s, want %s", result.Title.Value, tt.expected.Title.Value)
-				}
-				if result.Description != nil && result.Description.Value != tt.expected.Description.Value {
-					t.Errorf("got description %s, want %s", result.Description.Value, tt.expected.Description.Value)
-				}
-			} else if result != tt.expected {
-				t.Errorf("got %v, want %v", result, tt.expected)
+			if len(result) != tt.expected {
+				t.Errorf("got %d rules, want %d", len(result), tt.expected)
 			}
-		})
-	}
-}
-
-// TestGetDsProfileTitle tests the GetDsProfileTitle function.
-// It also uses the getDsElement function with some additional logic specific for profile titles.
-func TestGetDsProfileTitle(t *testing.T) {
-	tests := []struct {
-		profileId string
-		dsPath    string
-		expected  string
-		wantErr   bool
-	}{
-		{"test_profile", filepath.Join(testDataDir, "ssg-rhel-ds.xml"), "Test Profile", false},
-		{"test_profile_no_title", filepath.Join(testDataDir, "ssg-rhel-ds.xml"), "", false},
-		{"absent_profile", filepath.Join(testDataDir, "ssg-rhel-ds.xml"), "", true},
-		{"invalid_profile", filepath.Join(testDataDir, "absent.xml"), "", true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.profileId, func(t *testing.T) {
-			result, err := GetDsProfileTitle(tt.profileId, tt.dsPath)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("GetDsProfileTitle() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if result != tt.expected {
-				t.Errorf("got %s, want %s", result, tt.expected)
+			if !tt.wantErr {
+				for _, rule := range result {
+					if rule.ID == "" {
+						t.Errorf("got rule with empty ID: %v", rule)
+					}
+					if rule.Title == "" {
+						t.Errorf("got rule with empty title: %v", rule)
+					}
+					if rule.Description == "" {
+						t.Errorf("got rule with empty description: %v", rule)
+					}
+				}
 			}
 		})
 	}

--- a/cmd/openscap-plugin/xccdf/tailoring.go
+++ b/cmd/openscap-plugin/xccdf/tailoring.go
@@ -135,6 +135,9 @@ func getTailoringSelections(oscalPolicy policy.Policy, dsProfile *xccdf.ProfileE
 
 func updateTailoringValues(tailoringValues, dsProfileValues []xccdf.SetValueElement, oscalPolicy policy.Policy) []xccdf.SetValueElement {
 	for _, rule := range oscalPolicy {
+		if rule.Rule.Parameter == nil {
+			continue
+		}
 		varAlreadyInDsProfile := false
 		for _, dsVar := range dsProfileValues {
 			varID := removePrefix(dsVar.IDRef, varIDPrefix)
@@ -163,6 +166,9 @@ func getTailoringValues(oscalPolicy policy.Policy, dsProfile *xccdf.ProfileEleme
 
 	// All OSCAL policy variables should be present in the Datastream
 	for _, rule := range oscalPolicy {
+		if rule.Rule.Parameter == nil {
+			continue
+		}
 		if !validateVariableExistence(rule.Rule.Parameter.ID, dsVariables) {
 			return nil, fmt.Errorf("variable not found in datastream: %s", rule.Rule.Parameter.ID)
 		}

--- a/cmd/openscap-plugin/xccdf/tailoring.go
+++ b/cmd/openscap-plugin/xccdf/tailoring.go
@@ -95,14 +95,13 @@ func selectAdditionalRules(tailoringSelections, dsProfileSelections []xccdf.Sele
 		for _, dsRule := range dsProfileSelections {
 			ruleID := removePrefix(dsRule.IDRef, ruleIDPrefix)
 			if rule.Rule.ID == ruleID {
-				// Not a common case, but a rule be be unselected in Datastream Profile
+				// Not a common case, but a rule be be unselected in a Datastream Profile
 				if dsRule.Selected {
 					ruleAlreadyInDsProfile = true
 				}
 				break
 			}
 		}
-
 		if !ruleAlreadyInDsProfile {
 			tailoringSelections = append(tailoringSelections, xccdf.SelectElement{
 				IDRef:    getDsRuleID(rule.Rule.ID),
@@ -119,7 +118,7 @@ func getTailoringSelections(oscalPolicy policy.Policy, dsProfile *xccdf.ProfileE
 		return nil, fmt.Errorf("failed to get rules from datastream: %w", err)
 	}
 
-	// All policy rules should be present in the Datastream
+	// All OSCAL Policy rules should be present in the Datastream
 	for _, rule := range oscalPolicy {
 		if !validateRuleExistence(rule.Rule.ID, dsRules) {
 			return nil, fmt.Errorf("rule not found in datastream: %s", rule.Rule.ID)
@@ -146,7 +145,6 @@ func updateTailoringValues(tailoringValues, dsProfileValues []xccdf.SetValueElem
 				break
 			}
 		}
-
 		if !varAlreadyInDsProfile {
 			tailoringValues = append(tailoringValues, xccdf.SetValueElement{
 				IDRef: getDsVarID(rule.Rule.Parameter.ID),
@@ -163,7 +161,7 @@ func getTailoringValues(oscalPolicy policy.Policy, dsProfile *xccdf.ProfileEleme
 		return nil, fmt.Errorf("failed to get variables from datastream: %w", err)
 	}
 
-	// All policy variables should be present in the Datastream
+	// All OSCAL policy variables should be present in the Datastream
 	for _, rule := range oscalPolicy {
 		if !validateVariableExistence(rule.Rule.Parameter.ID, dsVariables) {
 			return nil, fmt.Errorf("variable not found in datastream: %s", rule.Rule.Parameter.ID)
@@ -172,7 +170,7 @@ func getTailoringValues(oscalPolicy policy.Policy, dsProfile *xccdf.ProfileEleme
 
 	dsProfile, err = ResolveDsVariableOptions(dsProfile, dsVariables)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve variable options: %w", err)
+		return nil, fmt.Errorf("failed to get values from variables options: %w", err)
 	}
 
 	var tailoringValues []xccdf.SetValueElement

--- a/cmd/openscap-plugin/xccdf/tailoring.go
+++ b/cmd/openscap-plugin/xccdf/tailoring.go
@@ -95,7 +95,7 @@ func selectAdditionalRules(tailoringSelections, dsProfileSelections []xccdf.Sele
 		for _, dsRule := range dsProfileSelections {
 			ruleID := removePrefix(dsRule.IDRef, ruleIDPrefix)
 			if rule.Rule.ID == ruleID {
-				// Not a common case, but a rule be be unselected in a Datastream Profile
+				// Not a common case, but a rule can be unselected in a Datastream Profile
 				if dsRule.Selected {
 					ruleAlreadyInDsProfile = true
 				}

--- a/cmd/openscap-plugin/xccdf/tailoring.go
+++ b/cmd/openscap-plugin/xccdf/tailoring.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	XCCDFNamespace       string = "complytime.openscapplugin"
-	XCCDFTailoringSuffix string = "complytime-tailoring-profile"
+	XCCDFTailoringSuffix string = "complytime"
 )
 
 func removePrefix(str, prefix string) string {

--- a/cmd/openscap-plugin/xccdf/tailoring_test.go
+++ b/cmd/openscap-plugin/xccdf/tailoring_test.go
@@ -622,6 +622,9 @@ func TestGetTailoringProfile(t *testing.T) {
 	}
 }
 
+// This is a supporting function used by TestPolicyToXML.
+// It removes the time attribute from the XML because it is generated
+// dynamically and may differ in some seconds during the tests.
 func removeVersionTimeTest(xml string) string {
 	re := regexp.MustCompile(`time="[^"]*"`)
 	return re.ReplaceAllString(xml, `time=""`)

--- a/cmd/openscap-plugin/xccdf/tailoring_test.go
+++ b/cmd/openscap-plugin/xccdf/tailoring_test.go
@@ -4,6 +4,7 @@ package xccdf
 
 import (
 	"path/filepath"
+	"regexp"
 	"testing"
 	"time"
 
@@ -13,9 +14,24 @@ import (
 	"github.com/oscal-compass/oscal-sdk-go/extensions"
 )
 
+// This is a supporting function to get the profile element from the testing Datastream.
+// It is used by TestGetTailoringSelections and TestGetTailoringValues.
+func getProfileElementTest(t *testing.T, profileID string) (*xccdf.ProfileElement, error) {
+	doc, _ := LoadDsTest(t, "ssg-rhel-ds.xml")
+	dsProfile, err := getDsProfile(doc, profileID)
+	if err != nil {
+		t.Fatalf("failed to get profile: %v", err)
+	}
+	parsedProfile, err := initProfile(dsProfile, profileID)
+	if err != nil {
+		t.Fatalf("failed to init parsed profile: %v", err)
+	}
+	return parsedProfile, nil
+}
+
 // TestGetTailoringID tests the getTailoringID function.
 func TestGetTailoringID(t *testing.T) {
-	expected := "xccdf_complytime.openscapplugin_tailoring_complytime-tailoring-profile"
+	expected := "xccdf_complytime.openscapplugin_tailoring_complytime"
 	result := getTailoringID()
 
 	if result != expected {
@@ -25,8 +41,8 @@ func TestGetTailoringID(t *testing.T) {
 
 // TestGetTailoringProfileID tests the getTailoringProfileID function.
 func TestGetTailoringProfileID(t *testing.T) {
-	profileId := "test-profile"
-	expected := "xccdf_complytime.openscapplugin_profile_test-profile_complytime-tailoring-profile"
+	profileId := "test_profile"
+	expected := "xccdf_complytime.openscapplugin_profile_test_profile_complytime"
 	result := getTailoringProfileID(profileId)
 
 	if result != expected {
@@ -36,22 +52,18 @@ func TestGetTailoringProfileID(t *testing.T) {
 
 // TestGetTailoringProfileTitle tests the getTailoringProfileTitle function.
 func TestGetTailoringProfileTitle(t *testing.T) {
-	dsPath := filepath.Join("..", "..", "..", "internal", "complytime", "testdata", "openscap", "ssg-rhel-ds.xml")
-
 	tests := []struct {
-		profileId string
-		dsPath    string
-		expected  string
+		profileTitle string
+		expected     string
 	}{
-		{"test_profile", dsPath, "ComplyTime Tailoring Profile - Test Profile"},
-		{"no-ds-profile", dsPath, "ComplyTime Tailoring Profile - no-ds-profile"},
-		{"test_profile_no_title", dsPath, "ComplyTime Tailoring Profile - test_profile_no_title"},
+		{"Test Profile", "ComplyTime Tailoring Profile - Test Profile"},
+		{"test_profile_id", "ComplyTime Tailoring Profile - test_profile_id"},
 	}
 
 	for _, tt := range tests {
-		result := getTailoringProfileTitle(tt.profileId, tt.dsPath)
+		result := getTailoringProfileTitle(tt.profileTitle)
 		if result != tt.expected {
-			t.Errorf("getTailoringProfileTitle(%v, %v) = %v; want %v", tt.profileId, tt.dsPath, result, tt.expected)
+			t.Errorf("getTailoringProfileTitle(%v) = %v; want %v", tt.profileTitle, result, tt.expected)
 		}
 	}
 }
@@ -72,7 +84,7 @@ func TestGetTailoringVersion(t *testing.T) {
 
 // TestGetTailoringBenchmarkHref tests the getTailoringBenchmarkHref function.
 func TestGetTailoringBenchmarkHref(t *testing.T) {
-	dsPath := filepath.Join("..", "..", "..", "internal", "complytime", "testdata", "openscap", "ssg-rhel-ds.xml")
+	dsPath := filepath.Join(testDataDir, "ssg-rhel-ds.xml")
 	expected := xccdf.BenchmarkElement{
 		Href: dsPath,
 	}
@@ -83,19 +95,494 @@ func TestGetTailoringBenchmarkHref(t *testing.T) {
 	}
 }
 
+// TestValidateRuleExistence tests the validateRuleExistence function.
+func TestValidateRuleExistence(t *testing.T) {
+	tests := []struct {
+		name          string
+		policyRuleID  string
+		dsRules       []DsRules
+		expectedExist bool
+	}{
+		{
+			name:         "Rule exists",
+			policyRuleID: "rule1",
+			dsRules: []DsRules{
+				{ID: "xccdf_org.ssgproject.content_rule_rule1"},
+				{ID: "xccdf_org.ssgproject.content_rule_rule2"},
+			},
+			expectedExist: true,
+		},
+		{
+			name:         "Rule does not exist",
+			policyRuleID: "rule3",
+			dsRules: []DsRules{
+				{ID: "xccdf_org.ssgproject.content_rule_rule1"},
+				{ID: "xccdf_org.ssgproject.content_rule_rule2"},
+			},
+			expectedExist: false,
+		},
+		{
+			name:          "Empty dsRules",
+			policyRuleID:  "rule1",
+			dsRules:       []DsRules{},
+			expectedExist: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validateRuleExistence(tt.policyRuleID, tt.dsRules)
+			if result != tt.expectedExist {
+				t.Errorf("validateRuleExistence(%v, %v) = %v; want %v", tt.policyRuleID, tt.dsRules, result, tt.expectedExist)
+			}
+		})
+	}
+}
+
+// TestValidateVariableExistence tests the validateVariableExistence function.
+func TestValidateVariableExistence(t *testing.T) {
+	tests := []struct {
+		name              string
+		policyVariableID  string
+		dsVariables       []DsVariables
+		expectedExistence bool
+	}{
+		{
+			name:             "Variable exists",
+			policyVariableID: "var1",
+			dsVariables: []DsVariables{
+				{ID: "xccdf_org.ssgproject.content_value_var1"},
+				{ID: "xccdf_org.ssgproject.content_value_var2"},
+			},
+			expectedExistence: true,
+		},
+		{
+			name:             "Variable does not exist",
+			policyVariableID: "var3",
+			dsVariables: []DsVariables{
+				{ID: "xccdf_org.ssgproject.content_value_var1"},
+				{ID: "xccdf_org.ssgproject.content_value_var2"},
+			},
+			expectedExistence: false,
+		},
+		{
+			name:              "Empty dsVariables",
+			policyVariableID:  "var1",
+			dsVariables:       []DsVariables{},
+			expectedExistence: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validateVariableExistence(tt.policyVariableID, tt.dsVariables)
+			if result != tt.expectedExistence {
+				t.Errorf("validateVariableExistence(%v, %v) = %v; want %v", tt.policyVariableID, tt.dsVariables, result, tt.expectedExistence)
+			}
+		})
+	}
+}
+
+// TestUnselectAbsentRules tests the unselectAbsentRules function.
+func TestUnselectAbsentRules(t *testing.T) {
+	tests := []struct {
+		name                string
+		tailoringSelections []xccdf.SelectElement
+		dsProfileSelections []xccdf.SelectElement
+		oscalPolicy         policy.Policy
+		expectedSelections  []xccdf.SelectElement
+	}{
+		{
+			name:                "No absent rules",
+			tailoringSelections: []xccdf.SelectElement{},
+			dsProfileSelections: []xccdf.SelectElement{
+				{IDRef: "xccdf_org.ssgproject.content_rule_rule1", Selected: true},
+				{IDRef: "xccdf_org.ssgproject.content_rule_rule2", Selected: true},
+			},
+			oscalPolicy: policy.Policy{
+				{Rule: extensions.Rule{ID: "rule1"}},
+				{Rule: extensions.Rule{ID: "rule2"}},
+			},
+			expectedSelections: []xccdf.SelectElement{},
+		},
+		{
+			name:                "One absent rule",
+			tailoringSelections: []xccdf.SelectElement{},
+			dsProfileSelections: []xccdf.SelectElement{
+				{IDRef: "xccdf_org.ssgproject.content_rule_rule1", Selected: true},
+				{IDRef: "xccdf_org.ssgproject.content_rule_rule2", Selected: true},
+			},
+			oscalPolicy: policy.Policy{
+				{Rule: extensions.Rule{ID: "rule1"}},
+			},
+			expectedSelections: []xccdf.SelectElement{
+				{IDRef: "xccdf_org.ssgproject.content_rule_rule2", Selected: false},
+			},
+		},
+		{
+			name:                "All absent rules",
+			tailoringSelections: []xccdf.SelectElement{},
+			dsProfileSelections: []xccdf.SelectElement{
+				{IDRef: "xccdf_org.ssgproject.content_rule_rule1", Selected: true},
+				{IDRef: "xccdf_org.ssgproject.content_rule_rule2", Selected: true},
+			},
+			oscalPolicy: policy.Policy{},
+			expectedSelections: []xccdf.SelectElement{
+				{IDRef: "xccdf_org.ssgproject.content_rule_rule1", Selected: false},
+				{IDRef: "xccdf_org.ssgproject.content_rule_rule2", Selected: false},
+			},
+		},
+		{
+			name:                "No dsProfileSelections",
+			tailoringSelections: []xccdf.SelectElement{},
+			dsProfileSelections: []xccdf.SelectElement{},
+			oscalPolicy: policy.Policy{
+				{Rule: extensions.Rule{ID: "rule1"}},
+			},
+			expectedSelections: []xccdf.SelectElement{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := unselectAbsentRules(tt.tailoringSelections, tt.dsProfileSelections, tt.oscalPolicy)
+			if len(result) != len(tt.expectedSelections) {
+				t.Errorf("unselectAbsentRules() length = %v; want %v", len(result), len(tt.expectedSelections))
+			}
+			for i, selection := range result {
+				if selection.IDRef != tt.expectedSelections[i].IDRef || selection.Selected != tt.expectedSelections[i].Selected {
+					t.Errorf("unselectAbsentRules()[%d] = %v; want %v", i, selection, tt.expectedSelections[i])
+				}
+			}
+		})
+	}
+}
+
+// TestSelectAdditionalRules tests the selectAdditionalRules function.
+func TestSelectAdditionalRules(t *testing.T) {
+	tests := []struct {
+		name                string
+		tailoringSelections []xccdf.SelectElement
+		dsProfileSelections []xccdf.SelectElement
+		oscalPolicy         policy.Policy
+		expectedSelections  []xccdf.SelectElement
+	}{
+		{
+			name:                "No additional rules",
+			tailoringSelections: []xccdf.SelectElement{},
+			dsProfileSelections: []xccdf.SelectElement{
+				{IDRef: "xccdf_org.ssgproject.content_rule_rule1", Selected: true},
+				{IDRef: "xccdf_org.ssgproject.content_rule_rule2", Selected: true},
+			},
+			oscalPolicy: policy.Policy{
+				{Rule: extensions.Rule{ID: "rule1"}},
+				{Rule: extensions.Rule{ID: "rule2"}},
+			},
+			expectedSelections: []xccdf.SelectElement{},
+		},
+		{
+			name:                "One additional rule",
+			tailoringSelections: []xccdf.SelectElement{},
+			dsProfileSelections: []xccdf.SelectElement{
+				{IDRef: "xccdf_org.ssgproject.content_rule_rule1", Selected: true},
+			},
+			oscalPolicy: policy.Policy{
+				{Rule: extensions.Rule{ID: "rule1"}},
+				{Rule: extensions.Rule{ID: "rule2"}},
+			},
+			expectedSelections: []xccdf.SelectElement{
+				{IDRef: "xccdf_org.ssgproject.content_rule_rule2", Selected: true},
+			},
+		},
+		{
+			name:                "All additional rules",
+			tailoringSelections: []xccdf.SelectElement{},
+			dsProfileSelections: []xccdf.SelectElement{},
+			oscalPolicy: policy.Policy{
+				{Rule: extensions.Rule{ID: "rule1"}},
+				{Rule: extensions.Rule{ID: "rule2"}},
+			},
+			expectedSelections: []xccdf.SelectElement{
+				{IDRef: "xccdf_org.ssgproject.content_rule_rule1", Selected: true},
+				{IDRef: "xccdf_org.ssgproject.content_rule_rule2", Selected: true},
+			},
+		},
+		{
+			name:                "Rule already in dsProfile but unselected",
+			tailoringSelections: []xccdf.SelectElement{},
+			dsProfileSelections: []xccdf.SelectElement{
+				{IDRef: "xccdf_org.ssgproject.content_rule_rule1", Selected: false},
+			},
+			oscalPolicy: policy.Policy{
+				{Rule: extensions.Rule{ID: "rule1"}},
+			},
+			expectedSelections: []xccdf.SelectElement{
+				{IDRef: "xccdf_org.ssgproject.content_rule_rule1", Selected: true},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := selectAdditionalRules(tt.tailoringSelections, tt.dsProfileSelections, tt.oscalPolicy)
+			if len(result) != len(tt.expectedSelections) {
+				t.Errorf("selectAdditionalRules() length = %v; want %v", len(result), len(tt.expectedSelections))
+			}
+			for i, selection := range result {
+				if selection.IDRef != tt.expectedSelections[i].IDRef || selection.Selected != tt.expectedSelections[i].Selected {
+					t.Errorf("selectAdditionalRules()[%d] = %v; want %v", i, selection, tt.expectedSelections[i])
+				}
+			}
+		})
+	}
+}
+
+// TestGetTailoringSelections tests the getTailoringSelections function.
+func TestGetTailoringSelections(t *testing.T) {
+	dsPath := filepath.Join(testDataDir, "ssg-rhel-ds.xml")
+	parsedProfile, _ := getProfileElementTest(t, "xccdf_org.ssgproject.content_profile_test_profile")
+
+	tests := []struct {
+		name           string
+		oscalPolicy    policy.Policy
+		expectedError  bool
+		expectedResult []xccdf.SelectElement
+	}{
+		{
+			name: "All rules present",
+			oscalPolicy: policy.Policy{
+				{Rule: extensions.Rule{ID: "package_telnet-server_removed"}},
+				{Rule: extensions.Rule{ID: "package_telnet_removed"}},
+				{Rule: extensions.Rule{ID: "set_password_hashing_algorithm_logindefs"}},
+				{Rule: extensions.Rule{ID: "set_password_hashing_algorithm_systemauth"}},
+			},
+			expectedError:  false,
+			expectedResult: []xccdf.SelectElement{},
+		},
+		{
+			name: "One rule missing in datastream",
+			oscalPolicy: policy.Policy{
+				{Rule: extensions.Rule{ID: "package_telnet-server_removed"}},
+				{Rule: extensions.Rule{ID: "package_telnet_removed"}},
+				{Rule: extensions.Rule{ID: "set_password_hashing_algorithm_logindefs"}},
+				{Rule: extensions.Rule{ID: "set_password_hashing_algorithm_systemauth"}},
+				{Rule: extensions.Rule{ID: "this_rule_is_not_in_datastream"}},
+			},
+			expectedError:  true,
+			expectedResult: nil,
+		},
+		{
+			name:        "No rules in OSCAL policy",
+			oscalPolicy: policy.Policy{},
+			expectedResult: []xccdf.SelectElement{
+				{IDRef: "xccdf_org.ssgproject.content_rule_package_telnet-server_removed", Selected: false},
+				{IDRef: "xccdf_org.ssgproject.content_rule_package_telnet_removed", Selected: false},
+				{IDRef: "xccdf_org.ssgproject.content_rule_set_password_hashing_algorithm_logindefs", Selected: false},
+				{IDRef: "xccdf_org.ssgproject.content_rule_set_password_hashing_algorithm_systemauth", Selected: false},
+			},
+		},
+		{
+			name: "Additional rule in OSCAL policy",
+			oscalPolicy: policy.Policy{
+				{Rule: extensions.Rule{ID: "package_telnet-server_removed"}},
+				{Rule: extensions.Rule{ID: "package_telnet_removed"}},
+				{Rule: extensions.Rule{ID: "set_password_hashing_algorithm_logindefs"}},
+				{Rule: extensions.Rule{ID: "set_password_hashing_algorithm_systemauth"}},
+				{Rule: extensions.Rule{ID: "account_unique_id"}},
+			},
+			expectedError: false,
+			expectedResult: []xccdf.SelectElement{
+				{IDRef: "xccdf_org.ssgproject.content_rule_account_unique_id", Selected: true},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := getTailoringSelections(tt.oscalPolicy, parsedProfile, dsPath)
+			if (err != nil) != tt.expectedError {
+				t.Errorf("getTailoringSelections() error = %v; want %v", err, tt.expectedError)
+			}
+			if len(result) != len(tt.expectedResult) {
+				t.Errorf("getTailoringSelections() length = %v; want %v", len(result), len(tt.expectedResult))
+			}
+			for i, selection := range result {
+				if selection.IDRef != tt.expectedResult[i].IDRef || selection.Selected != tt.expectedResult[i].Selected {
+					t.Errorf("getTailoringSelections()[%d] = %v; want %v", i, selection, tt.expectedResult[i])
+				}
+			}
+		})
+	}
+}
+
+// TestUpdateTailoringValues tests the updateTailoringValues function.
+func TestUpdateTailoringValues(t *testing.T) {
+	tests := []struct {
+		name            string
+		tailoringValues []xccdf.SetValueElement
+		dsProfileValues []xccdf.SetValueElement
+		oscalPolicy     policy.Policy
+		expectedValues  []xccdf.SetValueElement
+	}{
+		{
+			name:            "No additional values",
+			tailoringValues: []xccdf.SetValueElement{},
+			dsProfileValues: []xccdf.SetValueElement{
+				{IDRef: "xccdf_org.ssgproject.content_value_var1", Value: "value1"},
+				{IDRef: "xccdf_org.ssgproject.content_value_var2", Value: "value2"},
+			},
+			oscalPolicy: policy.Policy{
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "var1", Value: "value1"}}},
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "var2", Value: "value2"}}},
+			},
+			expectedValues: []xccdf.SetValueElement{},
+		},
+		{
+			name:            "One additional value",
+			tailoringValues: []xccdf.SetValueElement{},
+			dsProfileValues: []xccdf.SetValueElement{
+				{IDRef: "xccdf_org.ssgproject.content_value_var1", Value: "value1"},
+			},
+			oscalPolicy: policy.Policy{
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "var1", Value: "value1"}}},
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "var2", Value: "value2"}}},
+			},
+			expectedValues: []xccdf.SetValueElement{
+				{IDRef: "xccdf_org.ssgproject.content_value_var2", Value: "value2"},
+			},
+		},
+		{
+			name:            "All additional values",
+			tailoringValues: []xccdf.SetValueElement{},
+			dsProfileValues: []xccdf.SetValueElement{},
+			oscalPolicy: policy.Policy{
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "var1", Value: "value1"}}},
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "var2", Value: "value2"}}},
+			},
+			expectedValues: []xccdf.SetValueElement{
+				{IDRef: "xccdf_org.ssgproject.content_value_var1", Value: "value1"},
+				{IDRef: "xccdf_org.ssgproject.content_value_var2", Value: "value2"},
+			},
+		},
+		{
+			name:            "Variable already in dsProfile but different value",
+			tailoringValues: []xccdf.SetValueElement{},
+			dsProfileValues: []xccdf.SetValueElement{
+				{IDRef: "xccdf_org.ssgproject.content_value_var1", Value: "old_value"},
+			},
+			oscalPolicy: policy.Policy{
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "var1", Value: "new_value"}}},
+			},
+			expectedValues: []xccdf.SetValueElement{
+				{IDRef: "xccdf_org.ssgproject.content_value_var1", Value: "new_value"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := updateTailoringValues(tt.tailoringValues, tt.dsProfileValues, tt.oscalPolicy)
+			if len(result) != len(tt.expectedValues) {
+				t.Errorf("updateTailoringValues() length = %v; want %v", len(result), len(tt.expectedValues))
+			}
+			for i, value := range result {
+				if value.IDRef != tt.expectedValues[i].IDRef || value.Value != tt.expectedValues[i].Value {
+					t.Errorf("updateTailoringValues()[%d] = %v; want %v", i, value, tt.expectedValues[i])
+				}
+			}
+		})
+	}
+}
+
+// TestGetTailoringValues tests the getTailoringValues function.
+func TestGetTailoringValues(t *testing.T) {
+	dsPath := filepath.Join(testDataDir, "ssg-rhel-ds.xml")
+
+	tests := []struct {
+		name           string
+		oscalPolicy    policy.Policy
+		expectedError  bool
+		expectedResult []xccdf.SetValueElement
+	}{
+		{
+			name: "All variables present",
+			oscalPolicy: policy.Policy{
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "var_password_hashing_algorithm", Value: "SHA512"}}},
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "var_password_hashing_algorithm_pam", Value: "sha512"}}},
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "var_accounts_tmout", Value: "900"}}},
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "var_password_pam_remember_control_flag", Value: "requisite,required"}}},
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "var_password_pam_remember", Value: "5"}}},
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "var_system_crypto_policy", Value: "DEFAULT"}}},
+			},
+			expectedError:  false,
+			expectedResult: []xccdf.SetValueElement{},
+		},
+		{
+			name: "One variable missing in datastream",
+			oscalPolicy: policy.Policy{
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "var_password_hashing_algorithm", Value: "SHA512"}}},
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "var_password_hashing_algorithm_pam", Value: "sha512"}}},
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "var_accounts_tmout", Value: "900"}}},
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "var_password_pam_remember_control_flag", Value: "requisite,required"}}},
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "var_password_pam_remember", Value: "5"}}},
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "this_variable_is_not_in_datastream", Value: "value"}}},
+			},
+			expectedError:  true,
+			expectedResult: nil,
+		},
+		{
+			name: "Additional variable in OSCAL policy",
+			oscalPolicy: policy.Policy{
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "var_password_hashing_algorithm", Value: "SHA512"}}},
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "var_password_hashing_algorithm_pam", Value: "sha512"}}},
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "var_accounts_tmout", Value: "900"}}},
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "var_password_pam_remember_control_flag", Value: "requisite,required"}}},
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "var_password_pam_remember", Value: "5"}}},
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "var_system_crypto_policy", Value: "DEFAULT"}}},
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "var_selinux_policy_name", Value: "mls"}}},
+			},
+			expectedError: false,
+			expectedResult: []xccdf.SetValueElement{
+				{IDRef: "xccdf_org.ssgproject.content_value_var_selinux_policy_name", Value: "mls"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		// Variables options are resolved during the process, so we need to get the profile element again.
+		parsedProfile, _ := getProfileElementTest(t, "xccdf_org.ssgproject.content_profile_test_profile")
+
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := getTailoringValues(tt.oscalPolicy, parsedProfile, dsPath)
+			if (err != nil) != tt.expectedError {
+				t.Errorf("getTailoringValues() error = %v; want %v", err, tt.expectedError)
+			}
+			if len(result) != len(tt.expectedResult) {
+				t.Errorf("getTailoringValues() length = %v; want %v", len(result), len(tt.expectedResult))
+			}
+			for i, value := range result {
+				if value.IDRef != tt.expectedResult[i].IDRef || value.Value != tt.expectedResult[i].Value {
+					t.Errorf("getTailoringValues()[%d] = %v; want %v", i, value, tt.expectedResult[i])
+				}
+			}
+		})
+	}
+}
+
 // TestGetTailoringProfile tests the getTailoringProfile function.
 func TestGetTailoringProfile(t *testing.T) {
-	profileId := "test-profile"
-	dsPath := filepath.Join("..", "..", "..", "internal", "complytime", "testdata", "openscap", "ssg-rhel-ds.xml")
+	dsPath := filepath.Join(testDataDir, "ssg-rhel-ds.xml")
+	profileId := "test_profile"
+
 	tailoringPolicy := policy.Policy{
 		{
 			Rule: extensions.Rule{
-				ID:          "rule1",
-				Description: "rule1_description",
+				ID:          "set_password_hashing_algorithm_logindefs",
+				Description: "Set Password Hashing Algorithm in /etc/login.defs",
 				Parameter: &extensions.Parameter{
-					ID:          "param1",
-					Description: "param1_description",
-					Value:       "value1",
+					ID:          "var_password_hashing_algorithm",
+					Description: "Password Hashing algorithm",
+					Value:       "YESCRYPT",
 				},
 			},
 		},
@@ -104,17 +591,22 @@ func TestGetTailoringProfile(t *testing.T) {
 	expected := xccdf.ProfileElement{
 		ID: getTailoringProfileID(profileId),
 		Title: &xccdf.TitleOrDescriptionElement{
-			Value: getTailoringProfileTitle(profileId, dsPath),
+			Value: "ComplyTime Tailoring Profile - Test Profile",
 		},
 		Selections: []xccdf.SelectElement{
-			{IDRef: "rule1", Selected: true},
+			{IDRef: "xccdf_org.ssgproject.content_rule_package_telnet-server_removed", Selected: false},
+			{IDRef: "xccdf_org.ssgproject.content_rule_package_telnet_removed", Selected: false},
+			{IDRef: "xccdf_org.ssgproject.content_rule_set_password_hashing_algorithm_systemauth", Selected: false},
 		},
 		Values: []xccdf.SetValueElement{
-			{IDRef: "param1", Value: "value1"},
+			{IDRef: "xccdf_org.ssgproject.content_value_var_password_hashing_algorithm", Value: "YESCRYPT"},
 		},
 	}
 
-	result := getTailoringProfile(profileId, tailoringPolicy, dsPath)
+	result, err := getTailoringProfile(profileId, dsPath, tailoringPolicy)
+	if err != nil {
+		t.Fatalf("getTailoringProfile() error = %v", err)
+	}
 
 	if result.ID != expected.ID {
 		t.Errorf("getTailoringProfile().ID = %v; want %v", result.ID, expected.ID)
@@ -130,146 +622,25 @@ func TestGetTailoringProfile(t *testing.T) {
 	}
 }
 
-// TestGetPolicySelections tests the getPolicySelections function.
-func TestGetPolicySelections(t *testing.T) {
-	tailoringPolicy := policy.Policy{
-		{
-			Rule: extensions.Rule{
-				ID:          "rule1",
-				Description: "rule1_description",
-			},
-		},
-		{
-			Rule: extensions.Rule{
-				ID:          "rule2",
-				Description: "rule2_description",
-			},
-		},
-	}
-
-	expected := []xccdf.SelectElement{
-		{IDRef: "rule1", Selected: true},
-		{IDRef: "rule2", Selected: true},
-	}
-
-	result := getPolicySelections(tailoringPolicy)
-
-	if len(result) != len(expected) {
-		t.Errorf("getPolicySelections() length = %v; want %v", len(result), len(expected))
-	}
-
-	for i, selection := range result {
-		if selection.IDRef != expected[i].IDRef || selection.Selected != expected[i].Selected {
-			t.Errorf("getPolicySelections()[%d] = %v; want %v", i, selection, expected[i])
-		}
-	}
-}
-
-// TestGetValuesFromPolicyVariables tests the getValuesFromPolicyVariables function.
-func TestGetValuesFromPolicyVariables(t *testing.T) {
-	tests := []struct {
-		name            string
-		tailoringPolicy policy.Policy
-		expected        []xccdf.SetValueElement
-	}{
-		{
-			name: "Single rule with parameter",
-			tailoringPolicy: policy.Policy{
-				{
-					Rule: extensions.Rule{
-						ID:          "rule1",
-						Description: "rule1_description",
-						Parameter: &extensions.Parameter{
-							ID:          "param1",
-							Description: "param1_description",
-							Value:       "value1",
-						},
-					},
-				},
-			},
-			expected: []xccdf.SetValueElement{
-				{IDRef: "param1", Value: "value1"},
-			},
-		},
-		{
-			name: "Multiple rules with parameters",
-			tailoringPolicy: policy.Policy{
-				{
-					Rule: extensions.Rule{
-						ID:          "rule1",
-						Description: "rule1_description",
-						Parameter: &extensions.Parameter{
-							ID:          "param1",
-							Description: "param1_description",
-							Value:       "value1",
-						},
-					},
-				},
-				{
-					Rule: extensions.Rule{
-						ID:          "rule2",
-						Description: "rule2_description",
-						Parameter: &extensions.Parameter{
-							ID:          "param2",
-							Description: "param2_description",
-							Value:       "value2",
-						},
-					},
-				},
-			},
-			expected: []xccdf.SetValueElement{
-				{IDRef: "param1", Value: "value1"},
-				{IDRef: "param2", Value: "value2"},
-			},
-		},
-		{
-			name: "Rule without parameter",
-			tailoringPolicy: policy.Policy{
-				{
-					Rule: extensions.Rule{
-						ID:          "rule1",
-						Description: "rule1_description",
-					},
-				},
-			},
-			expected: nil,
-		},
-		{
-			name:            "Empty policy",
-			tailoringPolicy: policy.Policy{},
-			expected:        nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := getValuesFromPolicyVariables(tt.tailoringPolicy)
-			if len(result) != len(tt.expected) {
-				t.Errorf("getValuesFromPolicyVariables() length = %v; want %v", len(result), len(tt.expected))
-			}
-			for i, value := range result {
-				if value.IDRef != tt.expected[i].IDRef || value.Value != tt.expected[i].Value {
-					t.Errorf("getValuesFromPolicyVariables()[%d] = %v; want %v", i, value, tt.expected[i])
-				}
-			}
-		})
-	}
+func removeVersionTimeTest(xml string) string {
+	re := regexp.MustCompile(`time="[^"]*"`)
+	return re.ReplaceAllString(xml, `time=""`)
 }
 
 // TestPolicyToXML tests the PolicyToXML function.
 func TestPolicyToXML(t *testing.T) {
-	dsPath := filepath.Join("..", "..", "..", "internal", "complytime", "testdata", "openscap", "ssg-rhel-ds.xml")
+	dsPath := filepath.Join(testDataDir, "ssg-rhel-ds.xml")
 	profileId := "test_profile"
 
 	tailoringPolicy := policy.Policy{
 		{
 			Rule: extensions.Rule{
-				ID:          "rule1",
-				Description: "rule1_description",
+				ID:          "account_unique_id",
+				Description: "Ensure All Accounts on the System Have Unique User IDs",
 				Parameter: &extensions.Parameter{
-					ID:          "param1",
-					Description: "param1_description",
-					Value:       "value1",
+					ID:          "var_password_hashing_algorithm",
+					Description: "Password Hashing algorithm",
+					Value:       "YESCRYPT",
 				},
 			},
 		},
@@ -280,13 +651,17 @@ func TestPolicyToXML(t *testing.T) {
 	cfg.Parameters.Profile = profileId
 
 	expectedXML := `<?xml version="1.0" encoding="UTF-8"?>
-<xccdf-1.2:Tailoring xmlns:xccdf-1.2="http://checklists.nist.gov/xccdf/1.2" id="xccdf_complytime.openscapplugin_tailoring_complytime-tailoring-profile">
+<xccdf-1.2:Tailoring xmlns:xccdf-1.2="http://checklists.nist.gov/xccdf/1.2" id="xccdf_complytime.openscapplugin_tailoring_complytime">
   <xccdf-1.2:benchmark href="` + dsPath + `"></xccdf-1.2:benchmark>
   <xccdf-1.2:version time="` + getTailoringVersion().Time + `">1</xccdf-1.2:version>
-  <xccdf-1.2:Profile id="xccdf_complytime.openscapplugin_profile_test_profile_complytime-tailoring-profile">
-    <xccdf-1.2:title override="false">ComplyTime Tailoring Profile - Test Profile</xccdf-1.2:title>
-    <xccdf-1.2:select idref="rule1" selected="true"></xccdf-1.2:select>
-    <xccdf-1.2:set-value idref="param1">value1</xccdf-1.2:set-value>
+  <xccdf-1.2:Profile id="xccdf_complytime.openscapplugin_profile_test_profile_complytime">
+    <xccdf-1.2:title override="true">ComplyTime Tailoring Profile - Test Profile</xccdf-1.2:title>
+    <xccdf-1.2:select idref="xccdf_org.ssgproject.content_rule_package_telnet-server_removed" selected="false"></xccdf-1.2:select>
+    <xccdf-1.2:select idref="xccdf_org.ssgproject.content_rule_package_telnet_removed" selected="false"></xccdf-1.2:select>
+    <xccdf-1.2:select idref="xccdf_org.ssgproject.content_rule_set_password_hashing_algorithm_logindefs" selected="false"></xccdf-1.2:select>
+    <xccdf-1.2:select idref="xccdf_org.ssgproject.content_rule_set_password_hashing_algorithm_systemauth" selected="false"></xccdf-1.2:select>
+    <xccdf-1.2:select idref="xccdf_org.ssgproject.content_rule_account_unique_id" selected="true"></xccdf-1.2:select>
+    <xccdf-1.2:set-value idref="xccdf_org.ssgproject.content_value_var_password_hashing_algorithm">YESCRYPT</xccdf-1.2:set-value>
   </xccdf-1.2:Profile>
 </xccdf-1.2:Tailoring>`
 
@@ -295,7 +670,12 @@ func TestPolicyToXML(t *testing.T) {
 		t.Fatalf("PolicyToXML() error = %v", err)
 	}
 
-	if result != expectedXML {
-		t.Errorf("PolicyToXML() = %v; want %v", result, expectedXML)
+	// It takes some seconds to generate the tailoring file and the time differs.
+	// So we remove the time attribute to compare the XMLs.
+	expected := removeVersionTimeTest(expectedXML)
+	actual := removeVersionTimeTest(result)
+
+	if actual != expected {
+		t.Errorf("PolicyToXML() = %v; want %v", actual, expected)
 	}
 }

--- a/cmd/openscap-plugin/xccdf/tailoring_test.go
+++ b/cmd/openscap-plugin/xccdf/tailoring_test.go
@@ -477,6 +477,17 @@ func TestUpdateTailoringValues(t *testing.T) {
 				{IDRef: "xccdf_org.ssgproject.content_value_var1", Value: "new_value"},
 			},
 		},
+		{
+			name:            "Rule without parameter",
+			tailoringValues: []xccdf.SetValueElement{},
+			dsProfileValues: []xccdf.SetValueElement{
+				{IDRef: "xccdf_org.ssgproject.content_value_var1", Value: "value1"},
+			},
+			oscalPolicy: policy.Policy{
+				{Rule: extensions.Rule{Parameter: nil}},
+			},
+			expectedValues: []xccdf.SetValueElement{},
+		},
 	}
 
 	for _, tt := range tests {
@@ -545,6 +556,14 @@ func TestGetTailoringValues(t *testing.T) {
 			expectedResult: []xccdf.SetValueElement{
 				{IDRef: "xccdf_org.ssgproject.content_value_var_selinux_policy_name", Value: "mls"},
 			},
+		},
+		{
+			name: "OSCAL policy without variables",
+			oscalPolicy: policy.Policy{
+				{Rule: extensions.Rule{Parameter: nil}},
+			},
+			expectedError:  false,
+			expectedResult: []xccdf.SetValueElement{},
 		},
 	}
 


### PR DESCRIPTION
## Summary

This PR complements #29, #33 and #35 and completes the code to generate Tailoring files to be used with `openscap-plugin`.

`oscap` consumes accurate, tested and signed Datastreams provided by `scap-security-guide` package.
These Datastream contain well tested profiles aligned to official Benchmarks and maintained by [ComplianceAsCode/content](https://github.com/complianceAsCode/content).

The Datastream should not be modified but in some cases it needs to be tailored to include or remove an specific rule or to change a variable value. In the context of OSCAL, it may also include slightly different settings when compared to a Datastream. With this PR, all rules and parameters informed by OSCAL Policy will be validated and a minimalist Tailoring files will be generated to ensure a scan aligned to OSCAL content and and the Datastream.

## Related Issues
- Relates to CPLYTM-475

## Review Hints

The commit descriptions should provide the context and more details about each change.
The features were gradually introduced by each commit, so a chronological review commit by commit tends to be easier.
The first 4 commits are more substantial while the last 2 are minor improvements and fixes identified by tests.

For unit tests
`make test-unit`
