### PR TITLE
fix: CPLYTM-700 cleanup plugin process on error

### DIFF
--- a/cmd/complytime/cli/generate.go
+++ b/cmd/complytime/cli/generate.go
@@ -79,10 +79,12 @@ func runGenerate(cmd *cobra.Command, opts *generateOptions) error {
 
 	pluginOptions := opts.complyTimeOpts.ToPluginOptions()
 	plugins, cleanup, err := complytime.Plugins(manager, pluginOptions)
+	if cleanup != nil {
+		defer cleanup()
+	}
 	if err != nil {
 		return fmt.Errorf("errors launching plugins: %w", err)
 	}
-	defer cleanup()
 
 	err = manager.GeneratePolicy(cmd.Context(), plugins, planSettings)
 	if err != nil {

--- a/cmd/complytime/cli/scan.go
+++ b/cmd/complytime/cli/scan.go
@@ -91,10 +91,12 @@ func runScan(cmd *cobra.Command, opts *scanOptions) error {
 
 	pluginOptions := opts.complyTimeOpts.ToPluginOptions()
 	plugins, cleanup, err := complytime.Plugins(manager, pluginOptions)
+	if cleanup != nil {
+		defer cleanup()
+	}
 	if err != nil {
 		return fmt.Errorf("errors launching plugins: %w", err)
 	}
-	defer cleanup()
 	logger.Info(fmt.Sprintf("Successfully loaded %v plugin(s).", len(plugins)))
 
 	allResults, err := manager.AggregateResults(cmd.Context(), plugins, planSettings)

--- a/internal/complytime/plugins.go
+++ b/internal/complytime/plugins.go
@@ -58,7 +58,7 @@ func (p PluginOptions) ToMap() map[string]string {
 }
 
 // Plugins launches and configures plugins with the given complytime global options. This function returns the plugin map with the
-// launched plugins, a plugin cleanup function, and an error.
+// launched plugins, a plugin cleanup function, and an error. The cleanup function should be used if it is not nil.
 func Plugins(manager *framework.PluginManager, selections PluginOptions) (map[string]policy.Provider, func(), error) {
 	manifests, err := manager.FindRequestedPlugins()
 	if err != nil {
@@ -70,8 +70,9 @@ func Plugins(manager *framework.PluginManager, selections PluginOptions) (map[st
 		return nil, nil, err
 	}
 	plugins, err := manager.LaunchPolicyPlugins(manifests, configSelections)
+	// Plugin subprocess has now been launched; cleanup always required below
 	if err != nil {
-		return nil, nil, err
+		return nil, manager.Clean, err
 	}
 	return plugins, manager.Clean, nil
 }


### PR DESCRIPTION
## Summary
The plugin process can be started and left running after complytime exits. This change cleans up the plugin process if it is started

## Review Hints
Merge after #80 