### PR TITLE
docs: CPLYTM-510 highlighting functionality of logger  

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -29,3 +29,4 @@ To maintain consistency and compliance with the project’s licensing policy, al
 - **Empty Line at End of File**: Ensure that all files include an empty line at the end. This helps with version control diffs and adheres to POSIX standards.
 - Other [Go checks](https://github.com/complytime/complytime/blob/main/.golangci.yml) are present in CI/CD and therefore it may be useful to also run them locally before submitting a PR.
 - The pre-commit and pre-push hooks can be configured by installing [pre-commit](https://pre-commit.com/) and running `make dev-setup`
+- ComplyTime leverages the [charmbracelet/log](https://github.com/charmbracelet/log) library for logging all command and plugin activity. By default, this output is printed to stdout.

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package log
 
 import (
@@ -71,7 +73,7 @@ func NewLogger(o io.Writer) hclog.Logger {
 	return l
 }
 
-// CharmHclog is a structure that accesses the attributes of charm logger.
+// CharmHclog adapts the charm logger to the hashicorp logger.
 type CharmHclog struct {
 	logger *charmlog.Logger
 }

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package log
 
 import (
@@ -116,6 +118,8 @@ func TestTypes(t *testing.T) {
 		})
 	}
 }
+
+// Testing various prefixes and levels entered.
 func TestPrefixMatch(t *testing.T) {
 	tests := []struct {
 		prefix   string


### PR DESCRIPTION
## Summary
This PR updates documentation to highlight the `charmbracelet/log` and `charmbracelet/lipgloss` libraries used for styling and adaptation to the `go-hclog` logger.  The `log.go` file includes in-line comments for style customization and log level mapping. The `STYLE_GUIDE.md`  provides additional guidelines regarding the functionality of the `charmbracelet` libraries used in complytime. 

**Location of documentation updates:**

-  `STYLE_GUIDE.md` 
-  `log.go` 

## Related Issues
_Inform any issues relevant to this PR. For example:_

## Review Hints

- Review commit by commit