### PR TITLE
Fix broken link to OSCAL Assessment Plan model

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ ComplyTime leverages [OSCAL](https://github.com/usnistgov/OSCAL/) to perform com
 
 ### Basic Usage
 
-Determine the baseline you want to run a scan for and create an OSCAL [Assessment Plan](https://pages.nist.gov/OSCAL/resources/concepts/layer/assessment/assessment-plan/). The Assessment
+Determine the baseline you want to run a scan for and create an OSCAL [Assessment Plan](https://pages.nist.gov/OSCAL/learn/concepts/layer/assessment/assessment-plan/). The Assessment
 Plan will act as configuration to guide the ComplyTime generation and scanning operations.
 
 ```bash


### PR DESCRIPTION
While perusing the README, I noticed the current link to the OSCAL
documentation for Assessment Plans returns a 404. This commit updates
the link to one that works.
