### PR TITLE
feat: CPLYTM-659 spike options for interactive editing (WIP)

### DIFF
--- a/cmd/complytime/cli/plan.go
+++ b/cmd/complytime/cli/plan.go
@@ -23,6 +23,7 @@ type planOptions struct {
 	*option.Common
 	complyTimeOpts *option.ComplyTime
 	frameworkID    string
+	updateOpts     *option.UpdatePlan
 }
 
 func setOptsPlanFromArgs(args []string, opts *planOptions) {
@@ -50,6 +51,7 @@ func planCmd(common *option.Common) *cobra.Command {
 		},
 	}
 	planOpts.complyTimeOpts.BindFlags(cmd.Flags())
+	planOpts.updateOpts.BindFlags(cmd.Flags())
 	return cmd
 }
 

--- a/cmd/complytime/cli/table.go
+++ b/cmd/complytime/cli/table.go
@@ -1,0 +1,205 @@
+package cli
+
+import (
+	"fmt"
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"os"
+)
+
+// This example was adapted from charmbracelet/bubbles
+// The original example can be found here:
+// https://github.com/charmbracelet/bubbletea/blob/main/examples/table/main.go
+var baseStyle = lipgloss.NewStyle().
+	BorderStyle(lipgloss.NormalBorder()).
+	BorderForeground(lipgloss.Color("240"))
+
+type model struct {
+	table table.Model
+}
+
+func (m model) Init() tea.Cmd { return nil }
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "esc":
+			if m.table.Focused() {
+				m.table.Blur()
+			} else {
+				m.table.Focus()
+			}
+		case "q", "ctrl+c":
+			return m, tea.Quit
+		case "enter":
+			return m, tea.Batch(
+				tea.Printf("Let's update the %s component: %s.", m.table.SelectedRow()[1], m.table.SelectedRow()[2]),
+			)
+		}
+	}
+	m.table, cmd = m.table.Update(msg)
+	return m, cmd
+}
+
+// parameterTable instantiates a separate table
+// parameterTable instantiates a separate table.
+// Choose to update parameters via command flags.
+func parameterTable() {
+	columns := []table.Column{
+		// Parameter Headers
+		{Title: "Framework ID", Width: 20},
+		{Title: "Component Type", Width: 20},
+		{Title: "Parameters", Width: 20},
+	}
+	rows := []table.Row{
+		{"anssi_bp28_minimal", "Parameter", "param_1"},
+		{"anssi_bp28_minimal", "Parameter", "param_2"},
+		{"anssi_bp28_minimal", "Parameter", "param_3"},
+		{"anssi_bp28_minimal", "Parameter", "param_4"},
+		{"anssi_bp28_minimal", "Parameter", "param_5"},
+		{"anssi_bp28_minimal", "Parameter", "param_6"},
+		{"anssi_bp28_minimal", "Parameter", "param_7"},
+		{"anssi_bp28_minimal", "Parameter", "param_8"},
+		{"anssi_bp28_minimal", "Parameter", "param_9"},
+		{"anssi_bp28_minimal", "Parameter", "param_1"},
+		{"anssi_bp28_minimal", "Parameter", "param_2"},
+	}
+
+	t := table.New(
+		table.WithColumns(columns),
+		table.WithRows(rows),
+		table.WithFocused(true),
+		table.WithHeight(7),
+	)
+
+	s := table.DefaultStyles()
+	s.Header = s.Header.
+		BorderStyle(lipgloss.NormalBorder()).
+		BorderForeground(lipgloss.Color("240")).
+		BorderBottom(true).
+		Bold(false)
+	s.Selected = s.Selected.
+		Foreground(lipgloss.Color("229")).
+		Background(lipgloss.Color("57")).
+		Bold(false)
+	t.SetStyles(s)
+
+	m := model{t}
+	if _, err := tea.NewProgram(m).Run(); err != nil {
+		fmt.Println("Error running program:", err)
+		os.Exit(1)
+	}
+}
+
+// controlsTable instantiates a separate table.
+// Choose to update controls via command flags.
+func controlsTable() {
+	columns := []table.Column{
+		// Control Headers
+		{Title: "Framework ID", Width: 20},
+		{Title: "Component Type", Width: 20},
+		{Title: "Controls", Width: 20},
+	}
+	rows := []table.Row{
+		{"anssi_bp28_minimal", "Control", "control_1"},
+		{"anssi_bp28_minimal", "Control", "control_2"},
+		{"anssi_bp28_minimal", "Control", "control_3"},
+		{"anssi_bp28_minimal", "Control", "control_4"},
+		{"anssi_bp28_minimal", "Control", "control_5"},
+		{"anssi_bp28_minimal", "Control", "control_6"},
+		{"anssi_bp28_minimal", "Control", "control_7"},
+		{"anssi_bp28_minimal", "Control", "control_8"},
+		{"anssi_bp28_minimal", "Control", "control_9"},
+		{"anssi_bp28_minimal", "Control", "control_n"},
+	}
+
+	t := table.New(
+		table.WithColumns(columns),
+		table.WithRows(rows),
+		table.WithFocused(true),
+		table.WithHeight(7),
+	)
+
+	s := table.DefaultStyles()
+	s.Header = s.Header.
+		BorderStyle(lipgloss.NormalBorder()).
+		BorderForeground(lipgloss.Color("240")).
+		BorderBottom(true).
+		Bold(false)
+	s.Selected = s.Selected.
+		Foreground(lipgloss.Color("229")).
+		Background(lipgloss.Color("57")).
+		Bold(false)
+	t.SetStyles(s)
+
+	m := model{t}
+	if _, err := tea.NewProgram(m).Run(); err != nil {
+		fmt.Println("Error running program:", err)
+		os.Exit(1)
+	}
+
+}
+
+// rulesTable instantiates a separate table.
+// Choose to update rules via command flags.
+func rulesTable() {
+	columns := []table.Column{
+		// Rule Headers
+		{Title: "Framework ID", Width: 20},
+		{Title: "Component Type", Width: 20},
+		{Title: "Rules", Width: 20},
+	}
+	rows := []table.Row{
+		{"anssi_bp28_minimal", "Rule", "rule_1"},
+		{"anssi_bp28_minimal", "Rule", "rule_2"},
+		{"anssi_bp28_minimal", "Rule", "rule_3"},
+		{"anssi_bp28_minimal", "Rule", "rule_4"},
+		{"anssi_bp28_minimal", "Rule", "rule_5"},
+		{"anssi_bp28_minimal", "Rule", "rule_6"},
+		{"anssi_bp28_minimal", "Rule", "rule_7"},
+		{"anssi_bp28_minimal", "Rule", "rule_8"},
+		{"anssi_bp28_minimal", "Rule", "rule_9"},
+		{"anssi_bp28_minimal", "Rule", "rule_n"},
+	}
+
+	t := table.New(
+		table.WithColumns(columns),
+		table.WithRows(rows),
+		table.WithFocused(true),
+		table.WithHeight(7),
+	)
+
+	s := table.DefaultStyles()
+	s.Header = s.Header.
+		BorderStyle(lipgloss.NormalBorder()).
+		BorderForeground(lipgloss.Color("240")).
+		BorderBottom(true).
+		Bold(false)
+	s.Selected = s.Selected.
+		Foreground(lipgloss.Color("229")).
+		Background(lipgloss.Color("57")).
+		Bold(false)
+	t.SetStyles(s)
+
+	m := model{t}
+	if _, err := tea.NewProgram(m).Run(); err != nil {
+		fmt.Println("Error running program:", err)
+		os.Exit(1)
+	}
+}
+func (m model) View() string {
+	return baseStyle.Render(m.table.View()) + "\n"
+
+}
+
+// ComponentTable calls the functions for each option.
+// Available components of the assessment plan will print in table.
+// Updates to assessment-plan components will be present in table
+func ComponentTable() {
+	controlsTable()
+	rulesTable()
+	parameterTable()
+}

