### PR TITLE
Minor reword in error messages for tailoring validation

### DIFF
--- a/cmd/openscap-plugin/xccdf/tailoring.go
+++ b/cmd/openscap-plugin/xccdf/tailoring.go
@@ -121,7 +121,7 @@ func getTailoringSelections(oscalPolicy policy.Policy, dsProfile *xccdf.ProfileE
 	// All OSCAL Policy rules should be present in the Datastream
 	for _, rule := range oscalPolicy {
 		if !validateRuleExistence(rule.Rule.ID, dsRules) {
-			return nil, fmt.Errorf("rule not found in datastream: %s", rule.Rule.ID)
+			return nil, fmt.Errorf("rule %s not found in datastream: %s", rule.Rule.ID, dsPath)
 		}
 	}
 
@@ -170,7 +170,7 @@ func getTailoringValues(oscalPolicy policy.Policy, dsProfile *xccdf.ProfileEleme
 			continue
 		}
 		if !validateVariableExistence(rule.Rule.Parameter.ID, dsVariables) {
-			return nil, fmt.Errorf("variable not found in datastream: %s", rule.Rule.Parameter.ID)
+			return nil, fmt.Errorf("variable %s not found in datastream: %s", rule.Rule.Parameter.ID, dsPath)
 		}
 	}
 


### PR DESCRIPTION
## Summary

When `openscap-plugin` is creating a tailoring file based on OSCAL content, it has a logic to validate if all rules and parameters from OSCAL Component Definition are also present in Datastream.

In case any value is not present, an error is reported.
This PR updates the error messages to be more intuitive

## Related Issues

There is not an actual issue, but makes the experience a bit better.

## Review Hints

The easiest way would be to create a Component Definition with an invalid RuleID value in the `openscap` validation component.
