### PR TITLE
CPLYTM-586 and CPLYTM-556: Improve configuration experience

### DIFF
--- a/cmd/complytime/option/common.go
+++ b/cmd/complytime/option/common.go
@@ -44,7 +44,7 @@ type ComplyTime struct {
 
 // BindFlags populate ComplyTime options from user-specified flags.
 func (o *ComplyTime) BindFlags(fs *pflag.FlagSet) {
-	fs.StringVarP(&o.UserWorkspace, "workspace", "w", ".", "workspace to use for artifact generation")
+	fs.StringVarP(&o.UserWorkspace, "workspace", "w", "./complytime", "workspace to use for artifact generation")
 }
 
 // ToPluginOptions returns global PluginOptions based on complytime Options.

--- a/cmd/openscap-plugin/README.md
+++ b/cmd/openscap-plugin/README.md
@@ -6,7 +6,7 @@ NOTE: The development of this plugin is in progress and therefore it should only
 
 **openscap-plugin** is a plugin which extends the **ComplyTime** capabilities to use OpenSCAP. The plugin communicates with **ComplyTime** via gRPC, providing a standard and consistent communication mechanism that gives independence for plugin developers to choose their preferred languages. This plugin is structured to allow modular development, ease of packaging, and maintainability.
 
-For now, this plugin is developed together with ComplyTime for better collaboration during this phase of the project. In the future, this plugin will likely be decoupled into its own repository.
+For now, this plugin is developed together with ComplyTime for better collaboration during this phase of the project. In the future, this plugin may be decoupled into its own repository.
 
 ## Plugin Structure
 
@@ -29,20 +29,43 @@ openscap-plugin/
 │ ├── datastream.go       # Main code used to process Datastream files
 │ ├── tailoring_test.go   # Tests for functions in tailoring.go
 │ └── tailoring.go        # Main code used to generate tailoring files based on OSCAL and available Datastreams.
-├── openscap-config.yml   # Example of plugin configuration file (still in development)
 └── README.md             # This file
 ```
 
 ## Features
-### Scan
-When the plugin receives the scan command from ComplyTime, it will use the configured Datastream and Policy (tailoring file) to:
-* Validate the SCAP files
-* Assembly the `oscap` command
-* Scan the system saving results in an ARF file according to the plugin configuration
-* Process the results and return observations to ComplyTime.
+
+### Configuration
+
+The plugin have some parameter that can be configured via the manifest file. Check the quick start [guide](../../docs/QUICK_START.md) to see an example.
+ComplyTime process the manifest file and send the configuration values to the plugin.
+
+These are the configuration used by openscap-plugin:
+- **workspace**:  Directory used to read the tailoring file and to save oscap files generated during the scan
+- **profile**:    Is the FrameworkID informed by ComplyTime. This FrameworkID correspond to a profile ID in the Datastream
+- **datastream**: Datastream file to be used by `generate` and `scan` commands.
+- **policy**:     File name for the tailoring file created by the `generate` command and consumed by the `scan` command.
+- **arf**:        File name to save the `oscap` ARF results during the `scan` command.
+- **results**:    File name to save `oscap` results during the `scan` command.
+
+Note that the Datastream path is essential for the plugin commands and therefore a required option.
+However it has no default value in the manifest because the plugin will try to determine the proper Datastream file automatically, based on system information. In case a Datastream file cannot be determined or validated, an error will be reported.
+In exception cases, it is possible to manually define the desired Datastream path via manifest file.
 
 ### Generate
-This feature is currently under development.
+
+When the plugin receives the `generate` command from ComplyTime, it will use the informed Datastream and FrameworkID in combination with the `assessment-plan.json` file to:
+* Process the `openscap` validation component from the `assessment-plan.json`
+* Validate if all rules and variables in `assessment-plan.json` are valid in the Datastream
+* Compare the rules, variables and variables values between the `assessment-plan.json` and the Datastream profile (FrameworkID)
+* Generate a tailoring file to be used by the `scan` command
+  * The tailoring file will extend the Datastream profile by overriding rules and variables values as defined in the `assessment-plan.json` file
+
+### Scan
+When the plugin receives the `scan` command from ComplyTime, it will use the informed Datastream and FrameworkID to:
+* Validate the Datastream and Policy (tailoring file created by `generate` command) files.
+* Assembly the `oscap` command
+* Scan the system saving `oscap` results in ARF and results files according to the values defined in the plugin manifest file
+* Process the results and return observations to ComplyTime so an `assessment-results.json` file can be created by `ComplyTime`
 
 ## Installation
 
@@ -60,6 +83,7 @@ cd complytime
 ```
 
 ## Build Instructions
+
 To compile complytime and openscap-plugin:
 
 ```bash
@@ -71,6 +95,7 @@ make build
 To use the plugin with `complytime`, see the quick start [guide](../../docs/QUICK_START.md).
 
 ### Testing
+
 Tests are organized within each package. Whenever possible a unit test is created for every function.
 
 Run tests using:

--- a/cmd/openscap-plugin/README.md
+++ b/cmd/openscap-plugin/README.md
@@ -36,12 +36,12 @@ openscap-plugin/
 
 ### Configuration
 
-The plugin have some parameter that can be configured via the manifest file. Check the quick start [guide](../../docs/QUICK_START.md) to see an example.
+The plugin has some parameters that can be configured via the manifest file. Check the quick start [guide](../../docs/QUICK_START.md) to see an example.
 ComplyTime process the manifest file and send the configuration values to the plugin.
 
 These are the configuration used by openscap-plugin:
-- **workspace**:  Directory used to read the tailoring file and to save oscap files generated during the scan
-- **profile**:    Is the FrameworkID informed by ComplyTime. This FrameworkID correspond to a profile ID in the Datastream
+- **workspace**:  Directory used to read the tailoring file and to save oscap files generated during the scan. This configuration can also be set by ComplyTime CLI.
+- **profile**:    Is the FrameworkID informed by ComplyTime. This FrameworkID corresponds to a profile ID in the Datastream.
 - **datastream**: Datastream file to be used by `generate` and `scan` commands.
 - **policy**:     File name for the tailoring file created by the `generate` command and consumed by the `scan` command.
 - **arf**:        File name to save the `oscap` ARF results during the `scan` command.

--- a/cmd/openscap-plugin/config/config.go
+++ b/cmd/openscap-plugin/config/config.go
@@ -312,5 +312,5 @@ func findMatchingDatastream() (string, error) {
 		return foundFile, nil
 	}
 
-	return "", fmt.Errorf("could not determine a datastream file for a %s system.", distroVersion)
+	return "", fmt.Errorf("could not determine a datastream file for a %s system", distroVersion)
 }

--- a/cmd/openscap-plugin/config/config.go
+++ b/cmd/openscap-plugin/config/config.go
@@ -77,7 +77,8 @@ func (c *Config) validate() error {
 		return err
 	}
 
-	// an empty string is updated to the current directory after SanitizePath
+	// if a Datastream path is not defined in plugin manifest, it will be set
+	// to the current directory after SanitizePath.
 	if cleanDsPath == "." {
 		matchingDsFile, err := findMatchingDatastream()
 		if err != nil {
@@ -231,7 +232,9 @@ func setConfigStruct(val reflect.Value, config map[string]string) error {
 		fieldType := t.Field(i)
 		key := fieldType.Tag.Get("config")
 		value, ok := config[key]
-		if !ok {
+		// if datastream is not set in manifest file, plugin will try to determine
+		// and validate the datastream path later based on system information.
+		if !ok && key != "datastream" {
 			return fmt.Errorf("missing configuration value for option %q (field: %s)", key, fieldType.Name)
 		}
 

--- a/cmd/openscap-plugin/config/config_test.go
+++ b/cmd/openscap-plugin/config/config_test.go
@@ -86,6 +86,64 @@ func TestSanitizePath(t *testing.T) {
 	}
 }
 
+func setupTestFiles() error {
+	if err := os.MkdirAll("testdata", os.ModePerm); err != nil {
+		return err
+	}
+
+	if err := os.WriteFile("testdata/valid.xml", []byte(`<root></root>`), 0600); err != nil {
+		return err
+	}
+	if err := os.WriteFile("testdata/invalid.xml", []byte(`<root>`), 0600); err != nil {
+		return err
+	}
+	return nil
+}
+
+func teardownTestFiles() {
+	os.RemoveAll("testdata")
+}
+
+func TestIsXMLFile(t *testing.T) {
+	if err := setupTestFiles(); err != nil {
+		t.Fatalf("Failed to setup test files: %v", err)
+	}
+	defer teardownTestFiles()
+
+	tests := []struct {
+		name      string
+		filePath  string
+		want      bool
+		expectErr bool
+	}{
+		{
+			name:      "Valid XML file",
+			filePath:  "testdata/valid.xml",
+			want:      true,
+			expectErr: false,
+		},
+		{
+			name:      "Invalid XML file",
+			filePath:  "testdata/invalid.xml",
+			want:      false,
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isXML, err := IsXMLFile(tt.filePath)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("IsXMLFile(%s) error = %v, expectErr %v", tt.filePath, err, tt.expectErr)
+				return
+			}
+			if isXML != tt.want {
+				t.Errorf("IsXMLFile() = %v, want %v", isXML, tt.want)
+			}
+		})
+	}
+}
+
 // TestEnsureDirectory tests the ensureDirectory function with various cases.
 func TestEnsureDirectory(t *testing.T) {
 	tempDir := t.TempDir()

--- a/cmd/openscap-plugin/config/config_test.go
+++ b/cmd/openscap-plugin/config/config_test.go
@@ -71,6 +71,7 @@ func TestSanitizePath(t *testing.T) {
 
 		// Weird but valid cases
 		{"~weird", "~weird", false}, // not common but possible
+		{"", ".", false},            // empty path is updated to the current directory
 	}
 
 	for _, tt := range tests {

--- a/cmd/openscap-plugin/config/config_test.go
+++ b/cmd/openscap-plugin/config/config_test.go
@@ -86,52 +86,6 @@ func TestSanitizePath(t *testing.T) {
 	}
 }
 
-// TestSanitizeAndValidatePath tests the SanitizeAndValidatePath function with various
-// valid and invalid paths.
-func TestSanitizeAndValidatePath(t *testing.T) {
-	tempDir := t.TempDir()
-	tempFile := filepath.Join(tempDir, "testfile")
-
-	file, err := os.Create(tempFile)
-	if err != nil {
-		t.Fatalf("Failed to create temporary file: %v", err)
-	}
-	file.Close()
-	defer os.RemoveAll(tempFile)
-
-	tests := []struct {
-		path        string
-		shouldBeDir bool
-		expectError bool
-		expected    string
-	}{
-		// Valid cases
-		{tempDir, true, false, tempDir},    // directory exists
-		{tempFile, false, false, tempFile}, // file exists
-		{"/nonexistent", true, true, ""},   // directory does not exist
-		{"/nonexistent", false, true, ""},  // file does not exist
-
-		// Invalid cases
-		{tempFile, true, true, ""},          // expected directory but found file
-		{tempDir, false, true, ""},          // expected file but found directory
-		{"/foo/bar/../baz", true, true, ""}, // normalized path does not exist
-		{"./foo/bar", true, true, ""},       // relative path does not exist
-		{"./foo/bar", true, true, ""},       // relative path does not exist
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.path, func(t *testing.T) {
-			result, err := SanitizeAndValidatePath(tt.path, tt.shouldBeDir)
-			if (err != nil) != tt.expectError {
-				t.Errorf("Expected error: %v, got: %v", tt.expectError, err)
-			}
-			if result != tt.expected {
-				t.Errorf("Expected result: %s, got: %s", tt.expected, result)
-			}
-		})
-	}
-}
-
 // TestEnsureDirectory tests the ensureDirectory function with various cases.
 func TestEnsureDirectory(t *testing.T) {
 	tempDir := t.TempDir()

--- a/cmd/openscap-plugin/scan/scan.go
+++ b/cmd/openscap-plugin/scan/scan.go
@@ -3,7 +3,6 @@
 package scan
 
 import (
-	"encoding/xml"
 	"fmt"
 	"os"
 
@@ -12,35 +11,13 @@ import (
 	"github.com/complytime/complytime/cmd/openscap-plugin/xccdf"
 )
 
-func isXMLFile(filePath string) (bool, error) {
-	file, err := os.Open(filePath)
-	if err != nil {
-		return false, fmt.Errorf("error opening file: %w", err)
-	}
-	defer file.Close()
-
-	decoder := xml.NewDecoder(file)
-	for {
-		_, err := decoder.Token()
-		if err != nil {
-			if err.Error() == "EOF" {
-				return true, nil
-			}
-			return false, fmt.Errorf("invalid XML file %s: %w", filePath, err)
-		}
-	}
-}
-
 func validateOpenSCAPFiles(cfg *config.Config) (map[string]string, error) {
-	if _, err := isXMLFile(cfg.Files.Datastream); err != nil {
-		return nil, err
-	}
-
 	if _, err := os.Stat(cfg.Files.Policy); err != nil {
 		return nil, err
 	}
 
-	if _, err := isXMLFile(cfg.Files.Policy); err != nil {
+	isXML, err := config.IsXMLFile(cfg.Files.Policy)
+	if err != nil || !isXML {
 		return nil, err
 	}
 

--- a/cmd/openscap-plugin/scan/scan_test.go
+++ b/cmd/openscap-plugin/scan/scan_test.go
@@ -9,41 +9,6 @@ import (
 	"github.com/complytime/complytime/cmd/openscap-plugin/config"
 )
 
-func TestIsXMLFile(t *testing.T) {
-	tests := []struct {
-		name      string
-		filePath  string
-		want      bool
-		expectErr bool
-	}{
-		{
-			name:      "Valid XML file",
-			filePath:  "testdata/valid.xml",
-			want:      true,
-			expectErr: false,
-		},
-		{
-			name:      "Invalid XML file",
-			filePath:  "testdata/invalid.xml",
-			want:      false,
-			expectErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			isXML, err := isXMLFile(tt.filePath)
-			if (err != nil) != tt.expectErr {
-				t.Errorf("isXMLFile(%s) error = %v, expectErr %v", tt.filePath, err, tt.expectErr)
-				return
-			}
-			if isXML != tt.want {
-				t.Errorf("isXMLFile() = %v, want %v", isXML, tt.want)
-			}
-		})
-	}
-}
-
 func setupTestFiles() error {
 	if err := os.MkdirAll("testdata", os.ModePerm); err != nil {
 		return err

--- a/docs/PLUGIN_GUIDE.md
+++ b/docs/PLUGIN_GUIDE.md
@@ -9,12 +9,12 @@ Plugins communicate with ComplyTime via gRPC and can be authored using any prefe
 The plugin acts as the gRPC server while the ComplyTime CLI acts as the client.
 When a `complytime` command is run, it invokes the appropriate method served by the plugin.
 
-ComplyTime is built on [compliance-to-policy-go](https://github.com/oscal-compass/compliance-to-policy-go/ which provides a flexible plugin framework for levering OSCAL with various PVPs. For developers choosing Golang, the same SDK can be used for plugin authoring.
+ComplyTime is built on [compliance-to-policy-go](https://github.com/oscal-compass/compliance-to-policy-go/ which provides a flexible plugin framework for leveraging OSCAL with various PVPs. For developers choosing Golang, the same SDK can be used for plugin authoring.
 
 ## Plugin Discovery
 
 ComplyTime performs automated plugin discovery using the compliance-to-policy-go [plugin manager](https://github.com/complytime/compliance-to-policy-go/blob/CPLYTM-272/plugin/discovery.go).
-Plugins are defined using a manifest files placed in the `c2p-plugins` directory.
+Plugins are defined using manifest files placed in the `c2p-plugins` directory.
 The plugin manifest is a JSON file that provides metadata about the plugin.
 Check the quick start [guide](QUICK_START.md) to see an example.
 
@@ -34,7 +34,7 @@ Check the quick start [guide](QUICK_START.md) to see an example.
       {
         "name": "config_name",
         "description": "Config description",
-		"default": "default_value",
+        "default": "default_value",
         "required": true
       },
 	]

--- a/docs/PLUGIN_GUIDE.md
+++ b/docs/PLUGIN_GUIDE.md
@@ -1,12 +1,22 @@
 # Plugin Authoring
 
+ComplyTime can be extended to support desired policy engines (PVPs) by the use of plugins.
+The plugin acts as the integration between ComplyTime and the PVPs native interface.
+Each plugin is responsible for converting the policy content described in OSCAL into the input format expected by the PVP.
+In addition, the plugin converts the raw results provided by the PVP into the schema used by ComplyTime to generate OSCAL output.
 
-ComplyTime can be extended to support desired policy engines (PVPs) by the use of plugins.  ComplyTime is built on [compliance-to-policy-go](https://github.com/oscal-compass/compliance-to-policy-go/ which provides a flexible plugin framework for levering OSCAL with various PVPs.  The plugin acts as the integration between ComplyTime and the PVPs native interface.  Each plugin is responsible for converting the policy content described in OSCAL into the input format expected by the PVP.  In addition, the plugin converts the raw results provided by the PVP into the schema used by ComplyTime to generate OSCAL output.  Plugins communicate with ComplyTime via gRPC and can be authored using any preferred language.  The plugin acts as the gRPC server while the ComplyTime CLI acts as the client.  When a `complytime` command is run, it invokes the appropriate method served by the plugin.  For developers choosing Golang, the [compliance-to-policy-go](https://github.com/oscal-compass/compliance-to-policy-go/) SDK can be used for plugin authoring.
+Plugins communicate with ComplyTime via gRPC and can be authored using any preferred language.
+The plugin acts as the gRPC server while the ComplyTime CLI acts as the client.
+When a `complytime` command is run, it invokes the appropriate method served by the plugin.
 
+ComplyTime is built on [compliance-to-policy-go](https://github.com/oscal-compass/compliance-to-policy-go/ which provides a flexible plugin framework for levering OSCAL with various PVPs. For developers choosing Golang, the same SDK can be used for plugin authoring.
 
 ## Plugin Discovery
 
-ComplyTime performs automated plugin discovery using the compliance-to-policy-go [plugin manager](https://github.com/complytime/compliance-to-policy-go/blob/CPLYTM-272/plugin/discovery.go).  Plugins are defined using a manifest files placed in the `c2p-plugins` directory.  The plugin manifest is a JSON file that provides metadata about the plugin.
+ComplyTime performs automated plugin discovery using the compliance-to-policy-go [plugin manager](https://github.com/complytime/compliance-to-policy-go/blob/CPLYTM-272/plugin/discovery.go).
+Plugins are defined using a manifest files placed in the `c2p-plugins` directory.
+The plugin manifest is a JSON file that provides metadata about the plugin.
+Check the quick start [guide](QUICK_START.md) to see an example.
 
 **Note:** the plugin manifest file must have the following syntax for automatic discovery: `c2p-<plugin name>-manifest.json`
 
@@ -20,14 +30,21 @@ ComplyTime performs automated plugin discovery using the compliance-to-policy-go
 	“type”: [“pvp”],
 	“executablePath”: "myplugin" // in relation to the plugin directory
 	“sha256”: “23f…” // sha256 of executable
-
+	"configuration": [
+      {
+        "name": "config_name",
+        "description": "Config description",
+		"default": "default_value",
+        "required": true
+      },
+	]
 }
 ```
 
-
 ### Plugin Selection
 
-ComplyTime generates a mapping of plugins to validation components at runtime.  This mapping uses the `title` of the validation component to find a matching plugin with that ID (defined in manifest).
+ComplyTime generates a mapping of plugins to validation components at runtime.
+This mapping uses the `title` of the validation component to find a matching plugin with that ID (defined in manifest).
 
 ```json
 {
@@ -37,7 +54,6 @@ ComplyTime generates a mapping of plugins to validation components at runtime.  
 	“title”: “myplugin”, // name must match plugin ID in manifest
 }
 ```
-
 
 ## Example
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -55,8 +55,8 @@ cat > ~/.config/complytime/plugins/c2p-openscap-manifest.json << EOF
     },
     {
       "name": "datastream",
-      "description": "The OpenSCAP datastream to use.",
-      "default": "/usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml",
+      "description": "The OpenSCAP datastream to use. If empty, the plugin will try to determine it based on system information",
+      "default": "",
       "required": false
     },
     {

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -54,21 +54,13 @@ cat > ~/.config/complytime/plugins/c2p-openscap-manifest.json << EOF
       "required": true
     },
     {
+      "name": "profile",
+      "description": "The OpenSCAP profile to run for assessment",
+      "required": true
+    },
+    {
       "name": "datastream",
-      "description": "The OpenSCAP datastream to use. If empty, the plugin will try to determine it based on system information",
-      "default": "",
-      "required": false
-    },
-    {
-      "name": "results",
-      "description": "The name of the generated results file",
-      "default": "results.xml",
-      "required": false
-    },
-    {
-      "name": "arf",
-      "description": "The name of the generated ARF file",
-      "default": "arf.xml",
+      "description": "The OpenSCAP datastream to use. If not set, the plugin will try to determine it based on system information",
       "required": false
     },
     {
@@ -78,9 +70,16 @@ cat > ~/.config/complytime/plugins/c2p-openscap-manifest.json << EOF
       "required": false
     },
     {
-      "name": "profile",
-      "description": "The OpenSCAP profile to run for assessment",
-      "required": true
+      "name": "arf",
+      "description": "The name of the generated ARF file",
+      "default": "arf.xml",
+      "required": false
+    },
+    {
+      "name": "results",
+      "description": "The name of the generated results file",
+      "default": "results.xml",
+      "required": false
     }
   ]
 }