--- a/cmd/complytime/main.go
+++ b/cmd/complytime/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/complytime/complytime/cmd/complytime/cli"
 )
 
+// Including the COmponentTable()
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()

--- a/cmd/complytime/main.go
+++ b/cmd/complytime/main.go
@@ -12,10 +12,10 @@ import (
 	"github.com/complytime/complytime/cmd/complytime/cli"
 )
 
-// Including the COmponentTable()
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 	complytime := cli.New()
 	cobra.CheckErr(complytime.ExecuteContext(ctx))
+	cli.ComponentTable()
 }

--- a/cmd/complytime/option/common.go
+++ b/cmd/complytime/option/common.go
@@ -34,7 +34,26 @@ type ComplyTime struct {
 	UserWorkspace string
 }
 
+type UpdatePlan struct {
+	Controls   map[string]string
+	Rules      map[string]string
+	Parameters map[string]string
+	Config     string
+	DryRun     bool
+}
+
 // BindFlags populate ComplyTime options from user-specified flags.
 func (o *ComplyTime) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&o.UserWorkspace, "workspace", "w", ".", "workspace to use for artifact generation")
+}
+
+// BindFlags populate UpdatePlan options from user specified flags.
+func (o *UpdatePlan) BindFlags(fs *pflag.FlagSet) {
+	fs.StringP("config", "c", "./config/complytime", "location of complytime bundles and controls in home dir")
+	fs.Bool("dry-run", false, "print table of assessment-plan components to standard output")
+	fs.StringSliceP("update-controls", "u", []string{}, "update control(s) status from 'ready to assess' to 'waived'")
+	fs.StringSlice("exclude-controls", []string{}, "control(s) to exclude from assessment-plan.json")
+	fs.StringSlice("update-rules", []string{}, "update rule(s) status from 'ready to assess' to 'waived'")
+	fs.StringSlice("exclude-rules", []string{}, "rule(s) to exclude from assessment-plan.json")
+	fs.StringSlice("update-parameters", []string{}, "update parameter(s) status from 'ready to assess' to 'waived'")
 }


