### PR TITLE
ci: include test to check dependencies in PRs

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,0 +1,15 @@
+name: Dependency Review
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1


### PR DESCRIPTION
## Summary

Scans pull requests for dependency changes, and raise an error if any vulnerabilities or invalid licenses are being introduced.

## Related Issues

The goal is to catch any dependency issues in a earlier stage, potentially reducing the volume of dependabot PRs.
This can also support maintainers during the review process of PRs.

## Review Hints

The supporting documentation can be found here:
- https://github.com/actions/dependency-review-action

It was intentional to use default configuration at this point. Lets observe and refine on demand.