### PR TITLE
CPLYTM-242 feat: add arf file to relevent evidences in pvp results

### DIFF
--- a/cmd/openscap-plugin/server/server.go
+++ b/cmd/openscap-plugin/server/server.go
@@ -132,6 +132,12 @@ func (s PluginServer) GetResults(oscalPolicy policy.Policy) (policy.PVPResult, e
 						Reason:      "my reason",
 					},
 				},
+				RelevantEvidences: []policy.Link{
+					{
+						Href:        fmt.Sprintf("file://%s", s.Config.Files.ARF),
+						Description: "ARF_FILE",
+					},
+				},
 			}
 			pvpResults.ObservationsByCheck = append(pvpResults.ObservationsByCheck, observation)
 		}


### PR DESCRIPTION
## Summary
This is a small change to include the `arf.xml` file generated by the openscap-plugin in the PVP results sent back to complytime.  This functionality has been verified in the complytime-demos environment.  The output contained in `assessment-results.json` shown below.  Note the current implementation uses a relative filepath in the users workspace.

```
"relevant-evidence": [
       {
            "description": "ARF_FILE",
            "href": "file://complytime/openscap/results/arf.xml"
       }
],
```

This is the first step towards centralizing evidence generated by plugins.  Future efforts will expand on evidence handling.