### PR TITLE
docs: CPLYTM-783 updating complytime plan flag references

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,18 @@ complytime plan <framework-id>
 ...
 # The file will be written out to assessment-plan.json in the specified workspace.
 # Defaults to current working directory.
+
 cat assessment-plan.json
+# The default assessment-plan.json will be available in the complytime workspace (complytime/assessment-plan.json).
+
+complytime plan <framework-id> --dry-run 
+# See the default contents of the assessment-plan.json.
+
+complytime plan <framework-id> --dry-run --out config.yml
+# Customize the assessment-plan.json with the "out" flag. Updates can be made in the config.yml. 
+
+complytime plan <framework-id> --with-config config.yml
+# The config.yml will be loaded when passing "with-config" to customize the assessment-plan.json. 
 ```
 
 Run the generate command to `generate` policy artifacts in the workspace and run the `scan` command to execute the generated artifacts and get results.


### PR DESCRIPTION
## Summary

This PR aligns the `complytime plan` documentation with the updates made for users to edit the controls of their `assessment-plan.json`. 

## Related Issues

-  Documentation coupled with PR #134 

## Review Hints

- The updates are coupled with PR #134 to document running the commands listed below
-  `complytime plan <frameworkid> --dry-run config.yml` 
- `complytime plan <frameworkid> --with-config config.yml` the `config.yml` 

