### PR TITLE
ci: CPLYTM-865 - introduce packit integration

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,18 @@
+files_to_sync:
+    - complyctl.spec
+    - .packit.yaml
+
+upstream_package_name: complyctl
+upstream_tag_template: v{version}
+specfile_path: complyctl.spec
+
+downstream_package_name: complyctl
+
+jobs:
+- job: copr_build
+  trigger: pull_request
+  targets:
+    - fedora-42-x86_64
+    - fedora-rawhide-x86_64
+    - centos-stream-9-x86_64
+    - centos-stream-10-x86_64


### PR DESCRIPTION
## Summary

Enable packit integration for testing RPM packages.
This can later be incremented to automate the release of Fedora packages.

## Related Issues

Make sure RPMs can be properly built in Fedora and CentOS Stream

## Review Hints

Packit information:
- https://packit.dev/docs/guide
- https://github.com/packit/notifications/issues/667

Also take a look at new CI jobs introduced by this integration, prefixed by `rpm-build:`

More Context:
- Not all dependencies used by `complyctl` are available as Fedora packages, blocking the `complyctl` to be built with packit in isolated environments for Fedora and CentOS stream.
- After considering to "Package Missing Dependencies" or "Vendoring Dependencies" maintainers decided to vendor the dependencies by https://github.com/complytime/complyctl/pull/184 .