--- a/internal/complytime/plan.go
+++ b/internal/complytime/plan.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	oscalTypes "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-2"
 	"github.com/oscal-compass/oscal-sdk-go/extensions"
@@ -16,6 +17,12 @@ import (
 
 // WritePlan writes an AssessmentPlan to a given path location with consistency.
 func WritePlan(plan *oscalTypes.AssessmentPlan, frameworkId string, planLocation string) error {
+	// Ensure UserWorkspace exists before writing the plan
+	userWorkspace := filepath.Dir(planLocation)
+	if err := os.MkdirAll(userWorkspace, 0700); err != nil {
+		return err
+	}
+
 	// Add the framework property needed for ComplyTime
 	if plan.Metadata.Props == nil {
 		plan.Metadata.Props = &[]oscalTypes.Property{}


### PR DESCRIPTION
## Summary

While reviewing https://github.com/complytime/complytime/pull/60 it was noticed some opportunities to improve the configuration experience using ComplyTime.

This PR introduces two main improvements
- The default value for user workspace is now set to `./complytime` in order to centralize all ComplyTime related files in a single directory separated from unrelated files.
- It is no longer necessary to manually inform the Datastream to be used. Instead, the plugin will try to determine the correct Datastream file based on system information and patterns established by `scap-security-guide` package.
  - It is still possible to manually set a Datastream for exceptional cases.

## Related Issues

- CPLYTM-586

## Review Hints

Commit by commit checking the commit descriptions for more context.
Some unit tests were moved in aligned to their respective functions, but the logic remained the same.
```make test-unit```

It could be also nice to test some different configurations in the manifest file using https://github.com/marcusburghardt/complytime-demos 
