### PR TITLE
CPLYTM-237 fix: applies fixes to broken build and UX

### DIFF
--- a/cmd/complytime/cli/plan.go
+++ b/cmd/complytime/cli/plan.go
@@ -21,6 +21,9 @@ import (
 
 const assessmentPlanLocation = "assessment-plan.json"
 
+// TODO: `assessmentPlanFilterLocation` is generic, but can be input based on the user preference
+const assessmentPlanFilterLocation = "config.yml"
+
 // PlanOptions defines options for the "plan" subcommand
 type planOptions struct {
 	*option.Common

--- a/cmd/complytime/cli/plan.go
+++ b/cmd/complytime/cli/plan.go
@@ -21,9 +21,6 @@ import (
 
 const assessmentPlanLocation = "assessment-plan.json"
 
-// TODO: `assessmentPlanFilterLocation` is generic, but can be input based on the user preference
-const assessmentPlanFilterLocation = "config.yml"
-
 // PlanOptions defines options for the "plan" subcommand
 type planOptions struct {
 	*option.Common
@@ -34,15 +31,20 @@ type planOptions struct {
 
 	// WithConfig "config.yml" to customize the generated assessment plan
 	withConfig string
+
+	// Out
+	Output string
 }
 
 var planExample = `
-	# The default behavior is to prepare a default assessment plan with all defined
-    # controls within the framework in scope
+	# The default behavior is to prepare a default assessment plan with all defined controls within the framework in scope
 	complytime plan myframework
 
 	# To customize the assessment plan, run in dry-run mode
-	complytime plan myframework --dry-run > config.yml
+	complytime plan myframework --dry-run
+
+	# To customize the assessment plan and write to a file, run in dry-run mode with out.
+	complytime plan myframework --dry-run --out config.yml
 
 	# Alter the configuration and use it as input for plan customization
 	complytime plan myframework --with-config config.yml
@@ -68,8 +70,10 @@ func planCmd(common *option.Common) *cobra.Command {
 			return runPlan(cmd, planOpts)
 		},
 	}
-	cmd.Flags().BoolVarP(&planOpts.dryRun, "dry-run", "d", false, "load the defaults and print the config to stdout")
+	cmd.Flags().BoolVar(&planOpts.dryRun, "dry-run", false, "load the defaults and print the config to stdout")
 	cmd.Flags().StringVarP(&planOpts.withConfig, "with-config", "c", "", "load config.yml to customize the generated assessment plan")
+	// FIXME: Check that dry-run is set of the user pass this in
+	cmd.Flags().StringVarP(&planOpts.Output, "out", "o", "-", "path to output file. Use '-' for stdout. Default '-'.")
 	planOpts.complyTimeOpts.BindFlags(cmd.Flags())
 	return cmd
 }
@@ -90,7 +94,7 @@ func runPlan(cmd *cobra.Command, opts *planOptions) error {
 
 	if opts.dryRun {
 		// Write the plan configuration to stdout
-		return planDryRun(opts.complyTimeOpts.FrameworkID, componentDefs)
+		return planDryRun(opts.complyTimeOpts.FrameworkID, componentDefs, opts.Output)
 	}
 
 	logger.Debug(fmt.Sprintf("Using bundle directory: %s for component definitions.", appDir.BundleDir()))
@@ -107,7 +111,7 @@ func runPlan(cmd *cobra.Command, opts *planOptions) error {
 		// stdout if desired.
 
 		// TODO: HB - updated location for reading file - may need change for variable name
-		configBytes, err := os.ReadFile(filepath.Join(opts.withConfig))
+		configBytes, err := os.ReadFile(filepath.Clean(opts.withConfig))
 		if err != nil {
 			return fmt.Errorf("error reading assessment plan: %w", err)
 		}
@@ -115,8 +119,7 @@ func runPlan(cmd *cobra.Command, opts *planOptions) error {
 		if err := yaml.Unmarshal(configBytes, &assessmentScope); err != nil {
 			return fmt.Errorf("error unmarshaling assessment plan: %w", err)
 		}
-		assessmentScope.Logger = logger
-		assessmentScope.ApplyScope(assessmentPlan)
+		assessmentScope.ApplyScope(assessmentPlan, logger)
 	}
 
 	filePath := filepath.Join(opts.complyTimeOpts.UserWorkspace, assessmentPlanLocation)
@@ -147,8 +150,8 @@ func loadPlan(opts *option.ComplyTime, validator validation.Validator) (*oscalTy
 
 // planDryRun leverages the AssessmentScope structure to populate tailoring config.
 // The config is written to stdout.
-func planDryRun(frameworkId string, cds []oscalTypes.ComponentDefinition) error {
-	baseScope := plan.NewAssessmentScope(frameworkId, nil)
+func planDryRun(frameworkId string, cds []oscalTypes.ComponentDefinition, output string) error {
+	baseScope := plan.NewAssessmentScope(frameworkId)
 	if cds == nil {
 		return fmt.Errorf("no component definitions found")
 	}
@@ -189,10 +192,15 @@ func planDryRun(frameworkId string, cds []oscalTypes.ComponentDefinition) error 
 		}
 	}
 
-	out, err := yaml.Marshal(&baseScope)
+	data, err := yaml.Marshal(&baseScope)
 	if err != nil {
 		return fmt.Errorf("error marshalling yaml content: %v", err)
 	}
-	fmt.Println(string(out))
+
+	if output == "-" {
+		fmt.Fprintln(os.Stdout, string(data))
+	} else {
+		return os.WriteFile(output, data, 0600)
+	}
 	return nil
 }

--- a/cmd/complytime/cli/plan.go
+++ b/cmd/complytime/cli/plan.go
@@ -37,17 +37,17 @@ type planOptions struct {
 }
 
 var planExample = `
-	# The default behavior is to prepare a default assessment plan with all defined controls within the framework in scope
-	complytime plan myframework
+# The default behavior is to prepare a default assessment plan with all defined controls within the framework in scope.
+complytime plan myframework
 
-	# To customize the assessment plan, run in dry-run mode
-	complytime plan myframework --dry-run
+# To see the default contents of the assessment plan, run in dry-run mode.
+complytime plan myframework --dry-run
 
-	# To customize the assessment plan and write to a file, run in dry-run mode with out.
-	complytime plan myframework --dry-run --out config.yml
+# To customize the assessment plan and write to a file, run in dry-run mode with out.
+complytime plan myframework --dry-run --out config.yml
 
-	# Alter the configuration and use it as input for plan customization
-	complytime plan myframework --with-config config.yml
+# Alter the configuration and use it as input for plan customization.
+complytime plan myframework --with-config config.yml
 `
 
 // planCmd creates a new cobra.Command for the "plan" subcommand

--- a/internal/complytime/plan/scope.go
+++ b/internal/complytime/plan/scope.go
@@ -3,12 +3,8 @@
 package plan
 
 import (
-	"os"
-
 	oscalTypes "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-3"
 	"github.com/hashicorp/go-hclog"
-
-	"github.com/complytime/complytime/pkg/log"
 )
 
 // AssessmentScope sets up the yaml mapping type for writing to config file.
@@ -20,38 +16,33 @@ type AssessmentScope struct {
 	// IncludeControls defines controls that are in scope
 	// of an assessment.
 	IncludeControls []string `yaml:"IncludeControls"`
-	Logger          hclog.Logger
 }
 
 // NewAssessmentScope create an AssessmentScope struct from a given framework id.
-func NewAssessmentScope(frameworkID string, logger hclog.Logger) AssessmentScope {
+func NewAssessmentScope(frameworkID string) AssessmentScope {
 	return AssessmentScope{
 		FrameworkID: frameworkID,
-		Logger:      logger.Named("plan-scope"),
 	}
 }
 
 // ApplyScope alters the given OSCAL Assessment Plan based on the AssessmentScope.
-func (a AssessmentScope) ApplyScope(assessmentPlan *oscalTypes.AssessmentPlan) {
-	if a.Logger == nil {
-		a.Logger = log.NewLogger(os.Stdout)
-	}
+func (a AssessmentScope) ApplyScope(assessmentPlan *oscalTypes.AssessmentPlan, logger hclog.Logger) {
 
 	// This is a thin wrapper right now, but the goal to expand to different areas
 	// of customization.
-	a.applyControlScope(assessmentPlan)
+	a.applyControlScope(assessmentPlan, logger)
 }
 
 // applyControlScope alters the AssessedControls of the given OSCAL Assessment Plan by the AssessmentScope
 // IncludeControls.
-func (a AssessmentScope) applyControlScope(assessmentPlan *oscalTypes.AssessmentPlan) {
+func (a AssessmentScope) applyControlScope(assessmentPlan *oscalTypes.AssessmentPlan, logger hclog.Logger) {
 	// "Any control specified within exclude-controls must first be within a range of explicitly
 	// included controls, via include-controls or include-all."
 	includedControls := map[string]bool{}
 	for _, id := range a.IncludeControls {
 		includedControls[id] = true
 	}
-	a.Logger.Debug("Found included controls", "count", len(includedControls))
+	logger.Debug("Found included controls", "count", len(includedControls))
 
 	// FIXME: We should remove activities that have been filtered out (i.e. have no in scope controls)
 	if assessmentPlan.LocalDefinitions != nil {

--- a/internal/complytime/plan/scope_test.go
+++ b/internal/complytime/plan/scope_test.go
@@ -56,9 +56,7 @@ func TestAssessmentScope_ApplyScope(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			scope := tt.scope
-			scope.Logger = testLogger
-
-			scope.ApplyScope(tt.basePlan)
+			scope.ApplyScope(tt.basePlan, testLogger)
 			require.Equal(t, tt.wantSelections, tt.basePlan.ReviewedControls.ControlSelections)
 		})
 	}


### PR DESCRIPTION
## Summary

Updates assessment-plan logic

- Fix broken build by removing redefined `d` shorthand
- Introduces `out` flag to the user can control where the config is written to.

### Rationale on providing `out` instead of writing to the workspace

For clear differentiation for the user on what should and should not be edited. Files written to the workspace and managed by `complytime` as configuration and to store state in between command runs should not be edited. Allowing the user to provide a location for the configuation gives a clear indication that the configuration is a different use case and the intent is to modify the contents.

## Related Issues
CPLYTM-237

## Review Hints

Review each commit individually

Run below to test:
```
complytime list
complytime plan <framework-id> --dry-run
complytime plan <framework-id> --dry-run --out config.yml
complytime plan <framework-id> --with-config config.yml
```