### PR TITLE
feat: CPLYTM-830 skipping activities with out-of-scope controls

### DIFF
--- a/cmd/complytime/cli/plan.go
+++ b/cmd/complytime/cli/plan.go
@@ -21,6 +21,9 @@ import (
 
 const assessmentPlanLocation = "assessment-plan.json"
 
+// TODO: `assessmentPlanFilterLocation` is generic, but can be input based on the user preference
+const assessmentPlanFilterLocation = "config.yml"
+
 // PlanOptions defines options for the "plan" subcommand
 type planOptions struct {
 	*option.Common

--- a/cmd/complytime/cli/plan.go
+++ b/cmd/complytime/cli/plan.go
@@ -21,9 +21,6 @@ import (
 
 const assessmentPlanLocation = "assessment-plan.json"
 
-// TODO: `assessmentPlanFilterLocation` is generic, but can be input based on the user preference
-const assessmentPlanFilterLocation = "config.yml"
-
 // PlanOptions defines options for the "plan" subcommand
 type planOptions struct {
 	*option.Common
@@ -34,15 +31,20 @@ type planOptions struct {
 
 	// WithConfig "config.yml" to customize the generated assessment plan
 	withConfig string
+
+	// Out
+	Output string
 }
 
 var planExample = `
-	# The default behavior is to prepare a default assessment plan with all defined
-    # controls within the framework in scope
+	# The default behavior is to prepare a default assessment plan with all defined controls within the framework in scope
 	complytime plan myframework
 
 	# To customize the assessment plan, run in dry-run mode
-	complytime plan myframework --dry-run > config.yml
+	complytime plan myframework --dry-run
+
+	# To customize the assessment plan and write to a file, run in dry-run mode with out.
+	complytime plan myframework --dry-run --out config.yml
 
 	# Alter the configuration and use it as input for plan customization
 	complytime plan myframework --with-config config.yml
@@ -68,8 +70,10 @@ func planCmd(common *option.Common) *cobra.Command {
 			return runPlan(cmd, planOpts)
 		},
 	}
-	cmd.Flags().BoolVarP(&planOpts.dryRun, "dry-run", "d", false, "load the defaults and print the config to stdout")
+	cmd.Flags().BoolVar(&planOpts.dryRun, "dry-run", false, "load the defaults and print the config to stdout")
 	cmd.Flags().StringVarP(&planOpts.withConfig, "with-config", "c", "", "load config.yml to customize the generated assessment plan")
+	// FIXME: Check that dry-run is set of the user pass this in
+	cmd.Flags().StringVarP(&planOpts.Output, "out", "o", "-", "path to output file. Use '-' for stdout. Default '-'.")
 	planOpts.complyTimeOpts.BindFlags(cmd.Flags())
 	return cmd
 }
@@ -90,7 +94,7 @@ func runPlan(cmd *cobra.Command, opts *planOptions) error {
 
 	if opts.dryRun {
 		// Write the plan configuration to stdout
-		return planDryRun(opts.complyTimeOpts.FrameworkID, componentDefs)
+		return planDryRun(opts.complyTimeOpts.FrameworkID, componentDefs, opts.Output)
 	}
 
 	logger.Debug(fmt.Sprintf("Using bundle directory: %s for component definitions.", appDir.BundleDir()))
@@ -107,7 +111,7 @@ func runPlan(cmd *cobra.Command, opts *planOptions) error {
 		// stdout if desired.
 
 		// TODO: HB - updated location for reading file - may need change for variable name
-		configBytes, err := os.ReadFile(filepath.Join(opts.withConfig))
+		configBytes, err := os.ReadFile(filepath.Clean(opts.withConfig))
 		if err != nil {
 			return fmt.Errorf("error reading assessment plan: %w", err)
 		}
@@ -115,8 +119,7 @@ func runPlan(cmd *cobra.Command, opts *planOptions) error {
 		if err := yaml.Unmarshal(configBytes, &assessmentScope); err != nil {
 			return fmt.Errorf("error unmarshaling assessment plan: %w", err)
 		}
-		assessmentScope.Logger = logger
-		assessmentScope.ApplyScope(assessmentPlan)
+		assessmentScope.ApplyScope(assessmentPlan, logger)
 	}
 
 	filePath := filepath.Join(opts.complyTimeOpts.UserWorkspace, assessmentPlanLocation)
@@ -147,8 +150,8 @@ func loadPlan(opts *option.ComplyTime, validator validation.Validator) (*oscalTy
 
 // planDryRun leverages the AssessmentScope structure to populate tailoring config.
 // The config is written to stdout.
-func planDryRun(frameworkId string, cds []oscalTypes.ComponentDefinition) error {
-	baseScope := plan.NewAssessmentScope(frameworkId, nil)
+func planDryRun(frameworkId string, cds []oscalTypes.ComponentDefinition, output string) error {
+	baseScope := plan.NewAssessmentScope(frameworkId)
 	if cds == nil {
 		return fmt.Errorf("no component definitions found")
 	}
@@ -189,10 +192,15 @@ func planDryRun(frameworkId string, cds []oscalTypes.ComponentDefinition) error 
 		}
 	}
 
-	out, err := yaml.Marshal(&baseScope)
+	data, err := yaml.Marshal(&baseScope)
 	if err != nil {
 		return fmt.Errorf("error marshalling yaml content: %v", err)
 	}
-	fmt.Println(string(out))
+
+	if output == "-" {
+		fmt.Fprintln(os.Stdout, string(data))
+	} else {
+		return os.WriteFile(output, data, 0600)
+	}
 	return nil
 }

--- a/internal/complytime/plan/scope.go
+++ b/internal/complytime/plan/scope.go
@@ -3,12 +3,8 @@
 package plan
 
 import (
-	"os"
-
 	oscalTypes "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-3"
 	"github.com/hashicorp/go-hclog"
-
-	"github.com/complytime/complytime/pkg/log"
 )
 
 // AssessmentScope sets up the yaml mapping type for writing to config file.
@@ -20,38 +16,33 @@ type AssessmentScope struct {
 	// IncludeControls defines controls that are in scope
 	// of an assessment.
 	IncludeControls []string `yaml:"IncludeControls"`
-	Logger          hclog.Logger
 }
 
 // NewAssessmentScope create an AssessmentScope struct from a given framework id.
-func NewAssessmentScope(frameworkID string, logger hclog.Logger) AssessmentScope {
+func NewAssessmentScope(frameworkID string) AssessmentScope {
 	return AssessmentScope{
 		FrameworkID: frameworkID,
-		Logger:      logger.Named("plan-scope"),
 	}
 }
 
 // ApplyScope alters the given OSCAL Assessment Plan based on the AssessmentScope.
-func (a AssessmentScope) ApplyScope(assessmentPlan *oscalTypes.AssessmentPlan) {
-	if a.Logger == nil {
-		a.Logger = log.NewLogger(os.Stdout)
-	}
+func (a AssessmentScope) ApplyScope(assessmentPlan *oscalTypes.AssessmentPlan, logger hclog.Logger) {
 
 	// This is a thin wrapper right now, but the goal to expand to different areas
 	// of customization.
-	a.applyControlScope(assessmentPlan)
+	a.applyControlScope(assessmentPlan, logger)
 }
 
 // applyControlScope alters the AssessedControls of the given OSCAL Assessment Plan by the AssessmentScope
 // IncludeControls.
-func (a AssessmentScope) applyControlScope(assessmentPlan *oscalTypes.AssessmentPlan) {
+func (a AssessmentScope) applyControlScope(assessmentPlan *oscalTypes.AssessmentPlan, logger hclog.Logger) {
 	// "Any control specified within exclude-controls must first be within a range of explicitly
 	// included controls, via include-controls or include-all."
 	includedControls := map[string]bool{}
 	for _, id := range a.IncludeControls {
 		includedControls[id] = true
 	}
-	a.Logger.Debug("Found included controls", "count", len(includedControls))
+	logger.Debug("Found included controls", "count", len(includedControls))
 
 	// FIXME: We should remove activities that have been filtered out (i.e. have no in scope controls)
 	if assessmentPlan.LocalDefinitions != nil {

--- a/internal/complytime/plan/scope.go
+++ b/internal/complytime/plan/scope.go
@@ -54,6 +54,14 @@ func (a AssessmentScope) applyControlScope(assessmentPlan *oscalTypes.Assessment
 					for controlSelectionI := range controlSelections {
 						controlSelection := &controlSelections[controlSelectionI]
 						filterControlSelection(controlSelection, includedControls)
+						if controlSelection.IncludeControls == nil {
+							activity.UUID = ""
+							activity.RelatedControls = nil
+							activity.Props = nil
+							activity.Description = ""
+							activity.Title = "skipped"
+							activity.Steps = nil
+						}
 					}
 				}
 
@@ -70,13 +78,17 @@ func (a AssessmentScope) applyControlScope(assessmentPlan *oscalTypes.Assessment
 						for controlSelectionI := range controlSelections {
 							controlSelection := &controlSelections[controlSelectionI]
 							filterControlSelection(controlSelection, includedControls)
+							if controlSelection.IncludeControls == nil {
+								activity.RelatedControls.ControlSelections = nil
+								step.ReviewedControls = nil
+								step.Description = "skipped"
+							}
 						}
 					}
 				}
 			}
 		}
 	}
-
 	if assessmentPlan.ReviewedControls.ControlSelections != nil {
 		for controlSelectionI := range assessmentPlan.ReviewedControls.ControlSelections {
 			controlSelection := &assessmentPlan.ReviewedControls.ControlSelections[controlSelectionI]
@@ -108,5 +120,9 @@ func filterControlSelection(controlSelection *oscalTypes.AssessedControls, inclu
 			})
 		}
 	}
-	controlSelection.IncludeControls = &newIncludedControls
+	if newIncludedControls != nil {
+		controlSelection.IncludeControls = &newIncludedControls
+	} else {
+		controlSelection.IncludeControls = nil
+	}
 }

--- a/internal/complytime/plan/scope.go
+++ b/internal/complytime/plan/scope.go
@@ -5,6 +5,7 @@ package plan
 import (
 	oscalTypes "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-3"
 	"github.com/hashicorp/go-hclog"
+	"github.com/oscal-compass/oscal-sdk-go/extensions"
 )
 
 // AssessmentScope sets up the yaml mapping type for writing to config file.
@@ -55,12 +56,16 @@ func (a AssessmentScope) applyControlScope(assessmentPlan *oscalTypes.Assessment
 						controlSelection := &controlSelections[controlSelectionI]
 						filterControlSelection(controlSelection, includedControls)
 						if controlSelection.IncludeControls == nil {
-							activity.UUID = ""
 							activity.RelatedControls = nil
-							activity.Props = nil
-							activity.Description = ""
-							activity.Title = "skipped"
-							activity.Steps = nil
+							if activity.Props == nil {
+								activity.Props = &[]oscalTypes.Property{}
+							}
+							skippedActivity := oscalTypes.Property{
+								Name:  "skipped",
+								Value: "true",
+								Ns:    extensions.TrestleNameSpace,
+							}
+							*activity.Props = append(*activity.Props, skippedActivity)
 						}
 					}
 				}
@@ -81,7 +86,15 @@ func (a AssessmentScope) applyControlScope(assessmentPlan *oscalTypes.Assessment
 							if controlSelection.IncludeControls == nil {
 								activity.RelatedControls.ControlSelections = nil
 								step.ReviewedControls = nil
-								step.Description = "skipped"
+								if step.Props == nil {
+									step.Props = &[]oscalTypes.Property{}
+								}
+								skipped := oscalTypes.Property{
+									Name:  "skipped",
+									Value: "true",
+									Ns:    extensions.TrestleNameSpace,
+								}
+								*step.Props = append(*step.Props, skipped)
 							}
 						}
 					}

--- a/internal/complytime/plan/scope_test.go
+++ b/internal/complytime/plan/scope_test.go
@@ -76,9 +76,7 @@ func TestAssessmentScope_ApplyScope(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			scope := tt.scope
-			scope.Logger = testLogger
-
-			scope.ApplyScope(tt.basePlan)
+			scope.ApplyScope(tt.basePlan, testLogger)
 			require.Equal(t, tt.wantSelections, tt.basePlan.ReviewedControls.ControlSelections)
 		})
 	}

--- a/internal/complytime/plan/scope_test.go
+++ b/internal/complytime/plan/scope_test.go
@@ -53,19 +53,56 @@ func TestAssessmentScope_ApplyScope(t *testing.T) {
 		},
 		// Testing for out-of-scope controls
 		{
-			name: "Out-of-Scope Controls",
+			name: "All Controls Out-of-Scope",
 			basePlan: &oscalTypes.AssessmentPlan{
 				ReviewedControls: oscalTypes.ReviewedControls{
-					ControlSelections: nil,
+					ControlSelections: []oscalTypes.AssessedControls{
+						{
+							IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+								{
+									ControlId: "",
+								},
+							},
+						},
+					},
 				},
 			},
 			scope: AssessmentScope{
 				FrameworkID:     "test",
-				IncludeControls: []string{""},
+				IncludeControls: nil,
 			},
 			wantSelections: []oscalTypes.AssessedControls{
 				{
 					IncludeControls: nil,
+				},
+			},
+		},
+		{
+			name: "Some Controls Out-of-Scope",
+			basePlan: &oscalTypes.AssessmentPlan{
+				ReviewedControls: oscalTypes.ReviewedControls{
+					ControlSelections: []oscalTypes.AssessedControls{
+						{
+							IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+								{
+									ControlId: "example-1",
+								},
+							},
+						},
+					},
+				},
+			},
+			scope: AssessmentScope{
+				FrameworkID:     "test",
+				IncludeControls: []string{"example-1", "example-2"},
+			},
+			wantSelections: []oscalTypes.AssessedControls{
+				{
+					IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+						{
+							ControlId: "example-1",
+						},
+					},
 				},
 			},
 		},

--- a/internal/complytime/plan/scope_test.go
+++ b/internal/complytime/plan/scope_test.go
@@ -51,6 +51,26 @@ func TestAssessmentScope_ApplyScope(t *testing.T) {
 				},
 			},
 		},
+		// Testing for out-of-scope controls
+		{
+			name: "Out-of-Scope Controls",
+			basePlan: &oscalTypes.AssessmentPlan{
+				ReviewedControls: oscalTypes.ReviewedControls{
+					ControlSelections: nil,
+				},
+			},
+			scope: AssessmentScope{
+				FrameworkID:     "test",
+				IncludeControls: []string{""},
+			},
+			wantSelections: []oscalTypes.AssessedControls{
+				{
+					IncludeControls: nil,
+				},
+			},
+		},
+	}
+	{
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
This PR updates the OSCAL Assessment Plan `activities` field when filtering controls based on the assessment-plan. If the controls are excluded from the `assessment-plan.json` or deleted from the `config.yml`, the associated activities will be marked as "skipped" in the `assessment-plan.json`.

The `scope_test.go` updates were made to include a test for "All Controls Out-of-Scope" and "Some Controls Out-of-Scope." The tests will trigger the out-of-scope activities with `skippedProperty` and `skippedActivity` properties when expected `control-ids` are not provided. 

## Related Issues
_Inform any issues relevant to this PR. For example:_

- Depends on #134 
- Closes #140 
- Related to #156 
- Closes #155 
- CPLYTM-237[CPLYTM-830]

## Review Hints

**Review commit by commit** 
-   [Expanding unit tests](https://github.com/complytime/complytime/pull/171/commits/28e76490cb0033d3085562776cf0aa57e39d9e1c) 
-   [Introducing skipped property](https://github.com/complytime/complytime/pull/171/commits/8d8c72302a641bc223d0b9b13bc87b258c743863)
- Note: tests are passing in CI

#### Writing the config to the complytime workspace 
- `./bin/complytime plan <frameworkid> --dry-run`
- `./bin/complytime plan <frameworkid> --dry-run --out config.yml`
#### Update the `config.yml` to exclude r1 from the assessment-plan.json
- `./bin/complytime plan <frameworkid> --scope-config config.yml`
**Result:**
![image](https://github.com/user-attachments/assets/14bf28b4-d6ce-48a7-8665-dca643361f99)

