### PR TITLE
Automation for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,22 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "weekly"
-    allow:
-      - dependency-type: "all"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      patch-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,3 @@
+security-update:
+  - body: 'github.com/advisories/GHSA'
+  - title: '\(Security\)'

--- a/.github/workflows/dependabot-auto-review.yml
+++ b/.github/workflows/dependabot-auto-review.yml
@@ -7,23 +7,36 @@ on:
       - main
 
 permissions:
-  pull-requests: write # Needed for auto-approving
-  contents: write      # Needed for github/labeler to add labels if not already present
+  contents: read
   issues: write        # Explicitly grant write access to issues for labeling
+  pull-requests: write # Needed for auto-approving
 
 jobs:
   auto-approve-and-label:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
+      - name: Get Versions From Commit Message
+        id: commit_msg
+        run: |
+          COMMIT_SHA=$(jq -r '.pull_request.head.sha' "$GITHUB_EVENT_PATH")
+          COMMIT_MSG=$(git log --format=%s -n 1 $COMMIT_SHA)
+
+          versions=$(echo "$COMMIT_MSG" | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
+          read -r current new <<< "$versions"
+          echo "CURRENT_VERSION=$current" >> $GITHUB_ENV
+          echo "NEW_VERSION=$new" >> $GITHUB_ENV
+
       - name: Classify Dependabot PR
         id: classify_pr
         run: |
-          if [[ "${{ github.event.pull_request.title }}" =~ "bump" ]]; then
-            versions=$(echo "${{ github.event.pull_request.title }}" | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
-            read -r current new <<< "$versions"
-            IFS='.' read -r c_major c_minor c_patch <<< "$current"
-            IFS='.' read -r n_major n_minor n_patch <<< "$new"
+          if [[ -z "${{ env.CURRENT_VERSION }}" || -z "${{ env.NEW_VERSION }}" ]]; then
+            echo "No version information found in commit message. Defaulting to high risk."
+            echo "RISK=high" >> $GITHUB_ENV
+            exit 0
+          else
+            IFS='.' read -r c_major c_minor c_patch <<< "${{ env.CURRENT_VERSION }}"
+            IFS='.' read -r n_major n_minor n_patch <<< "${{ env.NEW_VERSION }}"
             if [[ "$c_major" -eq "$n_major" && "$c_minor" -eq "$n_minor" ]]; then
               echo "Patch update detected. Safe to auto-approve."
               echo "RISK=low" >> $GITHUB_ENV
@@ -34,9 +47,6 @@ jobs:
               echo "Major update detected. Requires manual review."
               echo "RISK=high" >> $GITHUB_ENV
             fi
-          else
-            echo "No version bump detected. Defaulting to high risk."
-            echo "RISK=high" >> $GITHUB_ENV
           fi
 
       - name: Auto-approve Dependabot PR
@@ -58,5 +68,4 @@ jobs:
       - name: Add labels if necessary
         uses: github/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
           sync-labels: true

--- a/.github/workflows/dependabot-auto-review.yml
+++ b/.github/workflows/dependabot-auto-review.yml
@@ -1,0 +1,62 @@
+name: Dependabot Auto-Review and Label
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+    branches:
+      - main
+
+permissions:
+  pull-requests: write # Needed for auto-approving
+  contents: write      # Needed for github/labeler to add labels if not already present
+  issues: write        # Explicitly grant write access to issues for labeling
+
+jobs:
+  auto-approve-and-label:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Classify Dependabot PR
+        id: classify_pr
+        run: |
+          if [[ "${{ github.event.pull_request.title }}" =~ "bump" ]]; then
+            versions=$(echo "${{ github.event.pull_request.title }}" | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
+            read -r current new <<< "$versions"
+            IFS='.' read -r c_major c_minor c_patch <<< "$current"
+            IFS='.' read -r n_major n_minor n_patch <<< "$new"
+            if [[ "$c_major" -eq "$n_major" && "$c_minor" -eq "$n_minor" ]]; then
+              echo "Patch update detected. Safe to auto-approve."
+              echo "RISK=low" >> $GITHUB_ENV
+            else if [[ "$c_major" -eq "$n_major" && "$c_minor" -lt "$n_minor" ]]; then
+              echo "Minor update detected. Safe to auto-approve but requires maintainer review."
+              echo "RISK=medium" >> $GITHUB_ENV
+            else
+              echo "Major update detected. Requires manual review."
+              echo "RISK=high" >> $GITHUB_ENV
+            fi
+          else
+            echo "No version bump detected. Defaulting to high risk."
+            echo "RISK=high" >> $GITHUB_ENV
+          fi
+
+      - name: Auto-approve Dependabot PR
+        id: auto_approve_pr
+        # Only auto-approve if the risk is low or medium
+        if: ${{ env.RISK != 'high' }}
+        uses: actions/github-script@26f1c243f728c0b568f97b198103c800b46487e5 # v7.0.1
+        with:
+          script: |
+            github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              event: 'APPROVE',
+              body: 'Automatically approved by GitHub Action for Dependabot PRs.'
+            });
+            console.log('Dependabot PR approved successfully.');
+
+      - name: Add labels if necessary
+        uses: github/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: true


### PR DESCRIPTION
## Summary

This PR includes changes related to dependabot PRs in order to make the dependencies management easier for maintainers.

First, the dependabot settings were reviewed and refined:
- Increase the frequency check for github-actions and use a "ci" prefix.
- Remove unnecessary "allow" since default values have the same effect.
- Group dependencies which are patch only for more efficient review.
- Increase PR limit for non-security updates.

Secondly, it was included a new workflow to auto-approve PRs with low and medium risk:

- Identify the version change and classify the risk for based on major,  minor or patch updates.
- If the risk is low or medium, auto-approve the PR and wait for a maintainer (human) to also review.
- If the risk is high, two maintainers need to approve.
- If the PR indicates a security update, add a label for faster triage.

## Related Issues

Review of dependabot PRs are overwhelming. We can save time with low risk PRs and focus more on high risk.

## Review Hints

Basically the official documentation can be used to validate settings:

- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
- https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates
- https://github.com/actions/labeler

This is a continuous improvement. Lets observe and adapt.
Commit messages can give more context.