### PR TITLE
chore: updates quick start sample content and script

### DIFF
--- a/docs/samples/sample-catalog.json
+++ b/docs/samples/sample-catalog.json
@@ -7,7 +7,6 @@
       "version": "REPLACE_ME",
       "oscal-version": "1.1.2"
     },
-    "params": [],
     "groups": [
       {
         "id": "r1",
@@ -17,7 +16,6 @@
             "id": "r1",
             "class": "CAC_IMPORT",
             "title": "Hardware Support",
-            "params": [],
             "props": [
               {
                 "name": "label",
@@ -40,4 +38,3 @@
     ]
   }
 }
-

--- a/docs/samples/sample-component-definition.json
+++ b/docs/samples/sample-component-definition.json
@@ -48,13 +48,13 @@
               {
                 "name": "Framework_Short_Name",
                 "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal/cd",
-                "value": "example"
+                "value": "anssi_bp28_minimal"
               }
             ],
             "implemented-requirements": [
               {
                 "uuid": "ed2ac4e9-d16a-4fc5-bd3a-13484b6d8fef",
-                "control-id": "most_important_requirement",
+                "control-id": "r1",
                 "description": "My example implemented requirement.",
                 "props": [
                   {

--- a/docs/samples/sample-profile.json
+++ b/docs/samples/sample-profile.json
@@ -1,9 +1,9 @@
 {
   "profile": {
-    "uuid": "0c546fdb-f2d2-4c94-8a03-32b86d37800b",
+    "uuid": "ea41314b-8594-4df9-9ad4-65133a660a44",
     "metadata": {
-      "title": "Example Profile (low)",
-      "last-modified": "2025-02-05T08:56:16.664181-05:00",
+      "title": "anssi-minimal",
+      "last-modified": "2025-02-20T14:01:42.642957+01:00",
       "version": "REPLACE_ME",
       "oscal-version": "1.1.2"
     },
@@ -13,7 +13,7 @@
         "include-controls": [
           {
             "with-ids": [
-              "most_important_requirement"
+              "r1"
             ]
           }
         ]

--- a/scripts/quick_start/Containerfile
+++ b/scripts/quick_start/Containerfile
@@ -1,5 +1,7 @@
 FROM registry.access.redhat.com/ubi9/ubi:9.5
 ARG RHEL_APPS_REPO
+ARG REPO
+ARG BRANCH
 COPY quick_start.sh /quick_start.sh
 ENV RHEL_APPS_REPO=${RHEL_APPS_REPO}
 ENV COMPLYTIME_DEV_MODE=1

--- a/scripts/quick_start/README.md
+++ b/scripts/quick_start/README.md
@@ -46,7 +46,7 @@ sh quick_start.sh
 Now you could explore Complytime CLIs:
 ```bash
 complytime list
-complytime plan example
+complytime plan anssi_bp28_minimal
 complytime generate
 complytime scan
 ```

--- a/scripts/quick_start/quick_start.sh
+++ b/scripts/quick_start/quick_start.sh
@@ -49,7 +49,9 @@ source ~/.bash_profile
 
 # Install and build complytime
 echo "Cloning the Complytime repository..."
-git clone https://github.com/complytime/complytime.git
+complytimerepo="${REPO:-"https://github.com/complytime/complytime"}"
+complytimebranch="${BRANCH:-"main"}"
+git clone -b ${complytimebranch} ${complytimerepo}
 cd complytime && make build && cp ./bin/complytime /usr/local/bin
 echo "Complytime installed successfully!"
 # Run complytime list to create the workspace

--- a/scripts/quick_start/quick_start.sh
+++ b/scripts/quick_start/quick_start.sh
@@ -41,9 +41,9 @@ rm -rf /usr/bin/go
 go_mod="https://raw.githubusercontent.com/complytime/complytime/main/go.mod"
 go_version=$(curl -s $go_mod | grep '^go' | awk '{print $2}')
 go_tar_file=go$go_version.linux-amd64.tar.gz
-wget https://go.dev/dl/$go_tar_file
-tar -C /usr/local -xvzf $go_tar_file
-rm -rf $go_tar_file
+wget "https://go.dev/dl/$go_tar_file"
+tar -C /usr/local -xvzf "$go_tar_file"
+rm -rf "$go_tar_file"
 export PATH=$PATH:/usr/local/go/bin
 source ~/.bash_profile
 
@@ -51,7 +51,7 @@ source ~/.bash_profile
 echo "Cloning the Complytime repository..."
 complytimerepo="${REPO:-"https://github.com/complytime/complytime"}"
 complytimebranch="${BRANCH:-"main"}"
-git clone -b ${complytimebranch} ${complytimerepo}
+git clone -b "${complytimebranch}" "${complytimerepo}"
 cd complytime && make build && cp ./bin/complytime /usr/local/bin
 echo "Complytime installed successfully!"
 # Run complytime list to create the workspace


### PR DESCRIPTION
## Summary

- Updates the framework id in the component definition to anssi
- Makes the repo and branch configuration so we can test using the quick start during PR review

## Related Issues

When running the `quickstart.sh` with podman. The generate step fails because the `example` profile is not a valid profile in the datastream.

## Review Hints

To test - run the following steps:

```bash
podman build --build-arg RHEL_APPS_REPO=${RHEL_APPS_REPO} REPO="https://github.com/complytime/complytime.git" --build-arg BRANCH="fix/quickstart" . -t quick-start:latest
```
`podman run -it quick-start:latest`
```bash
complytime list
complytime plan anssi_bp28_minimal
complytime generate
complytime scan
```


