### PR TITLE
feat: add charm logger in cli package

### DIFF
--- a/cmd/complytime/cli/list.go
+++ b/cmd/complytime/cli/list.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/hashicorp/go-hclog"
 	"github.com/spf13/cobra"
 
 	"github.com/complytime/complytime/cmd/complytime/option"
@@ -14,16 +15,16 @@ import (
 )
 
 // listCmd creates a new cobra.Command for the "list" subcommand
-func listCmd(common *option.Common) *cobra.Command {
+func listCmd(common *option.Common, logger hclog.Logger) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "list [flags]",
 		Short:        "List information about supported frameworks and components.",
 		SilenceUsage: true,
 		Example:      "complytime list",
 		Args:         cobra.NoArgs,
-		PreRun:       func(_ *cobra.Command, _ []string) { enableDebug(common) },
+		PreRun:       func(_ *cobra.Command, _ []string) { enableDebug(logger, common) },
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if err := runList(common); err != nil {
+			if err := runList(common, logger); err != nil {
 				logger.Error(err.Error())
 			}
 			return nil
@@ -32,7 +33,7 @@ func listCmd(common *option.Common) *cobra.Command {
 	return cmd
 }
 
-func runList(opts *option.Common) error {
+func runList(opts *option.Common, logger hclog.Logger) error {
 	appDir, err := complytime.NewApplicationDirectory(true)
 	if err != nil {
 		return err

--- a/cmd/complytime/cli/list.go
+++ b/cmd/complytime/cli/list.go
@@ -21,7 +21,13 @@ func listCmd(common *option.Common) *cobra.Command {
 		SilenceUsage: true,
 		Example:      "complytime list",
 		Args:         cobra.NoArgs,
-		RunE:         func(_ *cobra.Command, _ []string) error { return runList(common) },
+		PreRun:       func(_ *cobra.Command, _ []string) { enableDebug(common) },
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if err := runList(common); err != nil {
+				logger.Error(err.Error())
+			}
+			return nil
+		},
 	}
 	return cmd
 }
@@ -31,6 +37,7 @@ func runList(opts *option.Common) error {
 	if err != nil {
 		return err
 	}
+	logger.Debug(fmt.Sprintf("using application directory: %s", appDir.AppDir()))
 
 	frameworks, err := complytime.LoadFrameworks(appDir)
 	if err != nil {

--- a/cmd/complytime/cli/root.go
+++ b/cmd/complytime/cli/root.go
@@ -11,9 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var logger hclog.Logger
-
-func enableDebug(opts *option.Common) {
+func enableDebug(logger hclog.Logger, opts *option.Common) {
 	if opts.Debug {
 		logger.SetLevel(hclog.Debug)
 	}
@@ -22,13 +20,15 @@ func enableDebug(opts *option.Common) {
 // New creates a new cobra.Command root for ComplyTime
 func New() *cobra.Command {
 
-	logger = log.NewLogger(os.Stdout)
+	logger := log.NewLogger(os.Stdout)
 
 	cmd := &cobra.Command{
 		Use:           "complytime [command]",
 		SilenceErrors: true,
 		SilenceUsage:  false,
 	}
+
+	cmd.Context()
 
 	opts := option.Common{
 		Output: option.Output{
@@ -43,7 +43,7 @@ func New() *cobra.Command {
 		scanCmd(&opts),
 		generateCmd(&opts),
 		planCmd(&opts),
-		listCmd(&opts),
+		listCmd(&opts, logger),
 	)
 
 	return cmd

--- a/cmd/complytime/cli/root.go
+++ b/cmd/complytime/cli/root.go
@@ -3,13 +3,27 @@
 package cli
 
 import (
-	"github.com/spf13/cobra"
+	"os"
 
 	"github.com/complytime/complytime/cmd/complytime/option"
+	"github.com/complytime/complytime/pkg/log"
+	"github.com/hashicorp/go-hclog"
+	"github.com/spf13/cobra"
 )
+
+var logger hclog.Logger
+
+func enableDebug(opts *option.Common) {
+	if opts.Debug {
+		logger.SetLevel(hclog.Debug)
+	}
+}
 
 // New creates a new cobra.Command root for ComplyTime
 func New() *cobra.Command {
+
+	logger = log.NewLogger(os.Stdout)
+
 	cmd := &cobra.Command{
 		Use:           "complytime [command]",
 		SilenceErrors: true,

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -22,7 +22,7 @@ var (
 	FatalColor = lipgloss.AdaptiveColor{Light: "134", Dark: "134"}
 )
 
-func DefaultOptions() *charmlog.Options {
+func defaultOptions() *charmlog.Options {
 	return &charmlog.Options{
 		ReportCaller:    false,
 		ReportTimestamp: false,
@@ -63,9 +63,10 @@ func defaultStyles() *charmlog.Styles {
 	return styles
 }
 
-// Wrap the functionality of charm logger in go-hclog.
-func WrapLog(charmlog *charmlog.Logger) hclog.Logger {
-	l := &CharmHclog{charmlog}
+// NewLogger initializes a new wrapped logger with default styles
+func NewLogger(o io.Writer) hclog.Logger {
+	c := charmlog.NewWithOptions(o, *defaultOptions())
+	l := &CharmHclog{c}
 	l.logger.SetStyles(defaultStyles())
 	return l
 }
@@ -137,13 +138,11 @@ func (c *CharmHclog) With(args ...interface{}) hclog.Logger {
 // The GetPrefix() method will return the prefix of the logger.
 func (c *CharmHclog) Name() string { return c.logger.GetPrefix() }
 
-// The WithPrefix() method returns a logger with the prefix passed to Named().
 // The Named() method appends to the current logger prefix.
 func (c *CharmHclog) Named(name string) hclog.Logger {
 	return &CharmHclog{c.logger.WithPrefix(name)}
 }
 
-// The WithPrefix() method returns a logger with the prefix passed to ResetNamed().
 // The ResetNamed() method creates the logger with only the prefix passed.
 func (c *CharmHclog) ResetNamed(name string) hclog.Logger {
 	return &CharmHclog{c.logger.WithPrefix(name)}


### PR DESCRIPTION
## Summary
Adds new charm logger to CLI package for use throughout commands.

## Review Hints

- `root.go` creates a logger for use throughout the CLI package
- `enableDebug` will be used as a PreRun argument to the cobra commands
