### PR TITLE
feat: CPLYTM-509 default terminal output for commands

### DIFF
--- a/cmd/complytime/cli/generate.go
+++ b/cmd/complytime/cli/generate.go
@@ -61,6 +61,7 @@ func runGenerate(cmd *cobra.Command, opts *generateOptions, logger hclog.Logger)
 	if err != nil {
 		return err
 	}
+	logger.Debug("The configuration from the C2PConfig was successfully loaded.")
 	manager, err := framework.NewPluginManager(cfg)
 	if err != nil {
 		return fmt.Errorf("error initializing plugin manager: %w", err)
@@ -77,6 +78,6 @@ func runGenerate(cmd *cobra.Command, opts *generateOptions, logger hclog.Logger)
 	if err != nil {
 		return err
 	}
-	_, _ = fmt.Fprintf(opts.Out, "Policy generation completed successfully.")
+	logger.Info("Policy generation completed successfully.")
 	return nil
 }

--- a/cmd/complytime/cli/list.go
+++ b/cmd/complytime/cli/list.go
@@ -38,7 +38,7 @@ func runList(opts *option.Common, logger hclog.Logger) error {
 	if err != nil {
 		return err
 	}
-	logger.Debug(fmt.Sprintf("using application directory: %s", appDir.AppDir()))
+	logger.Debug(fmt.Sprintf("Using application directory: %s", appDir.AppDir()))
 
 	frameworks, err := complytime.LoadFrameworks(appDir)
 	if err != nil {

--- a/cmd/complytime/cli/plan.go
+++ b/cmd/complytime/cli/plan.go
@@ -70,6 +70,7 @@ func runPlan(cmd *cobra.Command, opts *planOptions, logger hclog.Logger) error {
 	if err != nil {
 		return err
 	}
+	logger.Debug(fmt.Sprintf("Using bundle directory: %s for component definitions.", appDir.BundleDir()))
 	assessmentPlan, err := transformers.ComponentDefinitionsToAssessmentPlan(cmd.Context(), componentDefs, opts.frameworkID)
 	if err != nil {
 		return err
@@ -81,7 +82,7 @@ func runPlan(cmd *cobra.Command, opts *planOptions, logger hclog.Logger) error {
 	if err := complytime.WritePlan(assessmentPlan, opts.frameworkID, cleanedPath); err != nil {
 		return fmt.Errorf("error writing assessment plan to %s: %w", cleanedPath, err)
 	}
-	fmt.Printf("Assessment plan written to %s\n", cleanedPath)
+	logger.Info(fmt.Sprintf("Assessment plan written to %s\n", cleanedPath))
 	return nil
 }
 

--- a/cmd/complytime/cli/scan.go
+++ b/cmd/complytime/cli/scan.go
@@ -131,11 +131,12 @@ func runScan(cmd *cobra.Command, opts *scanOptions, logger hclog.Logger) error {
 	filePath := filepath.Join(opts.complyTimeOpts.UserWorkspace, assessmentResultsLocation)
 	cleanedPath := filepath.Clean(filePath)
 
+
 	err = complytime.WriteAssessmentResults(&assessmentResults, cleanedPath)
 	if err != nil {
 		return err
 	}
-
+	logger.Info(fmt.Sprintf("The assessment results were successfully written to %v.", assessmentResultsLocation))
 	return nil
 }
 

--- a/cmd/complytime/cli/scan.go
+++ b/cmd/complytime/cli/scan.go
@@ -60,7 +60,6 @@ func runScan(cmd *cobra.Command, opts *scanOptions, logger hclog.Logger) error {
 	if err != nil {
 		return err
 	}
-
 	// Create the application directory if it does not exist
 	appDir, err := complytime.NewApplicationDirectory(true)
 	if err != nil {
@@ -80,7 +79,10 @@ func runScan(cmd *cobra.Command, opts *scanOptions, logger hclog.Logger) error {
 	if err != nil {
 		return err
 	}
-
+	for _, plugin := range plugins {
+		logger.Debug(fmt.Sprintf("Successfully loaded %v plugin.", plugin))
+	}
+	logger.Info("Information successfully retrieved from plugins.")
 	// Ensure all the plugins launch above are cleaned up
 	defer manager.Clean()
 
@@ -100,7 +102,7 @@ func runScan(cmd *cobra.Command, opts *scanOptions, logger hclog.Logger) error {
 	if !valid {
 		return fmt.Errorf("error reading framework property from assessment plan")
 	}
-
+	logger.Debug(fmt.Sprintf("Framework property was successfully read from the assessment plan: %v.", frameworkProp))
 	r, err := framework.NewReporter(cfg)
 	if err != nil {
 		return err
@@ -130,7 +132,6 @@ func runScan(cmd *cobra.Command, opts *scanOptions, logger hclog.Logger) error {
 
 	filePath := filepath.Join(opts.complyTimeOpts.UserWorkspace, assessmentResultsLocation)
 	cleanedPath := filepath.Clean(filePath)
-
 
 	err = complytime.WriteAssessmentResults(&assessmentResults, cleanedPath)
 	if err != nil {

--- a/cmd/openscap-plugin/config/config.go
+++ b/cmd/openscap-plugin/config/config.go
@@ -16,12 +16,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const PluginDir = "openscap"
+
 type Config struct {
-	Server struct {
-		Socket string `yaml:"socket"`
-	} `yaml:"server"`
 	Files struct {
-		PluginDir  string `yaml:"plugindir"`
 		Workspace  string `yaml:"workspace"`
 		Datastream string `yaml:"datastream"`
 		Results    string `yaml:"results"`
@@ -120,9 +118,9 @@ func ensureWorkspace(cfg *Config) (map[string]string, error) {
 
 	directories := map[string]string{
 		"workspace":  workspace,
-		"pluginDir":  filepath.Join(workspace, cfg.Files.PluginDir),
-		"policyDir":  filepath.Join(workspace, cfg.Files.PluginDir, "policy"),
-		"resultsDir": filepath.Join(workspace, cfg.Files.PluginDir, "results"),
+		"pluginDir":  filepath.Join(workspace, PluginDir),
+		"policyDir":  filepath.Join(workspace, PluginDir, "policy"),
+		"resultsDir": filepath.Join(workspace, PluginDir, "results"),
 	}
 
 	for key, dir := range directories {
@@ -163,7 +161,6 @@ func ReadConfig(configFile string) (*Config, error) {
 
 	// String values to sanitize
 	inputValues := []*string{
-		&config.Files.PluginDir,
 		&config.Files.Policy,
 		&config.Files.Results,
 		&config.Files.ARF,

--- a/cmd/openscap-plugin/config/config_test.go
+++ b/cmd/openscap-plugin/config/config_test.go
@@ -181,14 +181,12 @@ func TestEnsureWorkspace(t *testing.T) {
 		{
 			cfg: Config{
 				Files: struct {
-					PluginDir  string "yaml:\"plugindir\""
 					Workspace  string "yaml:\"workspace\""
 					Datastream string "yaml:\"datastream\""
 					Results    string "yaml:\"results\""
 					ARF        string "yaml:\"arf\""
 					Policy     string "yaml:\"policy\""
 				}{
-					PluginDir: "plugins",
 					Workspace: filepath.Join(tempDir, "workspace"),
 					Policy:    "policy.yaml",
 					Results:   "results.xml",
@@ -200,14 +198,12 @@ func TestEnsureWorkspace(t *testing.T) {
 		{
 			cfg: Config{
 				Files: struct {
-					PluginDir  string "yaml:\"plugindir\""
 					Workspace  string "yaml:\"workspace\""
 					Datastream string "yaml:\"datastream\""
 					Results    string "yaml:\"results\""
 					ARF        string "yaml:\"arf\""
 					Policy     string "yaml:\"policy\""
 				}{
-					PluginDir: "plugins",
 					Workspace: filepath.Join(tempDir, "invalid\000workspace"),
 					Policy:    "policy.yaml",
 					Results:   "results.xml",
@@ -247,14 +243,12 @@ func TestDefineFilesPaths(t *testing.T) {
 		{
 			cfg: Config{
 				Files: struct {
-					PluginDir  string "yaml:\"plugindir\""
 					Workspace  string "yaml:\"workspace\""
 					Datastream string "yaml:\"datastream\""
 					Results    string "yaml:\"results\""
 					ARF        string "yaml:\"arf\""
 					Policy     string "yaml:\"policy\""
 				}{
-					PluginDir:  "plugins",
 					Workspace:  filepath.Join(tempDir, "workspace"),
 					Datastream: filepath.Join(tempDir, "datastream.xml"),
 					Results:    "results.xml",
@@ -275,9 +269,9 @@ func TestDefineFilesPaths(t *testing.T) {
 
 			if !tt.expectError {
 				// Check if the paths are correctly set
-				expectedPolicyPath := filepath.Join(tempDir, "workspace", "plugins", "policy", "policy.yaml")
-				expectedResultsPath := filepath.Join(tempDir, "workspace", "plugins", "results", "results.xml")
-				expectedARFPath := filepath.Join(tempDir, "workspace", "plugins", "results", "arf.xml")
+				expectedPolicyPath := filepath.Join(tempDir, "workspace", "openscap", "policy", "policy.yaml")
+				expectedResultsPath := filepath.Join(tempDir, "workspace", "openscap", "results", "results.xml")
+				expectedARFPath := filepath.Join(tempDir, "workspace", "openscap", "results", "arf.xml")
 
 				if tt.cfg.Files.Policy != expectedPolicyPath {
 					t.Errorf("Expected policy path: %s, got: %s", expectedPolicyPath, tt.cfg.Files.Policy)

--- a/cmd/openscap-plugin/openscap-plugin.yml
+++ b/cmd/openscap-plugin/openscap-plugin.yml
@@ -1,8 +1,4 @@
-server:
-  # For tests it is currently created in the homeDir
-  socket: server_socket.sock
 files:
-  plugindir: openscap
   workspace: ~/.config/complytime
   datastream: /usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml
   results: results.xml

--- a/cmd/openscap-plugin/xccdf/tailoring.go
+++ b/cmd/openscap-plugin/xccdf/tailoring.go
@@ -121,7 +121,7 @@ func getTailoringSelections(oscalPolicy policy.Policy, dsProfile *xccdf.ProfileE
 	// All OSCAL Policy rules should be present in the Datastream
 	for _, rule := range oscalPolicy {
 		if !validateRuleExistence(rule.Rule.ID, dsRules) {
-			return nil, fmt.Errorf("rule not found in datastream: %s", rule.Rule.ID)
+			return nil, fmt.Errorf("rule %s not found in datastream: %s", rule.Rule.ID, dsPath)
 		}
 	}
 
@@ -170,7 +170,7 @@ func getTailoringValues(oscalPolicy policy.Policy, dsProfile *xccdf.ProfileEleme
 			continue
 		}
 		if !validateVariableExistence(rule.Rule.Parameter.ID, dsVariables) {
-			return nil, fmt.Errorf("variable not found in datastream: %s", rule.Rule.Parameter.ID)
+			return nil, fmt.Errorf("variable %s not found in datastream: %s", rule.Rule.Parameter.ID, dsPath)
 		}
 	}
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -2,7 +2,7 @@
 
 To get started with the `complytime` CLI, at least one plugin must be installed with a corresponding OSCAL [Component Definition](https://pages.nist.gov/OSCAL/resources/concepts/layer/implementation/component-definition/).
 
-> Note: Some of these steps are manual and will become more automated as the project gets further in development.
+> Note: Some of these steps are manual. The [quick_start.sh](../scripts/quick_start/quick_start.sh) automates the process below.
 
 ## Step 1: Install ComplyTime
 
@@ -33,17 +33,18 @@ cp docs/samples/sample-profile.json ~/.config/complytime/controls
 Each plugin requires a plugin manifest. For more information about plugin discovery see [PLUGIN_GUIDE.md](PLUGIN_GUIDE.md).
 
 ```bash
-cp myplugin ~/.config/complytime/plugins
-checksum=$(sha256sum ~/.config/complytime/plugins/myplugin | cut -d ' ' -f 1 )
-cat > ~/.config/complytime/plugins/c2p-myplugin-manifest.json << EOF
+cp bin/openscap-plugin ~/.config/complytime/plugins
+cp cmd/openscap-plugin/openscap-plugin.yml ~/.config/complytime/plugins
+checksum=$(sha256sum ~/.config/complytime/plugins/openscap-plugin| cut -d ' ' -f 1 )
+cat > ~/.config/complytime/plugins/c2p-openscap-manifest.json << EOF
 {
   "metadata": {
-    "id": "myplugin",
-    "description": "My complytime plugin",
+    "id": "openscap",
+    "description": "My openscap plugin",
     "version": "0.0.1",
     "types": ["pvp"]
   },
-  "executablePath": "myplugin",
+  "executablePath": "openscap-plugin",
   "sha256": "$checksum"
 }
 EOF

--- a/docs/samples/sample-component-definition.json
+++ b/docs/samples/sample-component-definition.json
@@ -17,32 +17,26 @@
           {
             "name": "Rule_Id",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
-            "value": "rule-1",
+            "value": "set_password_hashing_algorithm_logindefs",
             "remarks": "rule_set_00"
           },
           {
             "name": "Rule_Description",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
-            "value": "My first rule",
+            "value": "This rule ensures that the password hashing algorithm is set in login.defs",
             "remarks": "rule_set_00"
           },
           {
-            "name": "Parameter_Id",
+            "name": "Rule_Id",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
-            "value": "param-1",
-            "remarks": "rule_set_00"
+            "value": "package_telnet-server_removed",
+            "remarks": "rule_set_01"
           },
           {
-            "name": "Parameter_Description",
+            "name": "Rule_Description",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
-            "value": "A parameter for a file name",
-            "remarks": "rule_set_00"
-          },
-          {
-            "name": "Parameter_Vault_Default",
-            "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
-            "value": "value-1",
-            "remarks": "rule_set_00"
+            "value": "This rule ensures that telnet-server package is removed",
+            "remarks": "rule_set_01"
           }
         ],
         "control-implementations": [
@@ -56,25 +50,22 @@
                 "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
                 "value": "example"
               }
-          ],
-            "set-parameters": [
-              {
-                "param-id": "param-1",
-                "values": [
-                  "value-2"
-                ]
-              }
             ],
             "implemented-requirements": [
               {
                 "uuid": "ed2ac4e9-d16a-4fc5-bd3a-13484b6d8fef",
-                "control-id": "example-1",
+                "control-id": "most_important_requirement",
                 "description": "My example implemented requirement.",
                 "props": [
                   {
                     "name": "Rule_Id",
                     "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
-                    "value": "rule-1"
+                    "value": "set_password_hashing_algorithm_logindefs"
+                  },
+                  {
+                    "name": "Rule_Id",
+                    "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
+                    "value": "package_telnet-server_removed"
                   }
                 ]
               }
@@ -85,31 +76,31 @@
       {
         "uuid": "b1c7a388-e8d4-4ff0-a249-0bb6686764cf",
         "type": "validation",
-        "title": "myplugin",
-        "description": "An example validation component for myplugin",
+        "title": "openscap",
+        "description": "An example validation component for openscap-plugin",
         "props": [
           {
             "name": "Rule_Id",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
-            "value": "rule-1",
+            "value": "package_telnet-server_removed",
             "remarks": "rule_set_00"
           },
           {
             "name": "Rule_Description",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
-            "value": "MY first rule",
-            "remarks": "rule_set_08"
+            "value": "This rule ensures that telnet-server package is removed",
+            "remarks": "rule_set_00"
           },
           {
             "name": "Check_Id",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
-            "value": "check-1",
+            "value": "package_telnet-server_removed",
             "remarks": "rule_set_00"
           },
           {
             "name": "Check_Description",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
-            "value": "My first check",
+            "value": "For OpenSCAP, the rule and the check share the same ID",
             "remarks": "rule_set_00"
           }
         ]

--- a/docs/samples/sample-profile.json
+++ b/docs/samples/sample-profile.json
@@ -13,7 +13,7 @@
         "include-controls": [
           {
             "with-ids": [
-              "example-1"
+              "most_important_requirement"
             ]
           }
         ]

--- a/scripts/quick_start/Containerfile
+++ b/scripts/quick_start/Containerfile
@@ -1,0 +1,8 @@
+FROM registry.access.redhat.com/ubi9/ubi:9.5
+ARG RHEL_APPS_REPO
+COPY quick_start.sh /quick_start.sh
+ENV RHEL_APPS_REPO=${RHEL_APPS_REPO}
+RUN chmod +x /quick_start.sh && /quick_start.sh && rm -rf /var/cache/dnf
+
+# Optionally, set the container to continue running after execution
+CMD ["bash"]

--- a/scripts/quick_start/README.md
+++ b/scripts/quick_start/README.md
@@ -1,0 +1,52 @@
+# Automate Quick Start Guide for ComplyTime CLI
+
+This quick start guide aims to set up the minimum environment to explore the ComplyTime CLI.
+If you intend to run the ComplyTime CLI on a real target system, the content will need to be updated.
+Below are two options to quickly start using the ComplyTime CLI.
+
+## Option 1: Run the quick_start.sh in ubi9 container
+Assumed that you have installed [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) and [Podman](https://podman.io/docs/installation). If your system is Fedora, CentOS or RHEL you could install them directly:
+
+```bash
+dnf install git podman -y
+```
+
+1. Pull the ComplyTime Git repository to your local system:
+
+```bash
+git clone https://github.com/complytime/complytime.git
+cd complytime/scripts/quick_start
+```
+
+2. Set the RHEL_APPS_REPO variable to the app DNF repository URL:
+
+```bash
+export RHEL_APPS_REPO=${RHEL_APPS_REPO} # Change the ${RHEL_APPS_REPO} to the app dnf repo
+```
+
+3. Build the container image:
+
+```bash
+podman build --build-arg RHEL_APPS_REPO=${RHEL_APPS_REPO} . -t quick-start:latest
+podman run -it quick-start:latest /bin/bash
+```
+
+## Option 2: Run the quick_start.sh in a fresh RHEL
+Assume that you have already installed a fresh RHEL
+1. Download or copy the [quick_start.sh](quick_start.sh) script in your fresh RHEL system.
+
+2. Run the script on your fresh RHEL system:
+
+```bash
+chmod +x quick_start.sh
+export RHEL_APPS_REPO=$RHEL_APPS_REPO # Change the ${RHEL_APPS_REPO} to the app dnf repo
+sh quick_start.sh
+```
+
+Now you could explore Complytime CLIs:
+```bash
+complytime list
+complytime plan example
+complytime generate
+complytime scan
+```

--- a/scripts/quick_start/quick_start.sh
+++ b/scripts/quick_start/quick_start.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# How to run the script
+# Assume that you have already installed a fresh RHEL
+# 1. Download/copy this script in your RHEL system
+# 2. Run the script
+# chmod +x quick_start.sh
+# export RHEL_APPS_REPO=$RHEL_APPS_REPO
+# sh quick_start.sh
+
+set +e
+# Check if the scap-security-guide package is available in the enabled repositories
+dnf provides scap-security-guide
+
+# Check the exit status of the previous command
+if [ $? -ne 0 ]; then
+    echo "No working repository is available to install scap-security-guide."
+
+    # Check if RHEL_APPS_REPO variable is set
+    if [ -z "$RHEL_APPS_REPO" ]; then
+        echo "Error: RHEL_APPS_REPO is not set. Please set the variable and try again."
+        exit 1
+    else
+        echo "Setting up CaC Apps repository..."
+        cat > /etc/yum.repos.d/cac.repo <<EOF
+[cac_apps_repo]
+name=CaC Apps Repo
+baseurl=${RHEL_APPS_REPO}
+enabled=1
+gpgcheck=0
+EOF
+        echo "CaC Apps repository has been added."
+    fi
+fi
+
+echo "Installing dependencies..."
+dnf update -y
+dnf install git wget make scap-security-guide -y
+rm -rf /usr/bin/go
+go_mod="https://raw.githubusercontent.com/complytime/complytime/main/go.mod"
+go_version=$(curl -s $go_mod | grep '^go' | awk '{print $2}')
+go_tar_file=go$go_version.linux-amd64.tar.gz
+wget https://go.dev/dl/$go_tar_file
+tar -C /usr/local -xvzf $go_tar_file
+rm -rf $go_tar_file
+export PATH=$PATH:/usr/local/go/bin
+source ~/.bash_profile
+
+# Install and build complytime
+echo "Cloning the Complytime repository..."
+git clone https://github.com/complytime/complytime.git
+cd complytime && make build && cp ./bin/complytime /usr/local/bin
+echo "Complytime installed successfully!"
+# Run complytime list to create the workspace
+set +e
+# Running list command that will fail due to no requirements files
+echo "Attempting to run the command complytime list."
+bin/complytime list 2>/dev/null
+echo "An error occurred, but script continues after the complytime list."
+# Copy the artifacts to workspace
+cp docs/samples/sample-component-definition.json ~/.config/complytime/bundles
+cp docs/samples/sample-profile.json ~/.config/complytime/controls
+
+# Copy the plugins' files
+cp -rp bin/openscap-plugin ~/.config/complytime/plugins
+cp -rp cmd/openscap-plugin/openscap-plugin.yml ~/.config/complytime/plugins
+checksum=$(sha256sum ~/.config/complytime/plugins/openscap-plugin| cut -d ' ' -f 1 )
+cat > ~/.config/complytime/plugins/c2p-openscap-manifest.json << EOF
+{
+  "metadata": {
+    "id": "openscap",
+    "description": "My openscap plugin",
+    "version": "0.0.1",
+    "types": ["pvp"]
+  },
+  "executablePath": "openscap-plugin",
+  "sha256": "$checksum"
+}
+EOF


### PR DESCRIPTION
## Summary

This PR addresses the need for terminal output that allows users to follow plugin execution and completion. The `charmbracelet/log` package is coupled with the `charmbracelet/liplgoss` package for upgrading user-friendliness and awareness during interaction with the ComplyTime CLI. 

The complytime commands are updated with the default terminal output for plugin execution and completion. 

**Commands updated with default terminal output:** 

- `complytime scan`
- `complytime plan`
- `complytime generate` 

## Related Issues
- Depends on PR #59 

## Review Hints

- _Review hints here. Replace this text. Don't use the italics format!_

- _Use this optional section to give any relevant information that could help the reviewer to more quickly and assertively understand and test the changes._

- _Good examples are useful commands, if it is better to review all commits together or in a suggested sequence, any relevant discussion in other PRs or issues, etc._
