### PR TITLE
CPLYTM-579: Treat potential issues when generating tailoring files

### DIFF
--- a/cmd/openscap-plugin/xccdf/tailoring.go
+++ b/cmd/openscap-plugin/xccdf/tailoring.go
@@ -85,7 +85,7 @@ func unselectAbsentRules(tailoringSelections, dsProfileSelections []xccdf.Select
 				break
 			}
 		}
-		if !dsRuleAlsoInPolicy {
+		if !dsRuleAlsoInPolicy && dsRule.Selected {
 			tailoringSelections = append(tailoringSelections, xccdf.SelectElement{
 				IDRef:    dsRule.IDRef,
 				Selected: false,

--- a/cmd/openscap-plugin/xccdf/tailoring_test.go
+++ b/cmd/openscap-plugin/xccdf/tailoring_test.go
@@ -320,6 +320,21 @@ func TestSelectAdditionalRules(t *testing.T) {
 				{IDRef: "xccdf_org.ssgproject.content_rule_rule1", Selected: true},
 			},
 		},
+		{
+			name:                "One additional rule informed twice",
+			tailoringSelections: []xccdf.SelectElement{},
+			dsProfileSelections: []xccdf.SelectElement{
+				{IDRef: "xccdf_org.ssgproject.content_rule_rule1", Selected: true},
+			},
+			oscalPolicy: policy.Policy{
+				{Rule: extensions.Rule{ID: "rule1"}},
+				{Rule: extensions.Rule{ID: "rule2"}},
+				{Rule: extensions.Rule{ID: "rule2"}},
+			},
+			expectedSelections: []xccdf.SelectElement{
+				{IDRef: "xccdf_org.ssgproject.content_rule_rule2", Selected: true},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -487,6 +502,21 @@ func TestUpdateTailoringValues(t *testing.T) {
 				{Rule: extensions.Rule{Parameter: nil}},
 			},
 			expectedValues: []xccdf.SetValueElement{},
+		},
+		{
+			name:            "One additional value informed twice",
+			tailoringValues: []xccdf.SetValueElement{},
+			dsProfileValues: []xccdf.SetValueElement{
+				{IDRef: "xccdf_org.ssgproject.content_value_var1", Value: "value1"},
+			},
+			oscalPolicy: policy.Policy{
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "var1", Value: "value1"}}},
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "var2", Value: "value2"}}},
+				{Rule: extensions.Rule{Parameter: &extensions.Parameter{ID: "var2", Value: "value2"}}},
+			},
+			expectedValues: []xccdf.SetValueElement{
+				{IDRef: "xccdf_org.ssgproject.content_value_var2", Value: "value2"},
+			},
 		},
 	}
 


### PR DESCRIPTION
## Summary

During the tests with ANSSI content there was duplicated information of rules and variables in Component Definition, which was then propagated to Assessment Plan and later to the tailoring file after the `generate` command. 
Ultimately the "scan" command failed because `oscap` scanner reported duplicated ids.
Since similar issues may happen by different reasons, a treatment was included in `openscap-plugin` to avoid errors during the `scan`.

Another case was treated in the first commit to avoid unnecessary information in the tailoring file in a case that an element is only included in the Datastream profile but already using "selected=false".

## Related Issues

- CPLYTM-579

## Review Hints

Besides the code testing, the outcome with real content can be tested using complytime-demos
Once the base VM and Ansible environment is created as described in https://github.com/complytime/complytime-demos/blob/main/README.md#get-your-hands-dirty

Populate the VM with ANSSI content used for tests from the `base_ansible_env` directory
```bash
ansible-playbook populate_complytime_anssi_content.yml
```
Connect via SSH to the Demo VM using the `ansible` user.
```bash
complytime list
complytime plan anssi_bp28_minimal
complytime generate
vim .config/complytime/openscap/policy/tailoring_policy.xml
```