### PR TITLE
chore(dep): updates compliance-to-policy dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.27.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -92,6 +91,7 @@ require (
 	google.golang.org/protobuf v1.36.3 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.32.1 // indirect
 	k8s.io/apimachinery v0.32.1 // indirect
 	k8s.io/apiserver v0.32.0 // indirect
@@ -105,4 +105,4 @@ require (
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
-replace github.com/oscal-compass/compliance-to-policy-go/v2 => github.com/complytime/compliance-to-policy-go/v2 v2.0.0-20250219212651-3ec848c23b40
+replace github.com/oscal-compass/compliance-to-policy-go/v2 => github.com/complytime/compliance-to-policy-go/v2 v2.0.0-20250227121630-81169b4b0d96

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQ
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/clarketm/json v1.17.1 h1:U1IxjqJkJ7bRK4L6dyphmoO840P6bdhPdbbLySourqI=
 github.com/clarketm/json v1.17.1/go.mod h1:ynr2LRfb0fQU34l07csRNBTcivjySLLiY1YzQqKVfdo=
-github.com/complytime/compliance-to-policy-go/v2 v2.0.0-20250219212651-3ec848c23b40 h1:sKrGLNSVIrfkOU2b6DbBAz1Stb6zHo9V3oiJQ5/3Q88=
-github.com/complytime/compliance-to-policy-go/v2 v2.0.0-20250219212651-3ec848c23b40/go.mod h1:ayAFbmq1/RzJpxsSWHpax+IkMBWCQCM3PcXX+oPXqKo=
+github.com/complytime/compliance-to-policy-go/v2 v2.0.0-20250227121630-81169b4b0d96 h1:S750mby90gVx16QxxCNNU+D1+nl2UjSVXtqauODMyXg=
+github.com/complytime/compliance-to-policy-go/v2 v2.0.0-20250227121630-81169b4b0d96/go.mod h1:brB4VZ/WQKUk3MDvGoPegnBUROF5rwrDEN0l+oLz7jI=
 github.com/coreos/fcct v0.5.0 h1:f/z+MCoR2vULes+MyoPEApQ6iluy/JbXoRi6dahPItQ=
 github.com/coreos/fcct v0.5.0/go.mod h1:cbE+j77YSQwFB2fozWVB3qsI2Pi3YiVEbDz/b6Yywdo=
 github.com/coreos/go-json v0.0.0-20230131223807-18775e0fb4fb h1:rmqyI19j3Z/74bIRhuC59RB442rXUazKNueVpfJPxg4=


### PR DESCRIPTION
## Summary

Updates the compliance-to-policy-go dependency to the `CPLYTM-273` branch

## Related Issues

N/A

## Review Hints

N/A