### PR TITLE
CPLYTM-741 update observation subject to inventory item

### DIFF
--- a/complytime.spec
+++ b/complytime.spec
@@ -69,9 +69,12 @@ make test-unit
 %doc %{_mandir}/man5/c2p-openscap-manifest.5*
 
 %changelog
+<<<<<<< HEAD
 * Tue May 6 2025 Qingmin Duanmu <qduanmu@redhat.com>
 - Add complytime and openscap plugin man pages
 
+=======
+>>>>>>> 5631ccf (feat: update ApplicationDirectory for plugin manifest)
 * Wed Apr 30 2025 Qingmin Duanmu <qduanmu@redhat.com>
 - Separate plugin binary from manifest
 


### PR DESCRIPTION
## Summary

This PR updates the `Subject` of each `ObservationByCheck` to be an OSCAL inventory-item.  These inventory items will then be processed by compliance-to-policy-go and added to the AssessmentResults LocalDefinitions object.

The `inventory-item` is meant to represent the host that is being assessed by complytime.  The hostname is being extracted from the `arf.xml` target attribute.

## Review Hints

https://github.com/complytime/complytime/pull/119/commits/d931f0872279f9fc7fe1cd72f242fc72e246b57f contains the changes for this PR

