### PR TITLE
feat: adds creation of remediation files when calling generate method CPLYTM-720 CPLYTM-721

### DIFF
--- a/cmd/openscap-plugin/config/config.go
+++ b/cmd/openscap-plugin/config/config.go
@@ -20,6 +20,9 @@ import (
 
 const (
 	PluginDir      string = "openscap"
+	PolicyDir      string = "policy"
+	ResultsDir     string = "results"
+	RemediationDir string = "remediations"
 	DatastreamsDir string = "/usr/share/xml/scap/ssg/content"
 	SystemInfoFile string = "/etc/os-release"
 )
@@ -197,10 +200,11 @@ func ensureWorkspace(cfg *Config) (map[string]string, error) {
 	}
 
 	directories := map[string]string{
-		"workspace":  workspace,
-		"pluginDir":  filepath.Join(workspace, PluginDir),
-		"policyDir":  filepath.Join(workspace, PluginDir, "policy"),
-		"resultsDir": filepath.Join(workspace, PluginDir, "results"),
+		"workspace":      workspace,
+		"pluginDir":      filepath.Join(workspace, PluginDir),
+		"policyDir":      filepath.Join(workspace, PluginDir, PolicyDir),
+		"resultsDir":     filepath.Join(workspace, PluginDir, ResultsDir),
+		"remediationDir": filepath.Join(workspace, PluginDir, RemediationDir),
 	}
 
 	for key, dir := range directories {

--- a/cmd/openscap-plugin/oscap/oscap.go
+++ b/cmd/openscap-plugin/oscap/oscap.go
@@ -5,9 +5,35 @@ package oscap
 import (
 	"fmt"
 	"os/exec"
+	"path/filepath"
 
+	"github.com/complytime/complytime/cmd/openscap-plugin/config"
 	"github.com/hashicorp/go-hclog"
 )
+
+func executeCommand(command []string) ([]byte, error) {
+	cmdPath, err := exec.LookPath(command[0])
+	if err != nil {
+		return nil, fmt.Errorf("command not found: %s", command[0])
+	}
+
+	hclog.Default().Debug("Executing command", "command", command)
+	cmd := exec.Command(cmdPath, command[1:]...)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if err.Error() == "exit status 1" {
+			return output, fmt.Errorf("%s: oscap error during evaluation", err)
+		} else if err.Error() == "exit status 2" {
+			hclog.Default().Warn("at least one rule resulted in fail or unknown", "err", err)
+			return output, nil
+		} else {
+			hclog.Default().Warn("Error", "err", err)
+			return output, nil
+		}
+	}
+	return output, nil
+}
 
 func constructScanCommand(openscapFiles map[string]string, profile string) []string {
 	datastream := openscapFiles["datastream"]
@@ -32,26 +58,41 @@ func constructScanCommand(openscapFiles map[string]string, profile string) []str
 func OscapScan(openscapFiles map[string]string, profile string) ([]byte, error) {
 	command := constructScanCommand(openscapFiles, profile)
 
-	cmdPath, err := exec.LookPath(command[0])
-	if err != nil {
-		return nil, fmt.Errorf("command not found: %s", command[0])
+	return executeCommand(command)
+}
+
+func constructGenerateFixCommand(fixType string, output string, profile string, tailoringFile string, datastream string) []string {
+
+	cmd := []string{
+		"oscap",
+		"xccdf",
+		"generate",
+		"fix",
+		"--fix-type", fixType,
+		"--output", output,
+		"--profile", profile,
+		"--tailoring-file", tailoringFile,
+		datastream,
+	}
+	return cmd
+}
+
+func OscapGenerateFix(pluginDir string, profile string, policyFile string, datastream string) error {
+	fixTypes := map[string]string{
+		"bash":      "remediation-script.sh",
+		"ansible":   "remediation-playbook.yml",
+		"blueprint": "remediation-blueprint.toml",
 	}
 
-	hclog.Default().Info("Executing command", "command", command)
-	cmd := exec.Command(cmdPath, command[1:]...)
-
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		if err.Error() == "exit status 1" {
-			return output, fmt.Errorf("%s: oscap error during evaluation", err)
-		} else if err.Error() == "exit status 2" {
-			hclog.Default().Warn("at least one rule resulted in fail or unknown", "err", err)
-			return output, nil
-		} else {
-			hclog.Default().Warn("Error", "err", err)
-			return output, nil
+	for fixType, outputFile := range fixTypes {
+		outputPath := filepath.Join(pluginDir, config.RemediationDir, outputFile)
+		hclog.Default().Debug("Generating remedation file %s", outputPath)
+		command := constructGenerateFixCommand(fixType, outputPath, profile, policyFile, datastream)
+		_, err := executeCommand(command)
+		if err != nil {
+			return err
 		}
-	}
 
-	return output, nil
+	}
+	return nil
 }

--- a/cmd/openscap-plugin/oscap/oscap_test.go
+++ b/cmd/openscap-plugin/oscap/oscap_test.go
@@ -52,3 +52,44 @@ func TestConstructScanCommand(t *testing.T) {
 
 // In a more advanced stage we could add tests for the OscapScan function using a minimalistic
 // version of a OpenSCAP Datastream, but for now it's not implemented.
+
+func TestConstructGenerateFixCommand(t *testing.T) {
+	tests := []struct {
+		name          string
+		fixType       string
+		output        string
+		profile       string
+		tailoringFile string
+		datastream    string
+		expectedCmd   []string
+	}{
+		{
+			name:          "Genereate fix command construction",
+			fixType:       "bash",
+			output:        "test-remediation-script.sh",
+			profile:       "test-profile",
+			tailoringFile: "test-policy.xml",
+			datastream:    "test-datastream.xml",
+			expectedCmd: []string{
+				"oscap",
+				"xccdf",
+				"generate",
+				"fix",
+				"--fix-type", "bash",
+				"--output", "test-remediation-script.sh",
+				"--profile", "test-profile",
+				"--tailoring-file", "test-policy.xml",
+				"test-datastream.xml",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := constructGenerateFixCommand(tt.fixType, tt.output, tt.profile, tt.tailoringFile, tt.datastream)
+			if !reflect.DeepEqual(cmd, tt.expectedCmd) {
+				t.Errorf("constructGenerateFixCommand() = %v, expected %v", cmd, tt.expectedCmd)
+			}
+		})
+	}
+}

--- a/cmd/openscap-plugin/server/server.go
+++ b/cmd/openscap-plugin/server/server.go
@@ -65,9 +65,10 @@ func (s PluginServer) Generate(policy policy.Policy) error {
 	}
 
 	// Generate remedation files
+	hclog.Default().Info(("Generating remediation files"))
 	pluginDir := filepath.Join(s.Config.Files.Workspace, config.PluginDir)
-	_, errs := oscap.OscapGenerateFix(pluginDir, s.Config.Parameters.Profile, s.Config.Files.Policy, s.Config.Files.Datastream)
-	if errs != nil {
+	err = oscap.OscapGenerateFix(pluginDir, s.Config.Parameters.Profile, s.Config.Files.Policy, s.Config.Files.Datastream)
+	if err != nil {
 		return err
 	}
 	return nil

--- a/cmd/openscap-plugin/server/server.go
+++ b/cmd/openscap-plugin/server/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/oscal-compass/compliance-to-policy-go/v2/policy"
 
 	"github.com/complytime/complytime/cmd/openscap-plugin/config"
+	"github.com/complytime/complytime/cmd/openscap-plugin/oscap"
 	"github.com/complytime/complytime/cmd/openscap-plugin/scan"
 	"github.com/complytime/complytime/cmd/openscap-plugin/xccdf"
 )
@@ -60,6 +61,13 @@ func (s PluginServer) Generate(policy policy.Policy) error {
 	}
 	defer dst.Close()
 	if _, err := dst.WriteString(tailoringXML); err != nil {
+		return err
+	}
+
+	// Generate remedation files
+	pluginDir := filepath.Join(s.Config.Files.Workspace, config.PluginDir)
+	_, errs := oscap.OscapGenerateFix(pluginDir, s.Config.Parameters.Profile, s.Config.Files.Policy, s.Config.Files.Datastream)
+	if errs != nil {
 		return err
 	}
 	return nil

--- a/docs/PLUGIN_GUIDE.md
+++ b/docs/PLUGIN_GUIDE.md
@@ -43,7 +43,7 @@ Check the quick start [guide](QUICK_START.md) to see an example.
 
 ### Directory Naming Conventions
 
-In order to support automated aggregation of output files from multiple plugins the following directory names are excected by ComplyTime:
+In order to support automated aggregation of output files from multiple plugins the following directory names are expected by ComplyTime:
 
 **Note:** The `workspace` path will be provided by ComplyTime via the [configuration](https://github.com/complytime/complytime/blob/6cf2e92aff852119bba83e579e2c6d8700e4bcec/internal/complytime/plugins.go#L72) and represents the user's desired working directory for all ComplyTime activities.
 

--- a/docs/PLUGIN_GUIDE.md
+++ b/docs/PLUGIN_GUIDE.md
@@ -41,6 +41,15 @@ Check the quick start [guide](QUICK_START.md) to see an example.
 }
 ```
 
+### Directory Naming Conventions
+
+In order to support automated aggregation of output files from multiple plugins the following directory names are excected by ComplyTime:
+
+**Note:** The `workspace` path will be provided by ComplyTime via the [configuration](https://github.com/complytime/complytime/blob/6cf2e92aff852119bba83e579e2c6d8700e4bcec/internal/complytime/plugins.go#L72) and represents the user's desired working directory for all ComplyTime activities.
+
+- `{workspace}/{plugin name}/results` # files for evidence collection
+- `{workspace}/{plugin name}/remediations` # files for automated remediation 
+
 ### Plugin Selection
 
 ComplyTime generates a mapping of plugins to validation components at runtime.
@@ -81,3 +90,4 @@ func (s PluginServer) GetResults(p policy.Policy) (policy.PVPResult, error) {
 
 }
 ```
+


### PR DESCRIPTION
## Summary
This PR adds functionality to generate remediation files when the `Genereate()` method is invoked on the OpenScap plugin.  Remediation files for bash, ansible, and imagebuilder are created using the `oscap xccdf generate fix` command.  Files are placed in the `workspace/openscap/remediations` directory.

## Review Hints

Functionality can be tested with `complytime-demos`. 

https://github.com/complytime/complytime/commit/1668c19e6f4ef45dd24d2b46e91dba8cd7c62d6a contains all the changes
https://github.com/complytime/complytime/commit/6312300d72e6a9cde1d294d77e477640a0bbf033 just adds a log statement and a fix