### PR TITLE
CPLYTM-640: feat(cli): adds plain printing option for complytime list

### DIFF
--- a/internal/terminal/table_test.go
+++ b/internal/terminal/table_test.go
@@ -3,6 +3,7 @@
 package terminal
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,11 +14,12 @@ import (
 func TestShowDefinitionTable(t *testing.T) {
 	tests := []struct {
 		name       string
+		pretty     bool
 		frameworks []complytime.Framework
 		wantView   string
 	}{
 		{
-			name: "Valid/HappyPath",
+			name: "Valid/PlainMode",
 			frameworks: []complytime.Framework{
 				{
 					ID:                  "anotherexample",
@@ -30,15 +32,33 @@ func TestShowDefinitionTable(t *testing.T) {
 					SupportedComponents: []string{"My Software"},
 				},
 			},
+			wantView: plainTable,
+		},
+		{
+			name: "Valid/PrettyMode",
+			frameworks: []complytime.Framework{
+				{
+					ID:                  "anotherexample",
+					Title:               "Example Profile (moderate)",
+					SupportedComponents: []string{"My Software"},
+				},
+				{
+					ID:                  "example",
+					Title:               "Example Profile (low)",
+					SupportedComponents: []string{"My Software"},
+				},
+			},
+			pretty:   true,
 			wantView: populatedTable,
 		},
 		{
-			name:       "Valid/Empty",
+			name:       "Valid/EmptyPrettyMode",
 			frameworks: []complytime.Framework{},
+			pretty:     true,
 			wantView:   emptyTable,
 		},
 		{
-			name: "Valid/LongTitle",
+			name: "Valid/LongTitlePrettyMode",
 			frameworks: []complytime.Framework{
 				{
 					ID:                  "anotherexample",
@@ -46,57 +66,68 @@ func TestShowDefinitionTable(t *testing.T) {
 					SupportedComponents: []string{"My Software"},
 				},
 			},
+			pretty:   true,
 			wantView: longTitle,
 		},
 	}
 
 	for _, c := range tests {
 		t.Run(c.name, func(t *testing.T) {
-			initialModel := ShowDefinitionTable(c.frameworks)
-			gotView := initialModel.View()
+			var gotView string
+			if !c.pretty {
+				out := bytes.NewBuffer(nil)
+				ShowDefinitionTable(out, c.frameworks)
+				gotView = out.String()
+			} else {
+				initialModel := ShowPrettyDefinitionTable(c.frameworks)
+				gotView = initialModel.View()
+			}
 			require.Equal(t, c.wantView, gotView)
 		})
 	}
 }
 
 var (
-	emptyTable = `┌──────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│ Title                           Framework ID          Supported Components                               │
-│──────────────────────────────────────────────────────────────────────────────────────────────────────────│
-│                                                                                                          │
-│                                                                                                          │
-│                                                                                                          │
-│                                                                                                          │
-│                                                                                                          │
-│                                                                                                          │
-└──────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+	emptyTable = `┌──────────────────────────────────────────────────────────────────────────────────────┐
+│ Title                           Framework ID          Supported Components           │
+│──────────────────────────────────────────────────────────────────────────────────────│
+│                                                                                      │
+│                                                                                      │
+│                                                                                      │
+│                                                                                      │
+│                                                                                      │
+│                                                                                      │
+└──────────────────────────────────────────────────────────────────────────────────────┘
 
 Choose an option from the Framework ID column to use with complytime plan.
 `
-	populatedTable = `┌──────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│ Title                           Framework ID          Supported Components                               │
-│──────────────────────────────────────────────────────────────────────────────────────────────────────────│
-│ Example Profile (moderate)      anotherexample        My Software                                        │
-│ Example Profile (low)           example               My Software                                        │
-│                                                                                                          │
-│                                                                                                          │
-│                                                                                                          │
-│                                                                                                          │
-└──────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+	populatedTable = `┌──────────────────────────────────────────────────────────────────────────────────────┐
+│ Title                           Framework ID          Supported Components           │
+│──────────────────────────────────────────────────────────────────────────────────────│
+│ Example Profile (moderate)      anotherexample        My Software                    │
+│ Example Profile (low)           example               My Software                    │
+│                                                                                      │
+│                                                                                      │
+│                                                                                      │
+│                                                                                      │
+└──────────────────────────────────────────────────────────────────────────────────────┘
 
 Choose an option from the Framework ID column to use with complytime plan.
 `
-	longTitle = `┌──────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│ Title                           Framework ID          Supported Components                               │
-│──────────────────────────────────────────────────────────────────────────────────────────────────────────│
-│ This is a very very very long…  anotherexample        My Software                                        │
-│                                                                                                          │
-│                                                                                                          │
-│                                                                                                          │
-│                                                                                                          │
-│                                                                                                          │
-└──────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+	longTitle = `┌──────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│ Title                                           Framework ID          Supported Components           │
+│──────────────────────────────────────────────────────────────────────────────────────────────────────│
+│ This is a very very very long title (moderate)  anotherexample        My Software                    │
+│                                                                                                      │
+│                                                                                                      │
+│                                                                                                      │
+│                                                                                                      │
+│                                                                                                      │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────┘
 
 Choose an option from the Framework ID column to use with complytime plan.
 `
+	plainTable = "Title                         Framework ID        Supported Components          \n" +
+		"Example Profile (moderate)    anotherexample      My Software                   \n" +
+		"Example Profile (low)         example             My Software                   \n"
 )


### PR DESCRIPTION
## Summary
Adds plain table printing to `complytime list` more easily support automation/scripting use cases (use with `grep/awk`)

## Related Issues


## Review Hints

Test with `complytime list --plain`
