### PR TITLE
CPLYTM-612: chore: minor reword on message

### DIFF
--- a/cmd/complytime/cli/generate.go
+++ b/cmd/complytime/cli/generate.go
@@ -88,6 +88,6 @@ func runGenerate(cmd *cobra.Command, opts *generateOptions) error {
 	if err != nil {
 		return err
 	}
-	logger.Info("Policy generation completed successfully.")
+	logger.Info("Policy generation process completed for available plugins.")
 	return nil
 }


### PR DESCRIPTION
## Summary

After fixing C2P to alert instead of return error when there is no validation component for a plugins, the message was slightly updated to be more aligned to the C2P warning. In case no policy was generated, the message should not say that was generated successfully.

## Related Issues

- https://github.com/oscal-compass/compliance-to-policy-go/issues/69
- https://github.com/oscal-compass/compliance-to-policy-go/pull/70

## Review Hints

It can be tested with ComplyTime using the structure of https://github.com/complytime/complytime-demos where the VM is populated with a Component Definition.

After the generate command be finished, it shows
`INFO Policy generation process completed for available plugins.`
instead of 
`INFO Policy generation completed successfully.`
