### PR TITLE
CPLYTM-550 - Clean-up openscap-plugin configuration file

### DIFF
--- a/cmd/openscap-plugin/config/config.go
+++ b/cmd/openscap-plugin/config/config.go
@@ -17,9 +17,6 @@ import (
 )
 
 type Config struct {
-	Server struct {
-		Socket string `yaml:"socket"`
-	} `yaml:"server"`
 	Files struct {
 		PluginDir  string `yaml:"plugindir"`
 		Workspace  string `yaml:"workspace"`

--- a/cmd/openscap-plugin/config/config.go
+++ b/cmd/openscap-plugin/config/config.go
@@ -16,9 +16,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const PluginDir = "openscap"
+
 type Config struct {
 	Files struct {
-		PluginDir  string `yaml:"plugindir"`
 		Workspace  string `yaml:"workspace"`
 		Datastream string `yaml:"datastream"`
 		Results    string `yaml:"results"`
@@ -117,9 +118,9 @@ func ensureWorkspace(cfg *Config) (map[string]string, error) {
 
 	directories := map[string]string{
 		"workspace":  workspace,
-		"pluginDir":  filepath.Join(workspace, cfg.Files.PluginDir),
-		"policyDir":  filepath.Join(workspace, cfg.Files.PluginDir, "policy"),
-		"resultsDir": filepath.Join(workspace, cfg.Files.PluginDir, "results"),
+		"pluginDir":  filepath.Join(workspace, PluginDir),
+		"policyDir":  filepath.Join(workspace, PluginDir, "policy"),
+		"resultsDir": filepath.Join(workspace, PluginDir, "results"),
 	}
 
 	for key, dir := range directories {
@@ -160,7 +161,6 @@ func ReadConfig(configFile string) (*Config, error) {
 
 	// String values to sanitize
 	inputValues := []*string{
-		&config.Files.PluginDir,
 		&config.Files.Policy,
 		&config.Files.Results,
 		&config.Files.ARF,

--- a/cmd/openscap-plugin/config/config_test.go
+++ b/cmd/openscap-plugin/config/config_test.go
@@ -181,14 +181,12 @@ func TestEnsureWorkspace(t *testing.T) {
 		{
 			cfg: Config{
 				Files: struct {
-					PluginDir  string "yaml:\"plugindir\""
 					Workspace  string "yaml:\"workspace\""
 					Datastream string "yaml:\"datastream\""
 					Results    string "yaml:\"results\""
 					ARF        string "yaml:\"arf\""
 					Policy     string "yaml:\"policy\""
 				}{
-					PluginDir: "plugins",
 					Workspace: filepath.Join(tempDir, "workspace"),
 					Policy:    "policy.yaml",
 					Results:   "results.xml",
@@ -200,14 +198,12 @@ func TestEnsureWorkspace(t *testing.T) {
 		{
 			cfg: Config{
 				Files: struct {
-					PluginDir  string "yaml:\"plugindir\""
 					Workspace  string "yaml:\"workspace\""
 					Datastream string "yaml:\"datastream\""
 					Results    string "yaml:\"results\""
 					ARF        string "yaml:\"arf\""
 					Policy     string "yaml:\"policy\""
 				}{
-					PluginDir: "plugins",
 					Workspace: filepath.Join(tempDir, "invalid\000workspace"),
 					Policy:    "policy.yaml",
 					Results:   "results.xml",
@@ -247,14 +243,12 @@ func TestDefineFilesPaths(t *testing.T) {
 		{
 			cfg: Config{
 				Files: struct {
-					PluginDir  string "yaml:\"plugindir\""
 					Workspace  string "yaml:\"workspace\""
 					Datastream string "yaml:\"datastream\""
 					Results    string "yaml:\"results\""
 					ARF        string "yaml:\"arf\""
 					Policy     string "yaml:\"policy\""
 				}{
-					PluginDir:  "plugins",
 					Workspace:  filepath.Join(tempDir, "workspace"),
 					Datastream: filepath.Join(tempDir, "datastream.xml"),
 					Results:    "results.xml",
@@ -275,9 +269,9 @@ func TestDefineFilesPaths(t *testing.T) {
 
 			if !tt.expectError {
 				// Check if the paths are correctly set
-				expectedPolicyPath := filepath.Join(tempDir, "workspace", "plugins", "policy", "policy.yaml")
-				expectedResultsPath := filepath.Join(tempDir, "workspace", "plugins", "results", "results.xml")
-				expectedARFPath := filepath.Join(tempDir, "workspace", "plugins", "results", "arf.xml")
+				expectedPolicyPath := filepath.Join(tempDir, "workspace", "openscap", "policy", "policy.yaml")
+				expectedResultsPath := filepath.Join(tempDir, "workspace", "openscap", "results", "results.xml")
+				expectedARFPath := filepath.Join(tempDir, "workspace", "openscap", "results", "arf.xml")
 
 				if tt.cfg.Files.Policy != expectedPolicyPath {
 					t.Errorf("Expected policy path: %s, got: %s", expectedPolicyPath, tt.cfg.Files.Policy)

--- a/cmd/openscap-plugin/openscap-plugin.yml
+++ b/cmd/openscap-plugin/openscap-plugin.yml
@@ -1,6 +1,3 @@
-server:
-  # For tests it is currently created in the homeDir
-  socket: server_socket.sock
 files:
   plugindir: openscap
   workspace: ~/.config/complytime

--- a/cmd/openscap-plugin/openscap-plugin.yml
+++ b/cmd/openscap-plugin/openscap-plugin.yml
@@ -1,5 +1,4 @@
 files:
-  plugindir: openscap
   workspace: ~/.config/complytime
   datastream: /usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml
   results: results.xml


### PR DESCRIPTION
## Summary

- `Server` struct was only used in a very initial stage. Now the plugin is managed by ComplyTime.
- Plugin directory doesn't need to be changed through a configuration file.
  - If there is any valid case for this in the future, we can introduce options on demand. For now, it is removed in favor of simplicity.

## Related Issues

- CPLYTM-550

## Review Hints

No impact is expected on how the plugin and commands behave, so unit tests should be enough.
