### PR TITLE
CPLYTM-843 fix: removes control duplicates from config

### DIFF
--- a/cmd/complytime/cli/plan.go
+++ b/cmd/complytime/cli/plan.go
@@ -157,8 +157,11 @@ func loadPlan(opts *option.ComplyTime, validator validation.Validator) (*oscalTy
 // planDryRun leverages the AssessmentScope structure to populate tailoring config.
 // The config is written to stdout.
 func planDryRun(frameworkId string, cds []oscalTypes.ComponentDefinition, output string) error {
-
-	data, err := yaml.Marshal(&baseScope)
+	scope, err := plan.NewAssessmentScopeFromCDs(frameworkId, cds...)
+	if err != nil {
+		return fmt.Errorf("error creating assessment scope for %s", frameworkId)
+	}
+	data, err := yaml.Marshal(&scope)
 	if err != nil {
 		return fmt.Errorf("error marshalling yaml content: %v", err)
 	}

--- a/cmd/complytime/cli/plan_test.go
+++ b/cmd/complytime/cli/plan_test.go
@@ -3,6 +3,7 @@
 package cli
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/oscal-compass/oscal-sdk-go/validation"
@@ -27,4 +28,48 @@ func TestPlansInWorkspace(t *testing.T) {
 	_, gotPath, err := loadPlan(testOpts, validation.NoopValidator{})
 	require.NoError(t, err)
 	require.Equal(t, "testdata/assessment-plan.json", gotPath)
+}
+
+func TestValidatePlan(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    planOptions
+		wantErr string
+	}{
+		{
+			name: "Valid/DefaultOptions",
+			opts: planOptions{
+				// Set by flag
+				output: "-",
+			},
+		},
+		{
+			name: "Valid/CorrectPlanOptions",
+			opts: planOptions{
+				dryRun: true,
+				output: "myconfig.yml",
+			},
+		},
+		{
+			name: "Invalid/OutNoDryRun",
+			opts: planOptions{
+				dryRun: false,
+				output: "myconfig.yml",
+			},
+			wantErr: "" +
+				"invalid command flags: \"--dry-run\" must be used with \"--out\"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fmt.Println(tt.opts)
+			err := validatePlan(&tt.opts)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }

--- a/cmd/complytime/cli/scan.go
+++ b/cmd/complytime/cli/scan.go
@@ -162,11 +162,9 @@ func runScan(cmd *cobra.Command, opts *scanOptions) error {
 			return err
 		}
 		arMarkdownPath := filepath.Join(opts.complyTimeOpts.UserWorkspace, assessmentResultsLocationMd)
-		templateValues, err := framework.CreateResultsValues(*catalog, *ap, *assessmentResults)
-		if err != nil {
-			return err
-		}
-		assessmentResultsMd, err := templateValues.GenerateAssessmentResultsMd(arMarkdownPath)
+
+		posture := framework.NewPosture(assessmentResults, catalog, ap, logger)
+		assessmentResultsMd, err := posture.Generate(arMarkdownPath)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/goccy/go-yaml v1.17.1
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.6.3
-	github.com/oscal-compass/compliance-to-policy-go/v2 v2.0.0-20250604115044-c9d745f8b1a0
+	github.com/oscal-compass/compliance-to-policy-go/v2 v2.0.0-20250612165759-929b7bb27d96
 	github.com/oscal-compass/oscal-sdk-go v0.0.3
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6

--- a/go.sum
+++ b/go.sum
@@ -241,8 +241,8 @@ github.com/openshift/library-go v0.0.0-20240821135116-ade3966091b1 h1:Kp33k9pOeJ
 github.com/openshift/library-go v0.0.0-20240821135116-ade3966091b1/go.mod h1:PdASVamWinll2BPxiUpXajTwZxV8A1pQbWEsCN1od7I=
 github.com/openshift/machine-config-operator v0.0.1-0.20230815171034-c2bb862bc08a h1:3KR43D0bbEi3IYSS6b7abKWbj93RJyuxoHImmYaiWZU=
 github.com/openshift/machine-config-operator v0.0.1-0.20230815171034-c2bb862bc08a/go.mod h1:kP51fbL8QBSY/mAkFicoF73x0QSraPrX4BjWIdzFPio=
-github.com/oscal-compass/compliance-to-policy-go/v2 v2.0.0-20250604115044-c9d745f8b1a0 h1:Js/Zt6s6P+zmKJDAhYc+Zi9x32GVV271QVgPBAmnx0k=
-github.com/oscal-compass/compliance-to-policy-go/v2 v2.0.0-20250604115044-c9d745f8b1a0/go.mod h1:CK6EAtX9c07mrR1uOS/CCZyb3PKlLQLShoDluz6TjYU=
+github.com/oscal-compass/compliance-to-policy-go/v2 v2.0.0-20250612165759-929b7bb27d96 h1:xW4+zQf7BMwfzzpOZ9t5ipJuevfvMQcinst6MNosnOw=
+github.com/oscal-compass/compliance-to-policy-go/v2 v2.0.0-20250612165759-929b7bb27d96/go.mod h1:CK6EAtX9c07mrR1uOS/CCZyb3PKlLQLShoDluz6TjYU=
 github.com/oscal-compass/oscal-sdk-go v0.0.3 h1:hFoJT29nG/kJTgvUNB23+8tIPovkVuUP57lFTcgh++k=
 github.com/oscal-compass/oscal-sdk-go v0.0.3/go.mod h1:D75S58qemUznO4weI2F1/RhxDc+VJc9FI3m9wHjHBXU=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=


### PR DESCRIPTION
## Summary

 Removes control duplicates from config

## Related Issues
- Closes CPLYTM-843

## Review Hints

- Review each commit individually
- To test, see the `planExample`

### Testing Steps

```bash
complytime plan myframework
complytime plan myframework --dry-run > config.yml
complytime plan myframework --scope-config config.yml
```

Ensure the `config.yml` does not have the same control twice.
