### PR TITLE
chore: updated CODEOWNERS for changes in openscap-plugin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,10 +4,12 @@
 *       @complytime/complytime-dev
 
 # Order is important; the last matching pattern takes the most precedence.
-# Team complytime-approvers will be requested for approvers when someone
-# opens a pull request for any change inside `/cmd/complytime` directory
+# Team complytime-approvers will be requested to approve when someone opens
+# a pull request for any change inside `/cmd/complytime` directory
 /cmd/complytime/ @complytime/complytime-approvers
 
-# Team openscap-plugin-approvers will be requested for approvers when someone
-# opens a pull request for any change inside `/cmd/openscap-plugin` directory
-/cmd/openscap-plugin/ @complytime/openscap-plugin-approvers
+# Team openscap-plugin-approvers will be requested to approve when someone
+# opens a pull request for any change inside `/cmd/openscap-plugin` directory.
+# However, complytime-approvers can also satisfy this requirement in absence of
+# enough approvers from openscap-plugin-approvers
+/cmd/openscap-plugin/ @complytime/openscap-plugin-approvers @complytime/complytime-approvers


### PR DESCRIPTION
## Summary

Initially there were people dedicated to work with `openscap-plugin`.
Along the time, other ComplyTime developers got involved with the plugin and can also approve changes.
The `openscap-approvers` team was kept in order to preserve the granularity of permissions.

## Related Issues

- No technical issues, but more a reflection of the current state.

## Review Hints

The CODEOWNERS syntax can be checked here: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file