### PR TITLE
docs: add comment for assessment-results.json being written during scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Run the generate command to `generate` policy artifacts in the workspace and run
 complytime generate
 ...
 complytime scan
+
+# The results will be written to assessment-results.json in the specified workspace.
+# Defaults to current working directory.
 ```
 
 ## Contributing


### PR DESCRIPTION
## Summary
Simple README update to mention the `assessment-results.json` file is written to user workspace during `scan` command.
