### PR TITLE
CPLYTM-554: Adapt openSCAP plugin config to use Configure method

### DIFF
--- a/cmd/openscap-plugin/README.md
+++ b/cmd/openscap-plugin/README.md
@@ -71,7 +71,6 @@ Install the plugin
 ```bash
 mkdir -p ~/.config/complytime/plugins
 cp -rp bin/openscap-plugin ~/.config/complytime/plugins
-cp -rp cmd/openscap-plugin/openscap-plugin.yml ~/.config/complytime/plugins
 ```
 
 Create the manifest
@@ -83,10 +82,48 @@ cat > ~/.config/complytime/plugins/c2p-openscap-manifest.json << EOF
     "id": "openscap",
     "description": "My openscap plugin",
     "version": "0.0.1",
-    "types": ["pvp"]
+    "types": [
+      "pvp"
+    ]
   },
   "executablePath": "openscap-plugin",
-  "sha256": "$checksum"
+  "sha256": "$checksum",
+  "configuration": [
+    {
+      "name": "workspace",
+      "description": "Directory for writing plugin artifacts",
+      "required": true
+    },
+    {
+      "name": "datastream",
+      "description": "The OpenSCAP datastream to use.",
+      "default": "/usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml",
+      "required": false
+    },
+    {
+      "name": "results",
+      "description": "The name of the generated results file",
+      "default": "results.xml",
+      "required": false
+    },
+    {
+      "name": "arf",
+      "description": "The name of the generated ARF file",
+      "default": "arf.xml",
+      "required": false
+    },
+    {
+      "name": "policy",
+      "description": "The name of the generated tailoring file",
+      "default": "tailoring_policy.xml",
+      "required": false
+    },
+    {
+      "name": "profile",
+      "description": "The OpenSCAP profile to run for assessment",
+      "required": true
+    }
+  ]
 }
 EOF
 ```

--- a/cmd/openscap-plugin/README.md
+++ b/cmd/openscap-plugin/README.md
@@ -66,75 +66,9 @@ To compile complytime and openscap-plugin:
 make build
 ```
 
-## Running
-Install the plugin
-```bash
-mkdir -p ~/.config/complytime/plugins
-cp -rp bin/openscap-plugin ~/.config/complytime/plugins
-```
+### Running
 
-Create the manifest
-```bash
-checksum=$(sha256sum ~/.config/complytime/plugins/openscap-plugin| cut -d ' ' -f 1 )
-cat > ~/.config/complytime/plugins/c2p-openscap-manifest.json << EOF
-{
-  "metadata": {
-    "id": "openscap",
-    "description": "My openscap plugin",
-    "version": "0.0.1",
-    "types": [
-      "pvp"
-    ]
-  },
-  "executablePath": "openscap-plugin",
-  "sha256": "$checksum",
-  "configuration": [
-    {
-      "name": "workspace",
-      "description": "Directory for writing plugin artifacts",
-      "required": true
-    },
-    {
-      "name": "datastream",
-      "description": "The OpenSCAP datastream to use.",
-      "default": "/usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml",
-      "required": false
-    },
-    {
-      "name": "results",
-      "description": "The name of the generated results file",
-      "default": "results.xml",
-      "required": false
-    },
-    {
-      "name": "arf",
-      "description": "The name of the generated ARF file",
-      "default": "arf.xml",
-      "required": false
-    },
-    {
-      "name": "policy",
-      "description": "The name of the generated tailoring file",
-      "default": "tailoring_policy.xml",
-      "required": false
-    },
-    {
-      "name": "profile",
-      "description": "The OpenSCAP profile to run for assessment",
-      "required": true
-    }
-  ]
-}
-EOF
-```
-
-### Scan
-Run ComplyTime scan command to use plugin
-```bash
-bin/complytime scan
-```
-
-After the scan, check the files in "user_workspace" directory.
+To use the plugin with `complytime`, see the quick start [guide](../../docs/QUICK_START.md).
 
 ### Testing
 Tests are organized within each package. Whenever possible a unit test is created for every function.

--- a/cmd/openscap-plugin/main.go
+++ b/cmd/openscap-plugin/main.go
@@ -3,58 +3,14 @@
 package main
 
 import (
-	"fmt"
-	"log"
-	"os"
-	"path/filepath"
-
-	"github.com/complytime/complytime/cmd/openscap-plugin/config"
 	"github.com/complytime/complytime/cmd/openscap-plugin/server"
 
 	hplugin "github.com/hashicorp/go-plugin"
 	"github.com/oscal-compass/compliance-to-policy-go/v2/plugin"
 )
 
