### PR TITLE
fix: plugin loading in the scanning of system

### DIFF
--- a/cmd/complytime/cli/scan.go
+++ b/cmd/complytime/cli/scan.go
@@ -77,10 +77,8 @@ func runScan(cmd *cobra.Command, opts *scanOptions) error {
 	if err != nil {
 		return err
 	}
-	for _, plugin := range plugins {
-		logger.Debug(fmt.Sprintf("Successfully loaded %v plugin.", plugin))
-	}
-	logger.Info("Information successfully retrieved from plugins.")
+	logger.Info(fmt.Sprintf("Successfully loaded %v plugin(s).", len(plugins)))
+
 	// Ensure all the plugins launch above are cleaned up
 	defer manager.Clean()
 


### PR DESCRIPTION
## Summary
This PR addresses feedback from CPLYTM-245 regarding the plugins being loaded in the `complytime scan` command.

## Related Issues

Depends on PR #66 

## Review Hints

- Review commit by commit