### PR TITLE
feat: CPLYTM-659 introducing the config option for assessment plan editing (WIP)

### DIFF
--- a/cmd/complytime/cli/update.go
+++ b/cmd/complytime/cli/update.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-
 )
 
 // Structure for marshalling a go struct into json data
@@ -14,6 +13,7 @@ type Config struct {
 	IncludeControls []string `json:"include_controls"`
 	ControlIds      []string `json:"control_ids"`
 }
+
 // Function called in main that will populate config.json defaults
 func Write() {
 	c := Config{
@@ -43,8 +43,8 @@ func Write() {
 	}
 	// Printing to stdout, WIP
 	fmt.Printf("\nThe encoded file was successfully written to: %v", filepath.Name())
-	fmt.Println("\nframework_id:",c.FrameworkID)
-	fmt.Println("\ncomponents:",c.Components)
+	fmt.Println("\nframework_id:", c.FrameworkID)
+	fmt.Println("\ncomponents:", c.Components)
 	fmt.Println("\ncontrol_ids:", c.ControlIds)
 	fmt.Println("\ninclude_controls:", c.IncludeControls)
 	fmt.Println("\nconfig.json successfully written with updates")

--- a/cmd/complytime/cli/update.go
+++ b/cmd/complytime/cli/update.go
@@ -3,10 +3,11 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"gopkg.in/yaml.v3"
 	"os"
 )
 
-// Structure for marshalling a go struct into json data
+// Config is used for marshalling a go struct into json data.
 type Config struct {
 	FrameworkID     string   `json:"assessment_plan"`
 	Components      string   `json:"components"`
@@ -14,8 +15,46 @@ type Config struct {
 	ControlIds      []string `json:"control_ids"`
 }
 
-// Function called in main that will populate config.json defaults
-func Write() {
+// Configuration formats assessment-plan data as go struct.
+type Configuration struct {
+	FrameworkID     string   `yaml:"assessment_plan"`
+	Components      string   `yaml:"components"`
+	IncludeControls []string `yaml:"include_controls"`
+	ControlIds      []string `yaml:"control_ids"`
+}
+
+// PlanConfigYAML populates the config.yaml from defaults.
+func PlanConfigYAML() {
+	y := Configuration{
+		FrameworkID:     "complytime",
+		Components:      "controls",
+		IncludeControls: []string{"R1", "R2", "R3", "R4", "R5"},
+		ControlIds:      []string{"R1", "R2", "R3", "R4", "R5"},
+	}
+	yamlfile, err := os.Create("config.yaml")
+	if err != nil {
+		fmt.Println(err)
+	}
+	encodeFile := yaml.NewEncoder(yamlfile)
+	err = encodeFile.Encode(y)
+	if err != nil {
+		fmt.Println("There was an error encoding the plan_config.", err)
+	}
+	err = yamlfile.Close()
+	if err != nil {
+		return
+	}
+	fmt.Println("\nConfiguration successfully written to: ", yamlfile.Name())
+	fmt.Println("\nframework_id: ", y.FrameworkID)
+	fmt.Println("\ncomponents: ", y.Components)
+	fmt.Println("\nincluded_controls: ", y.IncludeControls)
+	fmt.Println("\ncontrol_ids: ", y.ControlIds)
+
+}
+
+// PlanConfigJSON populates config.json defaults from data.
+func PlanConfigJSON() {
+
 	c := Config{
 		FrameworkID:     "anssi_bp28_minimal",
 		Components:      "controls",

--- a/cmd/complytime/cli/update.go
+++ b/cmd/complytime/cli/update.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+)
+
+// Structure for marshalling a go struct into json data
+type Config struct {
+	FrameworkID     string   `json:"assessment_plan"`
+	Components      string   `json:"components"`
+	IncludeControls []string `json:"include_controls"`
+	ControlIds      []string `json:"control_ids"`
+}
+// Function called in main that will populate config.json defaults
+func Write() {
+	c := Config{
+		FrameworkID:     "anssi_bp28_minimal",
+		Components:      "controls",
+		IncludeControls: []string{"R1", "R2", "R3", "R4", "R5"},
+		ControlIds:      []string{"R1", "R2", "R3", "R4", "R5"},
+	}
+	filepath, err := os.Create("config.json")
+	if err != nil {
+		fmt.Println("error creating the config.json for updating:", err)
+		panic(err)
+	}
+	defer func(filepath *os.File) {
+		err := filepath.Close()
+		if err != nil {
+			fmt.Println("error closing the config.json for updating:", err)
+			panic(err)
+		}
+	}(filepath)
+
+	encoder := json.NewEncoder(filepath)
+	err = encoder.Encode(c)
+	if err != nil {
+		fmt.Println("error with encoding the config: ", err)
+		panic(err)
+	}
+	// Printing to stdout, WIP
+	fmt.Printf("\nThe encoded file was successfully written to: %v", filepath.Name())
+	fmt.Println("\nframework_id:",c.FrameworkID)
+	fmt.Println("\ncomponents:",c.Components)
+	fmt.Println("\ncontrol_ids:", c.ControlIds)
+	fmt.Println("\ninclude_controls:", c.IncludeControls)
+	fmt.Println("\nconfig.json successfully written with updates")
+}

--- a/cmd/complytime/cli/update.go
+++ b/cmd/complytime/cli/update.go
@@ -23,6 +23,45 @@ type Configuration struct {
 	ControlIds      []string `yaml:"control_ids"`
 }
 
+// PlanData sets up the yaml mapping type for writing to config file.
+// Formats testdata as go struct.
+type PlanData struct {
+	FrameworkID     string   `yaml:"assessment_plan"`
+	Components      []string `yaml:"components"`
+	IncludeControls []string `yaml:"include_controls"`
+	ControlIds      []string `yaml:"control_ids"`
+}
+
+// RelayContent leverages the PlanData structure to populate testdata
+// test data is written to the config.yaml.
+func RelayContent() {
+	ycfg := PlanData{
+		FrameworkID:     "anssi_bp28_minimal",
+		Components:      []string{"rules", "controls", "parameters"},
+		IncludeControls: []string{"R1", "R2"},
+		ControlIds:      []string{"R1", "R2", "R3", "R4", "R5"},
+	}
+	out, err := yaml.Marshal(&ycfg)
+	if err != nil {
+		fmt.Println("error marshalling yaml content: ", err)
+	}
+	fmt.Println(string(out))
+
+	file, err := os.Create("config.yaml")
+	if err != nil {
+		fmt.Println("error, the plan updates couldn't be written: ", err)
+	}
+	defer file.Close()
+
+	// Writing the YAML Data to config.yaml
+	_, err = file.Write(out)
+	if err != nil {
+		fmt.Println("error writing to config: ", err)
+
+	}
+	fmt.Println("The updated plan content was written to config.yaml")
+}
+
 // PlanConfigYAML populates the config.yaml from defaults.
 func PlanConfigYAML() {
 	y := Configuration{

--- a/cmd/complytime/main.go
+++ b/cmd/complytime/main.go
@@ -19,4 +19,5 @@ func main() {
 		cli.Error(fmt.Sprintf("error running complytime: %v", err))
 		os.Exit(1)
 	}
+	cli.Write()
 }

--- a/cmd/complytime/main.go
+++ b/cmd/complytime/main.go
@@ -19,8 +19,6 @@ func main() {
 		cli.Error(fmt.Sprintf("error running complytime: %v", err))
 		os.Exit(1)
 	}
-	// Included for the example printing to stdOut
-	cli.PlanConfigJSON()
-	cli.PlanConfigYAML()
+	// RelayContent will print assessment-plan data to StdOut.
 	cli.RelayContent()
 }

--- a/cmd/complytime/main.go
+++ b/cmd/complytime/main.go
@@ -22,4 +22,5 @@ func main() {
 	// Included for the example printing to stdOut
 	cli.PlanConfigJSON()
 	cli.PlanConfigYAML()
+	cli.RelayContent()
 }

--- a/cmd/complytime/main.go
+++ b/cmd/complytime/main.go
@@ -19,5 +19,7 @@ func main() {
 		cli.Error(fmt.Sprintf("error running complytime: %v", err))
 		os.Exit(1)
 	}
-	cli.Write()
+	// Included for the example printing to stdOut
+	cli.PlanConfigJSON()
+	cli.PlanConfigYAML()
 }


### PR DESCRIPTION
## Summary

This PR introduces the `update.go` file to populate a `config.yaml` in the complytime workspace. The changes made will allow the complytime user to copy and paste the default configuration from StdOut to the command line. Once pasting back to the command line - the default fields can be updated to tailor the assessment plan as preferred. The changes will then be leveraged to update the assessment-plan.  

The default config values are printed to standard out as `key: value` pairs.  The inclusion of both the `config.json` and `config.yaml` are for example purposes. 

## Related Issues

- CPLYTM-659

## Review Hints

-  The data used is for the purpose of an example. The functionality will be transitioned to only `.JSON` or `.yml` for populating the config file.

- Running `go run main.go` will populate the example in the output. 
-   ![image](https://github.com/user-attachments/assets/d26660ec-8ad9-4ad3-a1bc-ef92e59095a8)
-  ![image](https://github.com/user-attachments/assets/2fe75602-313c-4a97-8bee-ba30834392ea)
-   ![image](https://github.com/user-attachments/assets/e0fe3de4-766a-4aed-b20c-98173ca668c6)

**Miro Board**
-  ![image](https://github.com/user-attachments/assets/2ec11000-eb4f-4257-b15e-52696682dd2e)
- [Screen recording link](https://drive.google.com/drive/folders/1ykqQV2YpFK_Ppk982k8B8vojCrlhwFtg?usp=drive_link)

