### PR TITLE
fix: [CPLYTM-741] use inventory-item subject type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/defenseunicorns/go-oscal v0.6.2
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.6.3
-	github.com/oscal-compass/compliance-to-policy-go/v2 v2.0.0-20250602201016-df45e1a6b99b
+	github.com/oscal-compass/compliance-to-policy-go/v2 v2.0.0-20250604115044-c9d745f8b1a0
 	github.com/oscal-compass/oscal-sdk-go v0.0.3
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6

--- a/go.sum
+++ b/go.sum
@@ -239,8 +239,8 @@ github.com/openshift/library-go v0.0.0-20231102154438-cfcf2b4fbc87 h1:GcaI98ric0
 github.com/openshift/library-go v0.0.0-20231102154438-cfcf2b4fbc87/go.mod h1:8UzmrBMCn7+GzouL8DVYkL9COBQTB1Ggd13/mHJQCUg=
 github.com/openshift/machine-config-operator v0.0.1-0.20230815171034-c2bb862bc08a h1:3KR43D0bbEi3IYSS6b7abKWbj93RJyuxoHImmYaiWZU=
 github.com/openshift/machine-config-operator v0.0.1-0.20230815171034-c2bb862bc08a/go.mod h1:kP51fbL8QBSY/mAkFicoF73x0QSraPrX4BjWIdzFPio=
-github.com/oscal-compass/compliance-to-policy-go/v2 v2.0.0-20250602201016-df45e1a6b99b h1:tj1M9vNuxvraDAJZlbMl7xlQEe3m7/jQMXNG6Bxud4E=
-github.com/oscal-compass/compliance-to-policy-go/v2 v2.0.0-20250602201016-df45e1a6b99b/go.mod h1:CK6EAtX9c07mrR1uOS/CCZyb3PKlLQLShoDluz6TjYU=
+github.com/oscal-compass/compliance-to-policy-go/v2 v2.0.0-20250604115044-c9d745f8b1a0 h1:Js/Zt6s6P+zmKJDAhYc+Zi9x32GVV271QVgPBAmnx0k=
+github.com/oscal-compass/compliance-to-policy-go/v2 v2.0.0-20250604115044-c9d745f8b1a0/go.mod h1:CK6EAtX9c07mrR1uOS/CCZyb3PKlLQLShoDluz6TjYU=
 github.com/oscal-compass/oscal-sdk-go v0.0.3 h1:hFoJT29nG/kJTgvUNB23+8tIPovkVuUP57lFTcgh++k=
 github.com/oscal-compass/oscal-sdk-go v0.0.3/go.mod h1:D75S58qemUznO4weI2F1/RhxDc+VJc9FI3m9wHjHBXU=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=


### PR DESCRIPTION
## Summary

This PR updates the `Subject` of each `ObservationByCheck` to be an OSCAL inventory-item. These inventory items will then be processed by compliance-to-policy-go and added to the AssessmentResults LocalDefinitions object.

The `inventory-item` is meant to represent the host that is being assessed by complytime. The hostname is being extracted from the `arf.xml` target attribute.

## Related Issues
https://github.com/oscal-compass/compliance-to-policy-go/pull/144 implements the upstream fix.

## Review Hints

https://github.com/complytime/complytime/commit/d7df7f173274e1b27d87b1fc215849cb0cddb39d adds inventory item
https://github.com/complytime/complytime/commit/31c572fa95f1176cbec9966156bc6f21739cda9f bumps c2p version