### PR TITLE
chore: ensure checkout before git commands

### DIFF
--- a/.github/workflows/dependabot-auto-review.yml
+++ b/.github/workflows/dependabot-auto-review.yml
@@ -16,6 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Get Versions From Commit Message
         id: commit_msg
         run: |


### PR DESCRIPTION
## Summary

The issue was overshadowed by the previous issue https://github.com/complytime/complytime/pull/149 

## Related Issues

Refinements for workflow around dependabot PRs

## Review Hints

Example:
- https://github.com/complytime/complytime/actions/runs/15436886403/job/43445231014?pr=151
