### PR TITLE
feat: CPLYTM-659 introducing the config option for assessment plan editing (WIP)

### DIFF
--- a/cmd/complytime/cli/update.go
+++ b/cmd/complytime/cli/update.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-
 )
 
 // Structure for marshalling a go struct into json data
@@ -14,6 +13,7 @@ type Config struct {
 	IncludeControls []string `json:"include_controls"`
 	ControlIds      []string `json:"control_ids"`
 }
+
 // Function called in main that will populate config.json defaults
 func Write() {
 	c := Config{
@@ -43,8 +43,8 @@ func Write() {
 	}
 	// Printing to stdout, WIP
 	fmt.Printf("\nThe encoded file was successfully written to: %v", filepath.Name())
-	fmt.Println("\nframework_id:",c.FrameworkID)
-	fmt.Println("\ncomponents:",c.Components)
+	fmt.Println("\nframework_id:", c.FrameworkID)
+	fmt.Println("\ncomponents:", c.Components)
 	fmt.Println("\ncontrol_ids:", c.ControlIds)
 	fmt.Println("\ninclude_controls:", c.IncludeControls)
 	fmt.Println("\nconfig.json successfully written with updates")

--- a/cmd/complytime/cli/update.go
+++ b/cmd/complytime/cli/update.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+)
+
+// Structure for marshalling a go struct into json data
+type Config struct {
+	FrameworkID     string   `json:"assessment_plan"`
+	Components      string   `json:"components"`
+	IncludeControls []string `json:"include_controls"`
+	ControlIds      []string `json:"control_ids"`
+}
+// Function called in main that will populate config.json defaults
+func Write() {
+	c := Config{
+		FrameworkID:     "anssi_bp28_minimal",
+		Components:      "controls",
+		IncludeControls: []string{"R1", "R2", "R3", "R4", "R5"},
+		ControlIds:      []string{"R1", "R2", "R3", "R4", "R5"},
+	}
+	filepath, err := os.Create("config.json")
+	if err != nil {
+		fmt.Println("error creating the config.json for updating:", err)
+		panic(err)
+	}
+	defer func(filepath *os.File) {
+		err := filepath.Close()
+		if err != nil {
+			fmt.Println("error closing the config.json for updating:", err)
+			panic(err)
+		}
+	}(filepath)
+
+	encoder := json.NewEncoder(filepath)
+	err = encoder.Encode(c)
+	if err != nil {
+		fmt.Println("error with encoding the config: ", err)
+		panic(err)
+	}
+	// Printing to stdout, WIP
+	fmt.Printf("\nThe encoded file was successfully written to: %v", filepath.Name())
+	fmt.Println("\nframework_id:",c.FrameworkID)
+	fmt.Println("\ncomponents:",c.Components)
+	fmt.Println("\ncontrol_ids:", c.ControlIds)
+	fmt.Println("\ninclude_controls:", c.IncludeControls)
+	fmt.Println("\nconfig.json successfully written with updates")
+}

--- a/cmd/complytime/main.go
+++ b/cmd/complytime/main.go
@@ -19,4 +19,5 @@ func main() {
 		cli.Error(fmt.Sprintf("error running complytime: %v", err))
 		os.Exit(1)
 	}
+	cli.Write()
 }


### PR DESCRIPTION
## Summary
This PR introduces the `update.go` file to populate a `config.json` in the complytime workspace. (UPDATING to `.yml`). The changes made will allow for copying and pasting the default config from the terminal to load back to use for the `assessment-plan.json`.
## Related Issues
_Inform any issues relevant to this PR. For example:_

- _Closes #ISSUE_NUMBER_

## Review Hints

- _Review hints here. Replace this text. Don't use the italics format!_

- _Use this optional section to give any relevant information that could help the reviewer to more quickly and assertively understand and test the changes._

- _Good examples are useful commands, if it is better to review all commits together or in a suggested sequence, any relevant discussion in other PRs or issues, etc._
