### PR TITLE
feat: CPLYTM-759 updating scope config command flag

### DIFF
--- a/cmd/complytime/cli/plan.go
+++ b/cmd/complytime/cli/plan.go
@@ -21,6 +21,9 @@ import (
 
 const assessmentPlanLocation = "assessment-plan.json"
 
+// TODO: `assessmentPlanFilterLocation` is generic, but can be input based on the user preference
+const assessmentPlanFilterLocation = "config.yml"
+
 // PlanOptions defines options for the "plan" subcommand
 type planOptions struct {
 	*option.Common

--- a/cmd/complytime/cli/plan.go
+++ b/cmd/complytime/cli/plan.go
@@ -32,8 +32,8 @@ type planOptions struct {
 	// dryRun loads the defaults and prints the config to stdout
 	dryRun bool
 
-	// WithConfig "config.yml" to customize the generated assessment plan
-	withConfig string
+	// WithScopeConfig "config.yml" to customize the generated assessment plan
+	withScopeConfig string
 }
 
 var planExample = `
@@ -44,8 +44,8 @@ var planExample = `
 	# To customize the assessment plan, run in dry-run mode
 	complytime plan myframework --dry-run > config.yml
 
-	# Alter the configuration and use it as input for plan customization
-	complytime plan myframework --with-config config.yml
+	# Alter the scope configuration and use it as input for plan customization
+	complytime plan myframework --scope-config config.yml
 `
 
 // planCmd creates a new cobra.Command for the "plan" subcommand
@@ -69,7 +69,7 @@ func planCmd(common *option.Common) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVarP(&planOpts.dryRun, "dry-run", "d", false, "load the defaults and print the config to stdout")
-	cmd.Flags().StringVarP(&planOpts.withConfig, "with-config", "c", "", "load config.yml to customize the generated assessment plan")
+	cmd.Flags().StringVarP(&planOpts.withScopeConfig, "scope-config", "s", "", "load config.yml to customize the generated assessment plan")
 	planOpts.complyTimeOpts.BindFlags(cmd.Flags())
 	return cmd
 }
@@ -99,15 +99,14 @@ func runPlan(cmd *cobra.Command, opts *planOptions) error {
 		return err
 	}
 
-	if opts.withConfig != "" {
+	if opts.withScopeConfig != "" {
 		// Read assessment plan filter
 		// FIXME: Is `assessment filter plan` the right location?
 		// Seems more intuitive to write the plan content to a well-known location and load only
 		// if present or allow the user to pass in the path. We could use a mutli-writer to write to the path and
 		// stdout if desired.
 
-		// TODO: HB - updated location for reading file - may need change for variable name
-		configBytes, err := os.ReadFile(filepath.Join(opts.withConfig))
+		configBytes, err := os.ReadFile(filepath.Join(opts.withScopeConfig))
 		if err != nil {
 			return fmt.Errorf("error reading assessment plan: %w", err)
 		}
@@ -160,10 +159,6 @@ func planDryRun(frameworkId string, cds []oscalTypes.ComponentDefinition) error 
 			if component.ControlImplementations == nil {
 				continue
 			}
-			// FIXME: Filter the added controls by the framework ID property on the
-			// control implementation. This ensure only the applicable controls end up
-			// in the configuration for review.
-			// FIXME: logger statements should not include the filter location comment
 			for _, ci := range *component.ControlImplementations {
 				if ci.ImplementedRequirements == nil {
 					continue


### PR DESCRIPTION
## Summary
This PR changes the `--with-config` flag to `--scope-config` to reduce confusion and overlap of configuration flags. The update emphasizes the scope that is altered based on `FrameworkId` and the excluded controls of the `config.yml`.

## Related Issues
- CPLYTM-759
- Depends on PR #134 
- Closed by #156 
## Review Hints

**Useful commands:**

```bash
./bin/complytime list
./bin/complytime plan <framework-id> --dry-run 
./bin/complytime plan <framework-id> --dry-run --out config.yml
./bin/complytime plan <framework-id> --scope-config config.yml
```
