### PR TITLE
Updates workflows with fixes for CI issues

### DIFF
--- a/.github/workflows/go_lint.yml
+++ b/.github/workflows/go_lint.yml
@@ -21,3 +21,4 @@ jobs:
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 #v6
         with:
           version: v1.60
+          args: --timeout=5m

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -59,7 +59,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@97a0fba1372883ab732affbe8f94b823f91727db # v3.pre.node20
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
## Summary

- Increase the timeout of golangci-lint job to `5m`. The default in `1m`.
- Bumps upload/artifact to v4 to resolve issues with the name not valid error.

## Related Issues

Related to failure occurring [here](https://github.com/complytime/complytime/actions/runs/13061780153/job/36446313973) and in currently submitted PRs.

## Review Hints

Please review each commit. Each one fixes one issue.
