### PR TITLE
ci: include guiding comment in dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-review.yml
+++ b/.github/workflows/dependabot-auto-review.yml
@@ -26,19 +26,19 @@ jobs:
         run: |
           COMMIT_SUBJECT=$(git log -1 --format=%s)
           versions=($(grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' <<< "$COMMIT_SUBJECT"))
-          echo "CURRENT_VERSION=${versions[0]}" >> $GITHUB_ENV
-          echo "NEW_VERSION=${versions[1]}" >> $GITHUB_ENV
+          echo "FROM_VERSION=${versions[0]}" >> $GITHUB_ENV
+          echo "TO_VERSION=${versions[1]}" >> $GITHUB_ENV
 
       - name: Classify Dependabot PR
         id: classify_pr
         run: |
-          if [[ -z "${{ env.CURRENT_VERSION }}" || -z "${{ env.NEW_VERSION }}" ]]; then
+          if [[ -z "${{ env.FROM_VERSION }}" || -z "${{ env.TO_VERSION }}" ]]; then
             echo "No version information found in commit message. Defaulting to high risk."
             echo "RISK=high" >> $GITHUB_ENV
             exit 0
           else
-            IFS='.' read -r c_major c_minor c_patch <<< "${{ env.CURRENT_VERSION }}"
-            IFS='.' read -r n_major n_minor n_patch <<< "${{ env.NEW_VERSION }}"
+            IFS='.' read -r c_major c_minor c_patch <<< "${{ env.FROM_VERSION }}"
+            IFS='.' read -r n_major n_minor n_patch <<< "${{ env.TO_VERSION }}"
             if [[ "$c_major" -eq "$n_major" && "$c_minor" -eq "$n_minor" ]]; then
               echo "Patch update detected. Safe to auto-approve."
               echo "RISK=low" >> $GITHUB_ENV
@@ -71,3 +71,15 @@ jobs:
         uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:
           sync-labels: true
+
+      - name: Comment on PR
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Version bump from ${{ env.FROM_VERSION }} to ${{ env.TO_VERSION }}
+            Breaking risk based on semantic versioning: ${{ env.RISK }}
+            Before merging, please ensure:
+            - The update does not introduce breaking changes.
+            - The update has passed in CI tests.
+            - The update is also reviewed by a maintainer.

--- a/.github/workflows/dependabot-auto-review.yml
+++ b/.github/workflows/dependabot-auto-review.yml
@@ -18,17 +18,16 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
 
       - name: Get Versions From Commit Message
-        id: commit_msg
         run: |
-          COMMIT_SHA=$(jq -r '.pull_request.head.sha' "$GITHUB_EVENT_PATH")
-          COMMIT_MSG=$(git log --format=%s -n 1 $COMMIT_SHA)
-
-          versions=$(echo "$COMMIT_MSG" | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
-          read -r current new <<< "$versions"
-          echo "CURRENT_VERSION=$current" >> $GITHUB_ENV
-          echo "NEW_VERSION=$new" >> $GITHUB_ENV
+          COMMIT_SUBJECT=$(git log -1 --format=%s)
+          versions=($(grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' <<< "$COMMIT_SUBJECT"))
+          echo "CURRENT_VERSION=${versions[0]}" >> $GITHUB_ENV
+          echo "NEW_VERSION=${versions[1]}" >> $GITHUB_ENV
 
       - name: Classify Dependabot PR
         id: classify_pr


### PR DESCRIPTION
## Summary

This PR includes two commits:
- Fix the checkout reference so the versions can be extracted from the commit title
- Include a comment in PRs with guidance to move forward.

## Related Issues

Better experience reviewing dependabot PRs

## Review Hints

It is better to review the commits chronologically.
This should be the final changes in this workflow. It is minimalist, but can easily be extended on demand.