### PR TITLE
CPLYTM-591 feat: use hclog in openscap-plugin CPLYTM-696 CPLYTM-697

### DIFF
--- a/cmd/openscap-plugin/config/config.go
+++ b/cmd/openscap-plugin/config/config.go
@@ -8,13 +8,14 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"log"
 	"os"
 	"os/user"
 	"path/filepath"
 	"reflect"
 	"regexp"
 	"strings"
+
+	"github.com/hashicorp/go-hclog"
 )
 
 const (
@@ -175,7 +176,7 @@ func ensureDirectory(path string) error {
 		if err != nil {
 			return fmt.Errorf("failed to create directory: %w", err)
 		}
-		log.Printf("Directory created: %s\n", path)
+		hclog.Default().Info("Directory created", "path", path)
 	} else if err != nil {
 		return fmt.Errorf("error checking directory: %w", err)
 	}
@@ -191,7 +192,7 @@ func ensureWorkspace(cfg *Config) (map[string]string, error) {
 
 	workspace, err := validatePath(workspacePath, true)
 	if err != nil {
-		log.Printf("Informed workspace was not found. It will be created.")
+		hclog.Default().Info("Informed workspace was not found. It will be created.")
 		workspace = workspacePath
 	}
 

--- a/cmd/openscap-plugin/main.go
+++ b/cmd/openscap-plugin/main.go
@@ -3,13 +3,26 @@
 package main
 
 import (
+	"github.com/hashicorp/go-hclog"
+
 	"github.com/complytime/complytime/cmd/openscap-plugin/server"
 
 	hplugin "github.com/hashicorp/go-plugin"
 	"github.com/oscal-compass/compliance-to-policy-go/v2/plugin"
 )
 
+var log hclog.Logger
+
+func init() {
+	log = hclog.New(&hclog.LoggerOptions{
+		Name:  "openscap-plugin",
+		Level: hclog.Debug,
+	})
+	hclog.SetDefault(log)
+}
+
 func main() {
+	hclog.Default().Info("Starting OpenSCAP plugin")
 	openSCAPPlugin := server.New()
 	pluginByType := map[string]hplugin.Plugin{
 		plugin.PVPPluginName: &plugin.PVPPlugin{Impl: openSCAPPlugin},

--- a/cmd/openscap-plugin/main.go
+++ b/cmd/openscap-plugin/main.go
@@ -11,14 +11,14 @@ import (
 	"github.com/oscal-compass/compliance-to-policy-go/v2/plugin"
 )
 
-var log hclog.Logger
+var logger hclog.Logger
 
 func init() {
-	log = hclog.New(&hclog.LoggerOptions{
+	logger = hclog.New(&hclog.LoggerOptions{
 		Name:  "openscap-plugin",
 		Level: hclog.Debug,
 	})
-	hclog.SetDefault(log)
+	hclog.SetDefault(logger)
 }
 
 func main() {

--- a/cmd/openscap-plugin/main.go
+++ b/cmd/openscap-plugin/main.go
@@ -3,6 +3,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/hashicorp/go-hclog"
 
 	"github.com/complytime/complytime/cmd/openscap-plugin/server"
@@ -15,8 +17,10 @@ var logger hclog.Logger
 
 func init() {
 	logger = hclog.New(&hclog.LoggerOptions{
-		Name:  "openscap-plugin",
-		Level: hclog.Debug,
+		Name:       "openscap-plugin",
+		Level:      hclog.Debug,
+		Output:     os.Stderr,
+		JSONFormat: true,
 	})
 	hclog.SetDefault(logger)
 }

--- a/cmd/openscap-plugin/oscap/oscap.go
+++ b/cmd/openscap-plugin/oscap/oscap.go
@@ -4,8 +4,9 @@ package oscap
 
 import (
 	"fmt"
-	"log"
 	"os/exec"
+
+	"github.com/hashicorp/go-hclog"
 )
 
 func constructScanCommand(openscapFiles map[string]string, profile string) []string {
@@ -36,7 +37,7 @@ func OscapScan(openscapFiles map[string]string, profile string) ([]byte, error) 
 		return nil, fmt.Errorf("command not found: %s", command[0])
 	}
 
-	log.Printf("Executing the command: '%v'", command)
+	hclog.Default().Info("Executing command", "command", command)
 	cmd := exec.Command(cmdPath, command[1:]...)
 
 	output, err := cmd.CombinedOutput()
@@ -44,10 +45,10 @@ func OscapScan(openscapFiles map[string]string, profile string) ([]byte, error) 
 		if err.Error() == "exit status 1" {
 			return output, fmt.Errorf("%s: oscap error during evaluation", err)
 		} else if err.Error() == "exit status 2" {
-			log.Printf("%s: at least one rule resulted in fail or unknown", err)
+			hclog.Default().Warn("at least one rule resulted in fail or unknown", "err", err)
 			return output, nil
 		} else {
-			log.Printf("%s", err)
+			hclog.Default().Warn("Error", "err", err)
 			return output, nil
 		}
 	}

--- a/cmd/openscap-plugin/server/server.go
+++ b/cmd/openscap-plugin/server/server.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ComplianceAsCode/compliance-operator/pkg/utils"
 	"github.com/antchfx/xmlquery"
+	"github.com/hashicorp/go-hclog"
 	"github.com/oscal-compass/compliance-to-policy-go/v2/policy"
 
 	"github.com/complytime/complytime/cmd/openscap-plugin/config"
@@ -46,7 +47,7 @@ func (s PluginServer) Configure(configMap map[string]string) error {
 }
 
 func (s PluginServer) Generate(policy policy.Policy) error {
-	fmt.Println("Generating a tailoring file")
+	hclog.Default().Info("Generating a tailoring file")
 	tailoringXML, err := xccdf.PolicyToXML(policy, s.Config)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
Use hclog in openscap-plugin

## Review Hints
I decided to use a global logger for simplicity, but wouldn't be opposed to making a log package in the plugin
