### PR TITLE
CPLYTM-581: fix: trims oval check name in observation to expected format

### DIFF
--- a/cmd/openscap-plugin/server/server.go
+++ b/cmd/openscap-plugin/server/server.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -21,7 +22,12 @@ import (
 	"github.com/complytime/complytime/cmd/openscap-plugin/xccdf"
 )
 
-var _ policy.Provider = (*PluginServer)(nil)
+var (
+	_ policy.Provider = (*PluginServer)(nil)
+	// ovalRegex is a regular expression for capturing the check short name
+	// in an OVAL check definition identifier.
+	ovalRegex = regexp.MustCompile(`^[^:]*?:[^-]*?-(.*?):.*?$`)
+)
 
 const ovalCheckType = "http://oval.mitre.org/XMLSchema/oval-definitions-5"
 
@@ -52,13 +58,16 @@ func (s PluginServer) Generate(policy policy.Policy) error {
 	return nil
 }
 
-func (s PluginServer) GetResults(_ policy.Policy) (policy.PVPResult, error) {
-	fmt.Println("I am being scanned by OpenSCAP")
+func (s PluginServer) GetResults(oscalPolicy policy.Policy) (policy.PVPResult, error) {
 	pvpResults := policy.PVPResult{}
+	policyChecks := newChecks()
+
 	_, err := scan.ScanSystem(s.Config, s.Config.Parameters.Profile)
 	if err != nil {
 		return policy.PVPResult{}, err
 	}
+
+	policyChecks.LoadPolicy(oscalPolicy)
 
 	// get some results here
 	file, err := os.Open(filepath.Clean(s.Config.Files.ARF))
@@ -93,32 +102,74 @@ func (s PluginServer) GetResults(_ policy.Policy) (policy.PVPResult, error) {
 		if ovalRefEl == nil {
 			continue
 		}
-		ovalCheckName := strings.TrimSpace(ovalRefEl.SelectAttr("name"))
-
-		mappedResult, err := mapResultStatus(result)
+		ovalCheck, err := parseCheck(ovalRefEl)
 		if err != nil {
 			return policy.PVPResult{}, err
 		}
-		observation := policy.ObservationByCheck{
-			Title:     ruleIDRef,
-			Methods:   []string{"AUTOMATED"},
-			Collected: time.Now(),
-			CheckID:   ovalCheckName,
-			Subjects: []policy.Subject{
-				{
-					Title:       "My Comp",
-					Type:        "component",
-					ResourceID:  ruleIDRef,
-					EvaluatedOn: time.Now(),
-					Result:      mappedResult,
-					Reason:      "my reason",
+		if policyChecks.Has(ovalCheck) {
+			mappedResult, err := mapResultStatus(result)
+			if err != nil {
+				return policy.PVPResult{}, err
+			}
+			observation := policy.ObservationByCheck{
+				Title:     ruleIDRef,
+				Methods:   []string{"AUTOMATED"},
+				Collected: time.Now(),
+				CheckID:   ovalCheck,
+				Subjects: []policy.Subject{
+					{
+						Title:       "My Comp",
+						Type:        "component",
+						ResourceID:  ruleIDRef,
+						EvaluatedOn: time.Now(),
+						Result:      mappedResult,
+						Reason:      "my reason",
+					},
 				},
-			},
+			}
+			pvpResults.ObservationsByCheck = append(pvpResults.ObservationsByCheck, observation)
 		}
-		pvpResults.ObservationsByCheck = append(pvpResults.ObservationsByCheck, observation)
 	}
-
 	return pvpResults, nil
+}
+
+// checks is a Set implementation for comparing OSCAL
+// and OVAL checks ids.
+type checks map[string]struct{}
+
+func newChecks() checks {
+	policyChecks := make(checks)
+	return policyChecks
+}
+
+func (c checks) LoadPolicy(oscalPolicy policy.Policy) {
+	for _, rule := range oscalPolicy {
+		for _, check := range rule.Checks {
+			c[check.ID] = struct{}{}
+		}
+	}
+}
+
+func (c checks) Has(check string) bool {
+	_, ok := c[check]
+	return ok
+}
+
+// parseCheck returns the check short name without the OVAL-specific naming from a
+// rule in results.
+func parseCheck(check *xmlquery.Node) (string, error) {
+	ovalCheckName := strings.TrimSpace(check.SelectAttr("name"))
+	if ovalCheckName == "" {
+		return "", errors.New("check-content-ref node has no 'name' attribute")
+	}
+	matches := ovalRegex.FindStringSubmatch(ovalCheckName)
+
+	minimumPart, shortNameLoc := 2, 1
+	if len(matches) < minimumPart {
+		return "", fmt.Errorf("check id %q is in unexpected format", ovalCheckName)
+	}
+	trimmedCheckName := matches[shortNameLoc]
+	return trimmedCheckName, nil
 }
 
 func mapResultStatus(result *xmlquery.Node) (policy.Result, error) {

--- a/cmd/openscap-plugin/server/server_test.go
+++ b/cmd/openscap-plugin/server/server_test.go
@@ -82,3 +82,43 @@ func TestMapResultStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestParseCheck(t *testing.T) {
+	tests := []struct {
+		name           string
+		xmlContent     string
+		expectedResult string
+		expectedError  error
+	}{
+		{
+			name:           "Valid/ExpectedFormat",
+			xmlContent:     `<check-content-ref name="oval:ssg-audit_perm_change_success:def:1"/>`,
+			expectedResult: "audit_perm_change_success",
+		},
+		{
+			name:           "Invalid/UnexpectedFormat",
+			xmlContent:     `<check-content-ref name="ovalssg-audit_perm_change_success:def:1"/>`,
+			expectedResult: "",
+			expectedError:  errors.New("check id \"ovalssg-audit_perm_change_success:def:1\" is in unexpected format"),
+		},
+		{
+			name:           "Invalid/NoNameAttribute",
+			xmlContent:     `<check-content-ref/>`,
+			expectedResult: "",
+			expectedError:  errors.New("check-content-ref node has no 'name' attribute"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node, err := xmlquery.Parse(strings.NewReader(tt.xmlContent))
+			assert.NoError(t, err)
+			check, err := parseCheck(node.SelectElement("check-content-ref"))
+			assert.Equal(t, tt.expectedResult, check)
+			if tt.expectedError != nil {
+				assert.EqualError(t, err, tt.expectedError.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

WIP commit that trims the oval check name and ensure it exists in the known checks.

## Related Issues

Build on top of @marcusburghardt branch for #61 

## Review Hints

Only review the last commit. It is work in progress.