-func getConfigFile() (string, error) {
-	exePath, err := os.Executable()
-	if err != nil {
-		return "", fmt.Errorf("failed to get executable path: %v", err)
-	}
-
-	// Get the directory of the executable
-	exeDir := filepath.Dir(exePath)
-	configPath := filepath.Join(exeDir, "openscap-plugin.yml")
-
-	// Construct the full path to the file
-	configFile, err := config.SanitizeAndValidatePath(configPath, false)
-	if err != nil {
-		return "", fmt.Errorf("failed to sanitize or validate config file: %w", err)
-	}
-
-	return configFile, nil
-}
-
-func initializeConfig() (*config.Config, error) {
-	configFile, err := getConfigFile()
-	if err != nil {
-		return nil, fmt.Errorf("error locating config file: %w", err)
-	}
-
-	config, err := config.ReadConfig(configFile)
-	if err != nil {
-		return nil, fmt.Errorf("error reading config from %s: %w", configFile, err)
-	}
-
-	return config, nil
-}
-
 func main() {
-	config, err := initializeConfig()
-	if err != nil {
-		log.Fatalf("Failed to initialize config: %v", err)
-	}
-
-	openSCAPPlugin := server.New(config)
+	openSCAPPlugin := server.New()
 	pluginByType := map[string]hplugin.Plugin{
 		plugin.PVPPluginName: &plugin.PVPPlugin{Impl: openSCAPPlugin},
 	}

--- a/cmd/openscap-plugin/openscap-plugin.yml
+++ b/cmd/openscap-plugin/openscap-plugin.yml
@@ -1,8 +1,0 @@
-files:
-  workspace: ~/.config/complytime
-  datastream: /usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml
-  results: results.xml
-  arf: arf.xml
-  policy: tailoring_policy.xml
-parameters:
-  profile: cis

--- a/cmd/openscap-plugin/server/server.go
+++ b/cmd/openscap-plugin/server/server.go
@@ -29,13 +29,14 @@ type PluginServer struct {
 	Config *config.Config
 }
 
-func New(cfg *config.Config) PluginServer {
-	return PluginServer{Config: cfg}
+func New() PluginServer {
+	return PluginServer{
+		Config: config.NewConfig(),
+	}
 }
 
-func (s PluginServer) Configure(m map[string]string) error {
-	//TODO implement me
-	panic("implement me")
+func (s PluginServer) Configure(configMap map[string]string) error {
+	return s.Config.LoadSettings(configMap)
 }
 
 func (s PluginServer) Generate(policy policy.Policy) error {

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -34,7 +34,6 @@ Each plugin requires a plugin manifest. For more information about plugin discov
 
 ```bash
 cp bin/openscap-plugin ~/.config/complytime/plugins
-cp cmd/openscap-plugin/openscap-plugin.yml ~/.config/complytime/plugins
 checksum=$(sha256sum ~/.config/complytime/plugins/openscap-plugin| cut -d ' ' -f 1 )
 cat > ~/.config/complytime/plugins/c2p-openscap-manifest.json << EOF
 {
@@ -42,10 +41,48 @@ cat > ~/.config/complytime/plugins/c2p-openscap-manifest.json << EOF
     "id": "openscap",
     "description": "My openscap plugin",
     "version": "0.0.1",
-    "types": ["pvp"]
+    "types": [
+      "pvp"
+    ]
   },
   "executablePath": "openscap-plugin",
-  "sha256": "$checksum"
+  "sha256": "$checksum",
+  "configuration": [
+    {
+      "name": "workspace",
+      "description": "Directory for writing plugin artifacts",
+      "required": true
+    },
+    {
+      "name": "datastream",
+      "description": "The OpenSCAP datastream to use.",
+      "default": "/usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml",
+      "required": false
+    },
+    {
+      "name": "results",
+      "description": "The name of the generated results file",
+      "default": "results.xml",
+      "required": false
+    },
+    {
+      "name": "arf",
+      "description": "The name of the generated ARF file",
+      "default": "arf.xml",
+      "required": false
+    },
+    {
+      "name": "policy",
+      "description": "The name of the generated tailoring file",
+      "default": "tailoring_policy.xml",
+      "required": false
+    },
+    {
+      "name": "profile",
+      "description": "The OpenSCAP profile to run for assessment",
+      "required": true
+    }
+  ]
 }
 EOF
 ```


### PR DESCRIPTION
## Summary

Update how the `openscap-plugin` is configured

- Removes config file, but retains `Config` struct
- Map selected values from the `Configure` method to the `Config` struct
- Implemented the Configure method

Updates example manifest in README to replace options in `openscap-plugin.yml`

## Related Issues

CPLYTM-554

## Review Hints

Note: There is library that could be looked at if the configuration gets more complex https://github.com/go-viper/mapstructure. Since we are starting with supporting string values and the structs are not deeply nested, using struct tags seemed to be pretty straightforward and uses the standard library.
