### PR TITLE
chore: use plugin dir constant in tests

### DIFF
--- a/cmd/openscap-plugin/config/config_test.go
+++ b/cmd/openscap-plugin/config/config_test.go
@@ -269,9 +269,9 @@ func TestDefineFilesPaths(t *testing.T) {
 
 			if !tt.expectError {
 				// Check if the paths are correctly set
-				expectedPolicyPath := filepath.Join(tempDir, "workspace", "openscap", "policy", "policy.yaml")
-				expectedResultsPath := filepath.Join(tempDir, "workspace", "openscap", "results", "results.xml")
-				expectedARFPath := filepath.Join(tempDir, "workspace", "openscap", "results", "arf.xml")
+				expectedPolicyPath := filepath.Join(tempDir, "workspace", PluginDir, "policy", "policy.yaml")
+				expectedResultsPath := filepath.Join(tempDir, "workspace", PluginDir, "results", "results.xml")
+				expectedARFPath := filepath.Join(tempDir, "workspace", PluginDir, "results", "arf.xml")
 
 				if tt.cfg.Files.Policy != expectedPolicyPath {
 					t.Errorf("Expected policy path: %s, got: %s", expectedPolicyPath, tt.cfg.Files.Policy)


### PR DESCRIPTION
## Summary

This improvement was caught by @gvauter in #52 . Thanks

## Related Issues

- There is no related issue, it is a minor improvement.

## Review Hints

```
make unit-test
```