### PR TITLE
CPLYTM-561 - Adapt scan to use tailoring file

### DIFF
--- a/cmd/openscap-plugin/oscap/oscap.go
+++ b/cmd/openscap-plugin/oscap/oscap.go
@@ -5,11 +5,10 @@ package oscap
 import (
 	"fmt"
 	"log"
-	"os"
 	"os/exec"
 )
 
-func constructScanCommand(openscapFiles map[string]string, profile string) ([]string, error) {
+func constructScanCommand(openscapFiles map[string]string, profile string) []string {
 	datastream := openscapFiles["datastream"]
 	tailoringFile := openscapFiles["policy"]
 	resultsFile := openscapFiles["results"]
@@ -19,27 +18,18 @@ func constructScanCommand(openscapFiles map[string]string, profile string) ([]st
 		"oscap",
 		"xccdf",
 		"eval",
-		"--profile",
-		profile,
-		"--results",
-		resultsFile,
-		"--results-arf",
-		arfFile,
+		"--profile", profile,
+		"--results", resultsFile,
+		"--results-arf", arfFile,
+		"--tailoring-file", tailoringFile,
+		datastream,
 	}
 
-	if _, err := os.Stat(tailoringFile); err == nil {
-		cmd = append(cmd, "--tailoring-file", tailoringFile)
-	}
-
-	cmd = append(cmd, datastream)
-	return cmd, nil
+	return cmd
 }
 
 func OscapScan(openscapFiles map[string]string, profile string) ([]byte, error) {
-	command, err := constructScanCommand(openscapFiles, profile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to construct command %s: %w", command, err)
-	}
+	command := constructScanCommand(openscapFiles, profile)
 
 	cmdPath, err := exec.LookPath(command[0])
 	if err != nil {

--- a/cmd/openscap-plugin/oscap/oscap_test.go
+++ b/cmd/openscap-plugin/oscap/oscap_test.go
@@ -3,32 +3,22 @@
 package oscap
 
 import (
-	"os"
-	"path/filepath"
 	"reflect"
 	"testing"
 )
 
 func TestConstructScanCommand(t *testing.T) {
-	tailoringFilePath := filepath.Join(t.TempDir(), "test-policy.xml")
-	tailoringFile, err := os.Create(tailoringFilePath)
-	if err != nil {
-		t.Fatalf("Failed to create fake tailoring file: %v", err)
-	}
-	tailoringFile.Close()
-
 	tests := []struct {
 		name          string
 		openscapFiles map[string]string
 		profile       string
 		expectedCmd   []string
-		expectedErr   bool
 	}{
 		{
-			name: "Valid input with tailoring file",
+			name: "Scan command contruction",
 			openscapFiles: map[string]string{
 				"datastream": "test-datastream.xml",
-				"policy":     tailoringFilePath,
+				"policy":     "test-policy.xml",
 				"results":    "test-results.xml",
 				"arf":        "test-arf.xml",
 			},
@@ -44,43 +34,15 @@ func TestConstructScanCommand(t *testing.T) {
 				"--results-arf",
 				"test-arf.xml",
 				"--tailoring-file",
-				tailoringFilePath,
+				"test-policy.xml",
 				"test-datastream.xml",
 			},
-			expectedErr: false,
-		},
-		{
-			name: "Valid input without tailoring file",
-			openscapFiles: map[string]string{
-				"datastream": "test-datastream.xml",
-				"policy":     "",
-				"results":    "test-results.xml",
-				"arf":        "test-arf.xml",
-			},
-			profile: "test-profile",
-			expectedCmd: []string{
-				"oscap",
-				"xccdf",
-				"eval",
-				"--profile",
-				"test-profile",
-				"--results",
-				"test-results.xml",
-				"--results-arf",
-				"test-arf.xml",
-				"test-datastream.xml",
-			},
-			expectedErr: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd, err := constructScanCommand(tt.openscapFiles, tt.profile)
-			if (err != nil) != tt.expectedErr {
-				t.Errorf("constructScanCommand() error = %v, expectedErr %v", err, tt.expectedErr)
-				return
-			}
+			cmd := constructScanCommand(tt.openscapFiles, tt.profile)
 			if !reflect.DeepEqual(cmd, tt.expectedCmd) {
 				t.Errorf("constructScanCommand() = %v, expected %v", cmd, tt.expectedCmd)
 			}

--- a/cmd/openscap-plugin/scan/scan.go
+++ b/cmd/openscap-plugin/scan/scan.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/complytime/complytime/cmd/openscap-plugin/config"
 	"github.com/complytime/complytime/cmd/openscap-plugin/oscap"
+	"github.com/complytime/complytime/cmd/openscap-plugin/xccdf"
 )
 
 func isXMLFile(filePath string) (bool, error) {
@@ -57,7 +58,12 @@ func ScanSystem(cfg *config.Config, profile string) ([]byte, error) {
 		return nil, fmt.Errorf("invalid openscap files: %w", err)
 	}
 
-	output, err := oscap.OscapScan(openscapFiles, profile)
+	tailoringProfile := fmt.Sprintf("%s_%s", profile, xccdf.XCCDFTailoringSuffix)
+	// In the future, we can add an integrity check to confirm if the expected tailoring profile
+	// id exists in the tailoring file. It is not a common case but a guardrail to prevent manual
+	// manipulation of the tailoring file would be good.
+
+	output, err := oscap.OscapScan(openscapFiles, tailoringProfile)
 	if err != nil {
 		return output, fmt.Errorf("failed during scan: %w", err)
 	}

--- a/cmd/openscap-plugin/scan/scan_test.go
+++ b/cmd/openscap-plugin/scan/scan_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"testing"
+
+	"github.com/complytime/complytime/cmd/openscap-plugin/config"
 )
 
 func TestIsXMLFile(t *testing.T) {
@@ -70,5 +72,42 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-// validateOpenSCAPFiles and ScanSystem functions are not tested because they are high-level
-// functions using other functions already tested above or in other packages.
+// TestValidateOpenSCAPFiles tests the validateOpenSCAPFiles function when a policy file is present,
+// after the generate command, or absent before the generate command.
+// validateOpenSCAPFiles consumes other functions already tested so the only part to be tested here
+// is the policy file existence.
+func TestValidateOpenSCAPFiles(t *testing.T) {
+	cfg := new(config.Config)
+	cfg.Files.Datastream = "testdata/valid.xml"
+
+	tests := []struct {
+		name    string
+		cfgPol  string
+		wantErr bool
+	}{
+		{
+			name:    "present and valid policy file",
+			cfgPol:  "testdata/valid.xml",
+			wantErr: false,
+		},
+		{
+			name:    "absent policy file",
+			cfgPol:  "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg.Files.Policy = tt.cfgPol
+			_, err := validateOpenSCAPFiles(cfg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateOpenSCAPFiles() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+// ScanSystem function is not tested because it is high-level functions using other functions
+// already tested above or in other packages.

--- a/cmd/openscap-plugin/xccdf/tailoring.go
+++ b/cmd/openscap-plugin/xccdf/tailoring.go
@@ -15,6 +15,7 @@ import (
 )
 
 const (
+	XCCDFCaCNamespace    string = "xccdf_org.ssgproject.content"
 	XCCDFNamespace       string = "complytime.openscapplugin"
 	XCCDFTailoringSuffix string = "complytime"
 )
@@ -29,7 +30,7 @@ func getTailoringID() string {
 
 func getTailoringExtendedProfileID(profileId string) string {
 	return fmt.Sprintf(
-		"xccdf_%s_profile_%s", XCCDFNamespace, profileId)
+		"%s_profile_%s", XCCDFCaCNamespace, profileId)
 }
 
 func getTailoringProfileID(profileId string) string {

--- a/cmd/openscap-plugin/xccdf/tailoring.go
+++ b/cmd/openscap-plugin/xccdf/tailoring.go
@@ -27,6 +27,11 @@ func getTailoringID() string {
 	return fmt.Sprintf("xccdf_%s_tailoring_%s", XCCDFNamespace, XCCDFTailoringSuffix)
 }
 
+func getTailoringExtendedProfileID(profileId string) string {
+	return fmt.Sprintf(
+		"xccdf_%s_profile_%s", XCCDFNamespace, profileId)
+}
+
 func getTailoringProfileID(profileId string) string {
 	return fmt.Sprintf(
 		"xccdf_%s_profile_%s_%s", XCCDFNamespace, profileId, XCCDFTailoringSuffix)
@@ -193,6 +198,8 @@ func getTailoringProfile(profileId string, dsPath string, oscalPolicy policy.Pol
 	if err != nil {
 		return tailoringProfile, fmt.Errorf("failed to get base profile from datastream: %w", err)
 	}
+
+	tailoringProfile.Extends = getTailoringExtendedProfileID(profileId)
 
 	tailoringProfile.Title = &xccdf.TitleOrDescriptionElement{
 		Override: true,

--- a/cmd/openscap-plugin/xccdf/tailoring_test.go
+++ b/cmd/openscap-plugin/xccdf/tailoring_test.go
@@ -676,7 +676,7 @@ func TestPolicyToXML(t *testing.T) {
 <xccdf-1.2:Tailoring xmlns:xccdf-1.2="http://checklists.nist.gov/xccdf/1.2" id="xccdf_complytime.openscapplugin_tailoring_complytime">
   <xccdf-1.2:benchmark href="` + dsPath + `"></xccdf-1.2:benchmark>
   <xccdf-1.2:version time="` + getTailoringVersion().Time + `">1</xccdf-1.2:version>
-  <xccdf-1.2:Profile id="xccdf_complytime.openscapplugin_profile_test_profile_complytime">
+  <xccdf-1.2:Profile id="xccdf_complytime.openscapplugin_profile_test_profile_complytime" extends="xccdf_complytime.openscapplugin_profile_test_profile">
     <xccdf-1.2:title override="true">ComplyTime Tailoring Profile - Test Profile</xccdf-1.2:title>
     <xccdf-1.2:select idref="xccdf_org.ssgproject.content_rule_package_telnet-server_removed" selected="false"></xccdf-1.2:select>
     <xccdf-1.2:select idref="xccdf_org.ssgproject.content_rule_package_telnet_removed" selected="false"></xccdf-1.2:select>

--- a/cmd/openscap-plugin/xccdf/tailoring_test.go
+++ b/cmd/openscap-plugin/xccdf/tailoring_test.go
@@ -676,7 +676,7 @@ func TestPolicyToXML(t *testing.T) {
 <xccdf-1.2:Tailoring xmlns:xccdf-1.2="http://checklists.nist.gov/xccdf/1.2" id="xccdf_complytime.openscapplugin_tailoring_complytime">
   <xccdf-1.2:benchmark href="` + dsPath + `"></xccdf-1.2:benchmark>
   <xccdf-1.2:version time="` + getTailoringVersion().Time + `">1</xccdf-1.2:version>
-  <xccdf-1.2:Profile id="xccdf_complytime.openscapplugin_profile_test_profile_complytime" extends="xccdf_complytime.openscapplugin_profile_test_profile">
+  <xccdf-1.2:Profile id="xccdf_complytime.openscapplugin_profile_test_profile_complytime" extends="xccdf_org.ssgproject.content_profile_test_profile">
     <xccdf-1.2:title override="true">ComplyTime Tailoring Profile - Test Profile</xccdf-1.2:title>
     <xccdf-1.2:select idref="xccdf_org.ssgproject.content_rule_package_telnet-server_removed" selected="false"></xccdf-1.2:select>
     <xccdf-1.2:select idref="xccdf_org.ssgproject.content_rule_package_telnet_removed" selected="false"></xccdf-1.2:select>


### PR DESCRIPTION
## Summary

With the introduction of `plan` and `generate` commands as well the availability of real content transformed from CaC to OSCAL, the `openscap-plugin` can now generate a realistic tailoring file to be used by the `scan` command.
This PR ensures all these commands work together providing the expected outcome.

## Related Issues

- CPLYTM-561

## Review Hints

The changes were introduced gradually through the commits where each commit describes the context of each change, so it should be easier to review commit by commit.

Unit tests were also adapted to the changes and `make test-unit` should be green.