### PR DESCRIPTION
## Summary

This PR introduces the leverages command flags for editing assessment plans. The flags will update the status of `assessment-plan.json` components from *assessed* to *waived* and allow for excluding components from an assessment plan. This approach will allow for the user to tailor their assessment plan based on their needs.

- `--dry-run`: this flag will print the table of components for the provided `frameworkID` to standard out.
- `--update-controls`: this flag will update the status of the controls from *assessed* to *waived*. 
- `--exclude-controls`: this flag will allow the user to pass values from the printed table of available controls - to be excluded from the assessment plan. 
- `--update-rules`: this flag will update the status of the rules from *assessed* to *waived*. 
- `--exclude-rules`: this flag will allow the user to pass values from the printed table of available rules - to be excluded from the assessment plan. 
- `--update-parameters`: this flag will update the status of the parameters from *assessed* to *waived*. 

## Related Issues

- CPLYTM-659

## Review Hints

#### How the flags will work for editing the assessment-plan fields via ComplyTime CLI

- Running `./bin/complytime plan` will print the command flag options and their respective descriptions. This example will also print tables for each component set specific to the `<frameworkID>` passed to the `plan` command. 
- Using the hot keys `Ctrl+C` will go to the next component of the assessment-plan. If pressing `Enter` for a specific component ID, there will be a message printed to standard out in the form of "Let's update the `component`: `component_id`."

-   **Ex:** Using the `anssib_bp28_minimal` frameworkID and excluding control_1

**Load defaults from FrameworkID**
-     `./bin/complytime plan anssi_bp28_minimal --dry-run`

A list of Controls organized by Control ID will be populated in a table format. The up and down arrows scroll through available controls from the `anssi_bp28_minimal` framework. This procedure is the same for Rules and Parameters.

**Excluding controls from the anssi_bp28_minimal FrameworkID**
-   `complytime plan anssi_bp28_minimal --exclude-controls <control_1>`

The Control IDs can be copied and pasted from StdOut and passed to the command flags. The `<control_1>` passed to `--exclude-controls` would then exclude that control from the `assessment-plan.json`. 

**Ensuring updates were correctly processed**

- `./bin/complytime plan anssi_bp28_minimal --exclude-controls <control_1> --dry-run`
The table should then update with the values for the `anssi_bp28_minimal` controls, but excluding `<control_1>`. The dry-run flag will ultimately take the vues passed to the flags and update the table accordingly. 

**Table Format Example**

- **Table printing:** running `./bin/complytime plan` the command flags will print to StdOut. Notably, `--dry-run` will be the flag that prints a table with the components of the assessment plan to the terminal. 
  -  ![image](https://github.com/user-attachments/assets/ff4715c6-db24-4094-a77d-27fe180a2864)

- **Table printing specific to `frameworkID`:** run `./bin/complytime plan <frameworkid> --dry-run` will print a table separated by component [controls, rules, parameters]. The command flags to update the status or inclusion of a component can be updated based on the table.  
  -  ![image](https://github.com/user-attachments/assets/d87291e6-5bbe-4297-b682-ea602d5f8986)

- Running `./bin/complytime plan anssi_bp28_minimal --dry-run` would show the components in a table format. 
  - ![image](https://github.com/user-attachments/assets/b0a9bf0b-5120-4641-b310-bf34d1779cd0)

-  Passing `--dry-run` to see the controls that were updated or excluded
   - ![image](https://github.com/user-attachments/assets/48cdfd0f-fdf9-405c-9455-cd9cbc5b0200)

- Passing `--dry-run` to see the rules that were updated or excluded
  - ![image](https://github.com/user-attachments/assets/c7e094b2-625a-4979-847a-ffc83afa9e21)

- Passing `--dry-run` to see the parameters that were updated
  - ![image](https://github.com/user-attachments/assets/6646fcc0-07fd-4576-a0db-3f31b6228738)

**Miro Board**
-   ![image](https://github.com/user-attachments/assets/4a3117e2-d3d1-43c5-9572-0a998b2d8e45)
- 
- The [pflag](https://github.com/spf13/pflag) library is used to bind flags related to the `UpdatePlan` structure. 
-  The [charmbracelet](https://charm.sh/libs/) libraries will be used for printing a table of components.
-  The [charmbracelet/bubbles](https://github.com/charmbracelet/bubbles) format is used for presenting the table example.
- [Screen recording link](https://drive.google.com/drive/folders/1cS8D5Z2enU50u54YHNsRu8MfwfhTOi22?usp=drive_link)