### PR TITLE
ci: update golangci-lint-action

### DIFF
--- a/.github/workflows/go_lint.yml
+++ b/.github/workflows/go_lint.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version-file: './go.mod'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v1.64.8
+          version: v2.1
           args: --timeout=5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,17 @@
+version: "2"
 linters:
+  default: standard   # https://golangci-lint.run/usage/linters/#enabled-by-default
   enable:
-    - errcheck        # Checks for unchecked errors
-    - gosimple        # Finds code simplifications
-    - govet           # Vet checks for various errors
-    - ineffassign     # Finds useless assignments
-    - staticcheck     # Comprehensive static analysis
-    - unused          # Finds unused variables, functions, etc.
     - gosec           # Security checks for Go code
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+formatters:
+  enable:
     - goimports       # Checks import statements are formatted
+  exclusions:
+    generated: lax

--- a/cmd/complytime/cli/version.go
+++ b/cmd/complytime/cli/version.go
@@ -17,7 +17,7 @@ func versionCmd(common *option.Common) *cobra.Command {
 		Short: "Print the version",
 		Args:  cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			return version.WriteVersion(common.Output.Out)
+			return version.WriteVersion(common.Out)
 		},
 	}
 }


### PR DESCRIPTION
## Summary

We should be fine to move from v6 to v8.
This PR also fixed a QF1008 issue detected with the new version.

## Related Issues

Use updated versions in CI.
This PR will replace the dependabot PR #161

## Review Hints

- https://github.com/golangci/golangci-lint-action?tab=readme-ov-file#compatibility
- https://github.com/golangci/golangci-lint/releases
- https://golangci-lint.run/product/migration-guide/
- https://golangci-lint.run/usage/configuration/
- https://staticcheck.dev/docs/checks/#QF1008