### PR TITLE
CPLYTM-672: Include man pages for ComplyTime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ assessment-plan.json
 assessment-results.*
 !**/testdata/assessment-plan.json
 !**/testdata/assessment-results.*
+/docs/man/*.[1-8]

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,16 @@ GO_LD_EXTRAFLAGS :=-X github.com/complytime/complytime/internal/version.version=
 				   -X github.com/complytime/complytime/internal/version.commit="$(GIT_COMMIT)" \
 				   -X github.com/complytime/complytime/internal/version.buildDate="$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')"
 
+MAN_COMPLYTIME = docs/man/complytime.md
+MAN_COMPLYTIME_OUTPUT = docs/man/complytime.1
+MAN_OPENSCAP_CONF = docs/man/c2p-openscap-manifest.md
+MAN_OPENSCAP_CONF_OUTPUT = docs/man/c2p-openscap-manifest.5
+
+man:
+	mkdir -p $(dir $(MAN_COMPLYTIME_OUTPUT)) $(dir $(MAN_OPENSCAP_CONF_OUTPUT))
+	pandoc -s -t man $(MAN_COMPLYTIME) -o $(MAN_COMPLYTIME_OUTPUT)
+	pandoc -s -t man $(MAN_OPENSCAP_CONF) -o $(MAN_OPENSCAP_CONF_OUTPUT)
+
 dev-setup: dev-setup-commit-hooks
 .PHONY: dev-setup
 
@@ -31,6 +41,7 @@ vendor:
 
 clean:
 	@rm -rf ./$(GO_BUILD_BINDIR)/*
+	rm -f $(MAN_COMPLYTIME_OUTPUT) $(MAN_OPENSCAP_CONF_OUTPUT)
 .PHONY: clean
 
 test-unit:

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -4,6 +4,7 @@
 
 - **Go** version 1.20 or higher
 - **Make** (optional, for using the `Makefile` if included)
+- **pandoc** (optional, for generating man pages using the `make man`)
 
 ### Clone the repository
 

--- a/docs/man/c2p-openscap-manifest.md
+++ b/docs/man/c2p-openscap-manifest.md
@@ -1,0 +1,91 @@
+% C2P-OPENSCAP-MANIFEST.JSON(5) ComplyTime OpenSCAP Plugin Configuration
+% Marcus Burghardt <maburgha@redhat.com>
+% April 2025
+
+# NAME
+
+c2p-openscap-manifest.json - Configuration file for the OpenSCAP plugin used by ComplyTime
+
+# DESCRIPTION
+
+This file defines the metadata and runtime configuration options for the `openscap-plugin`, a plugin to be used with `complytime`.
+
+It is a JSON-formatted file typically installed at:
+
+**~/.config/complytime/plugins/c2p-openscap-manifest.json**
+
+# FILE FORMAT
+
+The configuration is a single JSON object with the following top-level keys:
+
+- `metadata`: General plugin information
+- `executablePath`: Name or path of the plugin binary
+- `sha256`: The checksum of the binary (used for integrity checks)
+- `configuration`: An array of runtime configuration options
+
+# FIELDS
+
+## metadata
+
+```json
+{
+  "id": "openscap",
+  "description": "My openscap plugin",
+  "version": "0.0.1",
+  "types": [ "pvp" ]
+}
+```
+
+## executablePath
+
+Path or name of the plugin binary to execute. Typically just:
+
+```json
+"executablePath": "openscap-plugin"
+```
+
+## sha256
+SHA256 checksum of the plugin binary, used for verification.
+
+## configuration
+A list of supported configuration parameters for the plugin.
+
+Each entry includes:
+
+- name: The name of the parameter
+- description: Explanation of its purpose
+- required: Whether this parameter must be provided
+- default (optional): The default value if not specified
+
+# CONFIGURATION OPTIONS
+## workspace (required)
+Directory for writing plugin artifacts.
+
+## profile (required)
+The OpenSCAP profile to run for assessment.
+
+## datastream (optional)
+The OpenSCAP datastream to use. If not set, the plugin will try to determine it based on system information.
+
+## results (optional, default: results.xml)
+The name of the generated results file.
+
+## arf (optional, default: arf.xml)
+The name of the generated ARF file.
+
+## policy (optional, default: tailoring_policy.xml)
+The name of the generated tailoring file.
+
+# EXAMPLE
+```json
+{
+  "workspace": "/tmp/scan",
+  "profile": "xccdf_org.ssgproject.content_profile_cis",
+  "datastream": "/usr/share/ssg-rhel9-ds.xml"
+}
+```
+
+# SEE ALSO
+complytime(1)
+
+See the Upstream project at https://github.com/complytime/complytime for more detailed documentation.

--- a/docs/man/c2p-openscap-manifest.md
+++ b/docs/man/c2p-openscap-manifest.md
@@ -45,7 +45,7 @@ Path or name of the plugin binary to execute. Typically just:
 ```
 
 ## sha256
-SHA256 checksum of the plugin binary, used for verification.
+SHA256 checksum of the plugin binary, used for runtime verification.
 
 ## configuration
 A list of supported configuration parameters for the plugin.

--- a/docs/man/complytime.md
+++ b/docs/man/complytime.md
@@ -1,0 +1,67 @@
+% COMPLYTIME(1) ComplyTime Manual
+% Marcus Burghardt <maburgha@redhat.com>
+% April 2025
+
+# NAME
+
+complytime - ComplyTime CLI perform compliance assessment activities using plugins for different underlying technologies.
+
+# SYNOPSIS
+
+**complytime** [command] [flags]
+
+# DESCRIPTION
+
+ComplyTime CLI leverages OSCAL to perform compliance assessment activities, using plugins for each stage of the lifecycle.
+
+ComplyTime can be extended to support desired policy engines (PVPs) by the use of plugins.
+The plugin acts as the integration between ComplyTime and the PVPs native interface.
+Each plugin is responsible for converting the policy content described in OSCAL into the input format expected by the PVP.
+In addition, the plugin converts the raw results provided by the PVP into the schema used by ComplyTime to generate OSCAL output.
+
+Plugins communicate with ComplyTime via gRPC and can be authored using any preferred language. The plugin acts as the gRPC server while the ComplyTime CLI acts as the client. When a complytime command is run, it invokes the appropriate method served by the plugin.
+
+ComplyTime is built on https://github.com/oscal-compass/compliance-to-policy-go which provides a flexible plugin framework for leveraging OSCAL with various PVPs.
+
+# COMMANDS
+
+**completion**
+Generate the autocompletion script for the specified shell.
+
+**generate**
+Generate PVP policy from an assessment plan.
+
+**help**
+Display help about any command.
+
+**list**
+List information about supported frameworks and components.
+
+**plan**
+Generate a new assessment plan for a given compliance framework ID.
+
+**scan**
+Scan environment with assessment plan.
+
+**version**
+Print the version.
+
+# OPTIONS
+
+**-d**, **--debug**
+Output debug logs.
+
+**-h**, **--help**
+Show help for complytime.
+
+Run **complytime [command] --help** for more information about a specific command.
+
+# SEE ALSO
+
+See the Upstream project at https://github.com/complytime/complytime for more detailed documentation.
+
+See https://github.com/oscal-compass/compliance-to-policy-go project.
+
+# COPYRIGHT
+
+© 2025 Red Hat, Inc. ComplyTime is released under the terms of the Apache-2.0 license.


### PR DESCRIPTION
## Summary

Man pages are essential to provide package local documentation, so this PR introduces two man pages:

- complytime (1)
  - Focus on ComplyTime commands
- c2p-openscap-manifest (5)
  - Focus on openscap-plugin manifest file

## Related Issues

- CPLYTM-672

## Review Hints

You can see how the man would looks like using the following commands:

```
make man
man ./docs/man/complytime.1 
man ./docs/man/c2p-openscap-manifest.5 
```
