### PR TITLE
chore: tiny fix for pre-commit check

### DIFF
--- a/scripts/quick_start/quick_start.sh
+++ b/scripts/quick_start/quick_start.sh
@@ -61,8 +61,8 @@ cp docs/samples/sample-component-definition.json ~/.config/complytime/bundles
 cp docs/samples/sample-profile.json ~/.config/complytime/controls
 
 # Copy the plugins' files
-cp -rp bin/openscap-plugin ~/.config/complytime/plugins 
-cp -rp cmd/openscap-plugin/openscap-plugin.yml ~/.config/complytime/plugins 
+cp -rp bin/openscap-plugin ~/.config/complytime/plugins
+cp -rp cmd/openscap-plugin/openscap-plugin.yml ~/.config/complytime/plugins
 checksum=$(sha256sum ~/.config/complytime/plugins/openscap-plugin| cut -d ' ' -f 1 )
 cat > ~/.config/complytime/plugins/c2p-openscap-manifest.json << EOF
 {


### PR DESCRIPTION
## Summary

To make pre-commit checks pass locally. It includes an empty line at the end of file.

## Related Issues

```
git commit -s
trim trailing whitespace.................................................Passed
fix end of files.........................................................Failed
- hook id: end-of-file-fixer
- exit code: 1
- files were modified by this hook

Fixing scripts/quick_start/quick_start.sh

check for added large files..............................................Passed
```

## Review Hints

Try to commit using pre-commit.