### PR TITLE
feat: CPLYTM-830 filtering added controls by frameworkID

### DIFF
--- a/cmd/complytime/cli/plan.go
+++ b/cmd/complytime/cli/plan.go
@@ -31,15 +31,20 @@ type planOptions struct {
 
 	// WithConfig "config.yml" to customize the generated assessment plan
 	withConfig string
+
+	// Out
+	Output string
 }
 
 var planExample = `
-	# The default behavior is to prepare a default assessment plan with all defined
-    # controls within the framework in scope
+	# The default behavior is to prepare a default assessment plan with all defined controls within the framework in scope
 	complytime plan myframework
 
 	# To customize the assessment plan, run in dry-run mode
-	complytime plan myframework --dry-run > config.yml
+	complytime plan myframework --dry-run
+
+	# To customize the assessment plan and write to a file, run in dry-run mode with out.
+	complytime plan myframework --dry-run --out config.yml
 
 	# Alter the configuration and use it as input for plan customization
 	complytime plan myframework --with-config config.yml
@@ -65,8 +70,10 @@ func planCmd(common *option.Common) *cobra.Command {
 			return runPlan(cmd, planOpts)
 		},
 	}
-	cmd.Flags().BoolVarP(&planOpts.dryRun, "dry-run", "d", false, "load the defaults and print the config to stdout")
+	cmd.Flags().BoolVar(&planOpts.dryRun, "dry-run", false, "load the defaults and print the config to stdout")
 	cmd.Flags().StringVarP(&planOpts.withConfig, "with-config", "c", "", "load config.yml to customize the generated assessment plan")
+	// FIXME: Check that dry-run is set of the user pass this in
+	cmd.Flags().StringVarP(&planOpts.Output, "out", "o", "-", "path to output file. Use '-' for stdout. Default '-'.")
 	planOpts.complyTimeOpts.BindFlags(cmd.Flags())
 	return cmd
 }
@@ -87,7 +94,7 @@ func runPlan(cmd *cobra.Command, opts *planOptions) error {
 
 	if opts.dryRun {
 		// Write the plan configuration to stdout
-		return planDryRun(opts.complyTimeOpts.FrameworkID, componentDefs)
+		return planDryRun(opts.complyTimeOpts.FrameworkID, componentDefs, opts.Output)
 	}
 
 	logger.Debug(fmt.Sprintf("Using bundle directory: %s for component definitions.", appDir.BundleDir()))
@@ -104,7 +111,7 @@ func runPlan(cmd *cobra.Command, opts *planOptions) error {
 		// stdout if desired.
 
 		// TODO: HB - updated location for reading file - may need change for variable name
-		configBytes, err := os.ReadFile(filepath.Join(opts.withConfig))
+		configBytes, err := os.ReadFile(filepath.Clean(opts.withConfig))
 		if err != nil {
 			return fmt.Errorf("error reading assessment plan: %w", err)
 		}
@@ -112,8 +119,7 @@ func runPlan(cmd *cobra.Command, opts *planOptions) error {
 		if err := yaml.Unmarshal(configBytes, &assessmentScope); err != nil {
 			return fmt.Errorf("error unmarshaling assessment plan: %w", err)
 		}
-		assessmentScope.Logger = logger
-		assessmentScope.ApplyScope(assessmentPlan)
+		assessmentScope.ApplyScope(assessmentPlan, logger)
 	}
 
 	filePath := filepath.Join(opts.complyTimeOpts.UserWorkspace, assessmentPlanLocation)
@@ -144,8 +150,8 @@ func loadPlan(opts *option.ComplyTime, validator validation.Validator) (*oscalTy
 
 // planDryRun leverages the AssessmentScope structure to populate tailoring config.
 // The config is written to stdout.
-func planDryRun(frameworkId string, cds []oscalTypes.ComponentDefinition) error {
-	baseScope := plan.NewAssessmentScope(frameworkId, nil)
+func planDryRun(frameworkId string, cds []oscalTypes.ComponentDefinition, output string) error {
+	baseScope := plan.NewAssessmentScope(frameworkId)
 	if cds == nil {
 		return fmt.Errorf("no component definitions found")
 	}
@@ -168,17 +174,11 @@ func planDryRun(frameworkId string, cds []oscalTypes.ComponentDefinition) error 
 				if ci.Props != nil {
 					for _, frameworkVal := range *ci.Props {
 						if baseScope.FrameworkID == frameworkVal.Value {
-							continue
-						}
-						for _, ir := range ci.ImplementedRequirements {
-							if ir.ControlId != "" {
-								baseScope.IncludeControls = append(baseScope.IncludeControls, ir.ControlId)
+							for _, ir := range ci.ImplementedRequirements {
+								if ir.ControlId != "" {
+									baseScope.IncludeControls = append(baseScope.IncludeControls, ir.ControlId)
+								}
 							}
-						}
-					}
-					for _, ir := range ci.ImplementedRequirements {
-						if ir.ControlId != "" {
-							baseScope.IncludeControls = append(baseScope.IncludeControls, ir.ControlId)
 						}
 					}
 				}
@@ -186,10 +186,16 @@ func planDryRun(frameworkId string, cds []oscalTypes.ComponentDefinition) error 
 		}
 	}
 
-	out, err := yaml.Marshal(&baseScope)
+	data, err := yaml.Marshal(&baseScope)
 	if err != nil {
 		return fmt.Errorf("error marshalling yaml content: %v", err)
 	}
-	fmt.Println(string(out))
+
+	if output == "-" {
+		//TODO handle error
+		fmt.Fprintln(os.Stdout, string(data))
+	} else {
+		return os.WriteFile(output, data, 0600)
+	}
 	return nil
 }

--- a/cmd/complytime/cli/plan.go
+++ b/cmd/complytime/cli/plan.go
@@ -105,12 +105,6 @@ func runPlan(cmd *cobra.Command, opts *planOptions) error {
 
 	if opts.withConfig != "" {
 		// Read assessment plan filter
-		// FIXME: Is `assessment filter plan` the right location?
-		// Seems more intuitive to write the plan content to a well-known location and load only
-		// if present or allow the user to pass in the path. We could use a mutli-writer to write to the path and
-		// stdout if desired.
-
-		// TODO: HB - updated location for reading file - may need change for variable name
 		configBytes, err := os.ReadFile(filepath.Clean(opts.withConfig))
 		if err != nil {
 			return fmt.Errorf("error reading assessment plan: %w", err)
@@ -166,7 +160,6 @@ func planDryRun(frameworkId string, cds []oscalTypes.ComponentDefinition, output
 			// FIXME: Filter the added controls by the framework ID property on the
 			// control implementation. This ensure only the applicable controls end up
 			// in the configuration for review.
-			// FIXME: logger statements should not include the filter location comment
 			for _, ci := range *component.ControlImplementations {
 				if ci.ImplementedRequirements == nil {
 					continue

--- a/internal/complytime/plan/scope.go
+++ b/internal/complytime/plan/scope.go
@@ -3,12 +3,8 @@
 package plan
 
 import (
-	"os"
-
 	oscalTypes "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-3"
 	"github.com/hashicorp/go-hclog"
-
-	"github.com/complytime/complytime/pkg/log"
 )
 
 // AssessmentScope sets up the yaml mapping type for writing to config file.
@@ -20,38 +16,33 @@ type AssessmentScope struct {
 	// IncludeControls defines controls that are in scope
 	// of an assessment.
 	IncludeControls []string `yaml:"IncludeControls"`
-	Logger          hclog.Logger
 }
 
 // NewAssessmentScope create an AssessmentScope struct from a given framework id.
-func NewAssessmentScope(frameworkID string, logger hclog.Logger) AssessmentScope {
+func NewAssessmentScope(frameworkID string) AssessmentScope {
 	return AssessmentScope{
 		FrameworkID: frameworkID,
-		Logger:      logger.Named("plan-scope"),
 	}
 }
 
 // ApplyScope alters the given OSCAL Assessment Plan based on the AssessmentScope.
-func (a AssessmentScope) ApplyScope(assessmentPlan *oscalTypes.AssessmentPlan) {
-	if a.Logger == nil {
-		a.Logger = log.NewLogger(os.Stdout)
-	}
+func (a AssessmentScope) ApplyScope(assessmentPlan *oscalTypes.AssessmentPlan, logger hclog.Logger) {
 
 	// This is a thin wrapper right now, but the goal to expand to different areas
 	// of customization.
-	a.applyControlScope(assessmentPlan)
+	a.applyControlScope(assessmentPlan, logger)
 }
 
 // applyControlScope alters the AssessedControls of the given OSCAL Assessment Plan by the AssessmentScope
 // IncludeControls.
-func (a AssessmentScope) applyControlScope(assessmentPlan *oscalTypes.AssessmentPlan) {
+func (a AssessmentScope) applyControlScope(assessmentPlan *oscalTypes.AssessmentPlan, logger hclog.Logger) {
 	// "Any control specified within exclude-controls must first be within a range of explicitly
 	// included controls, via include-controls or include-all."
 	includedControls := map[string]bool{}
 	for _, id := range a.IncludeControls {
 		includedControls[id] = true
 	}
-	a.Logger.Debug("Found included controls", "count", len(includedControls))
+	logger.Debug("Found included controls", "count", len(includedControls))
 
 	// FIXME: We should remove activities that have been filtered out (i.e. have no in scope controls)
 	if assessmentPlan.LocalDefinitions != nil {

--- a/internal/complytime/plan/scope.go
+++ b/internal/complytime/plan/scope.go
@@ -49,6 +49,13 @@ func (a AssessmentScope) applyControlScope(assessmentPlan *oscalTypes.Assessment
 		if assessmentPlan.LocalDefinitions.Activities != nil {
 			for activityI := range *assessmentPlan.LocalDefinitions.Activities {
 				activity := &(*assessmentPlan.LocalDefinitions.Activities)[activityI]
+				// TODO: testing - if no in-scope controls then remove those activities
+				if activity.RelatedControls != nil && activity.RelatedControls.ControlSelections == nil {
+					assessmentPlan.LocalDefinitions.Activities = nil
+					includedControls = nil
+					//activity = nil
+					continue
+				}
 				if activity.RelatedControls != nil && activity.RelatedControls.ControlSelections != nil {
 					controlSelections := activity.RelatedControls.ControlSelections
 					for controlSelectionI := range controlSelections {
@@ -71,6 +78,12 @@ func (a AssessmentScope) applyControlScope(assessmentPlan *oscalTypes.Assessment
 							controlSelection := &controlSelections[controlSelectionI]
 							filterControlSelection(controlSelection, includedControls)
 						}
+					}
+				} else {
+					controlSelections := activity.RelatedControls.ControlSelections
+					for controlSelectionI := range controlSelections {
+						controlSelection := &controlSelections[controlSelectionI]
+						filterControlSelection(controlSelection, includedControls)
 					}
 				}
 			}


### PR DESCRIPTION
## Summary
This PR updates the check for applicable controls based on the `frameworkID`. The `frameworkID` Property on the `ControlImplementationSet` is compared with the scoped `frameworkID` . Based on the check, the controls are included if applicable. 


## Related Issues

- CPLYTM-237
- Closed by #171 

## Review Hints

**Testing with the available frameworkID in the user workspace**
- `complytime plan <frameworkid> --dry-run --out config.yml`
-  `complytime plan <frameworkid> --scope-config config.yml`
- `cat config.yml`

