### PR TITLE
fix: ensure cosign can obtain a token for fulcio

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,8 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
+      contents: write # for github releases
+      id-token: write # for keyless signing
 
     steps:
       - name: Validate Tag
@@ -51,3 +52,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ github.event.inputs.tag }}
+        continue-on-error: false

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,5 +1,16 @@
 # Installation
 
+## Binary
+
+- The latest binary release can be downloaded from <https://github.com/complytime/complytime/releases/latest>.
+- The release signature can be verified with:
+  ```
+  cosign verify-blob --certificate complytime_*_checksums.txt.pem --signature complytime_*_checksums.txt.sig complytime_*_checksums.txt --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/complytime/complytime/.github/workflows/release.yml@refs/heads/main
+  ```
+
+
+## From Source
+
 ### Prerequisites
 
 - **Go** version 1.20 or higher


### PR DESCRIPTION
## Summary

The id-token permission is necessary for this job in order to use OIDC.
The permission is limited to this workflow during the job execution.

## Related Issues

- https://github.com/complytime/complytime/actions/runs/14779558804/job/41540111630#step:7:353
  - it is expecting an interactive authentication via browser, which timeouts after 5 minutes making the job to fail.

## Review Hints

- https://docs.sigstore.dev/quickstart/quickstart-ci/
- https://docs.sigstore.dev/cosign/signing/git_support/?#signing-and-verification