### PR TITLE
feat: CPLYTM-511 adding terminal printing logic to commands

### DIFF
--- a/cmd/complytime/cli/generate.go
+++ b/cmd/complytime/cli/generate.go
@@ -4,8 +4,8 @@ package cli
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-hclog"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/oscal-compass/compliance-to-policy-go/v2/framework"
 	"github.com/spf13/cobra"
 

--- a/cmd/complytime/cli/plan.go
+++ b/cmd/complytime/cli/plan.go
@@ -52,7 +52,6 @@ func planCmd(common *option.Common, logger hclog.Logger) *cobra.Command {
 			if err := runPlan(cmd, planOpts, logger); err != nil {
 				logger.Error(err.Error())
 			}
-			logger.Info("The plan command is running.", "command", cmd.CommandPath())
 			return nil
 		},
 	}

--- a/cmd/complytime/cli/plan.go
+++ b/cmd/complytime/cli/plan.go
@@ -5,9 +5,10 @@ package cli
 import (
 	"errors"
 	"fmt"
-	"github.com/hashicorp/go-hclog"
 	"os"
 	"path/filepath"
+
+	"github.com/hashicorp/go-hclog"
 
 	"github.com/oscal-compass/oscal-sdk-go/settings"
 	"github.com/oscal-compass/oscal-sdk-go/transformers"

--- a/cmd/complytime/cli/root.go
+++ b/cmd/complytime/cli/root.go
@@ -40,9 +40,9 @@ func New() *cobra.Command {
 
 	cmd.AddCommand(
 		versionCmd(&opts),
-		scanCmd(&opts),
-		generateCmd(&opts),
-		planCmd(&opts),
+		scanCmd(&opts, logger),
+		generateCmd(&opts, logger),
+		planCmd(&opts, logger),
 		listCmd(&opts, logger),
 	)
 

--- a/cmd/complytime/cli/scan.go
+++ b/cmd/complytime/cli/scan.go
@@ -4,9 +4,10 @@ package cli
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-hclog"
 	"os"
 	"path/filepath"
+
+	"github.com/hashicorp/go-hclog"
 
 	"github.com/complytime/complytime/internal/complytime"
 	oscalTypes "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-2"

--- a/cmd/complytime/cli/scan.go
+++ b/cmd/complytime/cli/scan.go
@@ -47,7 +47,6 @@ func scanCmd(common *option.Common, logger hclog.Logger) *cobra.Command {
 			if err := runScan(cmd, scanOpts, logger); err != nil {
 				logger.Error(err.Error())
 			}
-			logger.Info("The scan command is running.", "command", cmd.CommandPath())
 			return nil
 		},
 	}


### PR DESCRIPTION
## Summary
This PR addresses CPLYTM-511 updating command output to use new terminal printing logic. The files changed allow for use of the `enableDebug()` function within each of the complytime commands. 

**The commands updated to use the logger:**

- `complytime generate`
- `complytime plan`
- `complytime scan`

PR #58 depends on the completion of this task. 

## Related Issues
_Inform any issues relevant to this PR. For example:_

- _Closes #ISSUE_NUMBER_

## Review Hints

- Review commit by commit.
- The format of each command mimics the `complytime list` command.