### PR TITLE
CPLYTM-512 propogate charm logger to plugins

### DIFF
--- a/cmd/complytime/cli/generate.go
+++ b/cmd/complytime/cli/generate.go
@@ -62,6 +62,10 @@ func runGenerate(cmd *cobra.Command, opts *generateOptions, logger hclog.Logger)
 		return err
 	}
 	logger.Debug("The configuration from the C2PConfig was successfully loaded.")
+
+	// set config logger to CLI charm logger
+	cfg.Logger = logger
+
 	manager, err := framework.NewPluginManager(cfg)
 	if err != nil {
 		return fmt.Errorf("error initializing plugin manager: %w", err)

--- a/cmd/complytime/cli/scan.go
+++ b/cmd/complytime/cli/scan.go
@@ -71,6 +71,10 @@ func runScan(cmd *cobra.Command, opts *scanOptions, logger hclog.Logger) error {
 	if err != nil {
 		return err
 	}
+
+	// set config logger to CLI charm logger
+	cfg.Logger = logger
+
 	manager, err := framework.NewPluginManager(cfg)
 	if err != nil {
 		return fmt.Errorf("error initializing plugin manager: %w", err)


### PR DESCRIPTION
## Summary
This PR adds the charm logger to the c2p config to propagate it down to the plugins.