### PR TITLE
fix: do not remove policy file name from config

### DIFF
--- a/cmd/openscap-plugin/config/config.go
+++ b/cmd/openscap-plugin/config/config.go
@@ -74,7 +74,7 @@ func SanitizePath(path string) (string, error) {
 	cleanPath := filepath.Clean(path)
 	expandedPath, err := expandPath(cleanPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to expand path: %v", err)
+		return "", fmt.Errorf("failed to expand path: %w", err)
 	}
 	return expandedPath, nil
 }
@@ -143,15 +143,6 @@ func defineFilesPaths(cfg *Config) (*Config, error) {
 	cfg.Files.Policy = filepath.Join(directories["policyDir"], cfg.Files.Policy)
 	cfg.Files.Results = filepath.Join(directories["resultsDir"], cfg.Files.Results)
 	cfg.Files.ARF = filepath.Join(directories["resultsDir"], cfg.Files.ARF)
-
-	_, err = validatePath(cfg.Files.Policy, false)
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			cfg.Files.Policy = ""
-		} else {
-			return nil, err
-		}
-	}
 
 	return cfg, nil
 }

--- a/cmd/openscap-plugin/config/config_test.go
+++ b/cmd/openscap-plugin/config/config_test.go
@@ -259,7 +259,7 @@ func TestDefineFilesPaths(t *testing.T) {
 					Datastream: filepath.Join(tempDir, "datastream.xml"),
 					Results:    "results.xml",
 					ARF:        "arf.xml",
-					Policy:     "absent_policy.yaml",
+					Policy:     "policy.yaml",
 				},
 			},
 			expectError: false,
@@ -275,7 +275,7 @@ func TestDefineFilesPaths(t *testing.T) {
 
 			if !tt.expectError {
 				// Check if the paths are correctly set
-				expectedPolicyPath := ""
+				expectedPolicyPath := filepath.Join(tempDir, "workspace", "plugins", "policy", "policy.yaml")
 				expectedResultsPath := filepath.Join(tempDir, "workspace", "plugins", "results", "results.xml")
 				expectedARFPath := filepath.Join(tempDir, "workspace", "plugins", "results", "arf.xml")
 

--- a/cmd/openscap-plugin/oscap/oscap.go
+++ b/cmd/openscap-plugin/oscap/oscap.go
@@ -5,6 +5,7 @@ package oscap
 import (
 	"fmt"
 	"log"
+	"os"
 	"os/exec"
 )
 
@@ -26,9 +27,10 @@ func constructScanCommand(openscapFiles map[string]string, profile string) ([]st
 		arfFile,
 	}
 
-	if tailoringFile != "" {
+	if _, err := os.Stat(tailoringFile); err == nil {
 		cmd = append(cmd, "--tailoring-file", tailoringFile)
 	}
+
 	cmd = append(cmd, datastream)
 	return cmd, nil
 }

--- a/cmd/openscap-plugin/oscap/oscap_test.go
+++ b/cmd/openscap-plugin/oscap/oscap_test.go
@@ -3,11 +3,20 @@
 package oscap
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
 
 func TestConstructScanCommand(t *testing.T) {
+	tailoringFilePath := filepath.Join(t.TempDir(), "test-policy.xml")
+	tailoringFile, err := os.Create(tailoringFilePath)
+	if err != nil {
+		t.Fatalf("Failed to create fake tailoring file: %v", err)
+	}
+	tailoringFile.Close()
+
 	tests := []struct {
 		name          string
 		openscapFiles map[string]string
@@ -19,7 +28,7 @@ func TestConstructScanCommand(t *testing.T) {
 			name: "Valid input with tailoring file",
 			openscapFiles: map[string]string{
 				"datastream": "test-datastream.xml",
-				"policy":     "test-policy.xml",
+				"policy":     tailoringFilePath,
 				"results":    "test-results.xml",
 				"arf":        "test-arf.xml",
 			},
@@ -35,7 +44,7 @@ func TestConstructScanCommand(t *testing.T) {
 				"--results-arf",
 				"test-arf.xml",
 				"--tailoring-file",
-				"test-policy.xml",
+				tailoringFilePath,
 				"test-datastream.xml",
 			},
 			expectedErr: false,

--- a/cmd/openscap-plugin/scan/scan.go
+++ b/cmd/openscap-plugin/scan/scan.go
@@ -35,10 +35,12 @@ func validateOpenSCAPFiles(cfg *config.Config) (map[string]string, error) {
 		return nil, err
 	}
 
-	if cfg.Files.Policy != "" {
-		if _, err := isXMLFile(cfg.Files.Policy); err != nil {
-			return nil, err
-		}
+	if _, err := os.Stat(cfg.Files.Policy); err != nil {
+		return nil, err
+	}
+
+	if _, err := isXMLFile(cfg.Files.Policy); err != nil {
+		return nil, err
 	}
 
 	return map[string]string{


### PR DESCRIPTION
## Summary

With the introduction of the generate command (#15), the policy name is expected so the command can properly create the file if it is not already present.
This commit preserves the file name defined in configuration.

## Related Issues

- Avoid issues when generating a policy.

## Review Hints

This line was setting the policy file name to empty if the file was not found:
https://github.com/complytime/complytime/blob/f12079f9808680b290fd4ec0684b0c24b432c416/cmd/openscap-plugin/config/config.go#L147

However, this file is expected to be created by the `generate` command, so it can't be set to empty anymore.