### PR TITLE
feat: CPLYTM-817 CPLYTM-818 apply customized plugin configuration

### DIFF
--- a/cmd/complytime/cli/generate.go
+++ b/cmd/complytime/cli/generate.go
@@ -84,7 +84,7 @@ func runGenerate(cmd *cobra.Command, opts *generateOptions) error {
 
 	pluginOptions := opts.complyTimeOpts.ToPluginOptions()
 	pluginOptions.UserConfigRoot = opts.withPluginConfig
-	plugins, cleanup, err := complytime.Plugins(manager, inputContext, pluginOptions)
+	plugins, cleanup, err := complytime.Plugins(manager, inputContext, pluginOptions, logger)
 	if cleanup != nil {
 		defer cleanup()
 	}

--- a/cmd/complytime/cli/generate.go
+++ b/cmd/complytime/cli/generate.go
@@ -18,7 +18,8 @@ import (
 // generateOptions defines options for the "generate" subcommand
 type generateOptions struct {
 	*option.Common
-	complyTimeOpts *option.ComplyTime
+	complyTimeOpts   *option.ComplyTime
+	withPluginConfig string
 }
 
 // generateCmd creates a new cobra.Command for the "generate" subcommand
@@ -36,6 +37,7 @@ func generateCmd(common *option.Common) *cobra.Command {
 			return runGenerate(cmd, generateOpts)
 		},
 	}
+	cmd.Flags().StringVarP(&generateOpts.withPluginConfig, "plugin-config", "c", "", "Directory where user customized plugin manifests located.")
 	generateOpts.complyTimeOpts.BindFlags(cmd.Flags())
 	return cmd
 }
@@ -81,6 +83,7 @@ func runGenerate(cmd *cobra.Command, opts *generateOptions) error {
 	logger.Debug(fmt.Sprintf("Framework property was successfully read from the assessment plan: %v.", frameworkProp))
 
 	pluginOptions := opts.complyTimeOpts.ToPluginOptions()
+	pluginOptions.UserConfigRoot = opts.withPluginConfig
 	plugins, cleanup, err := complytime.Plugins(manager, inputContext, pluginOptions)
 	if cleanup != nil {
 		defer cleanup()

--- a/cmd/complytime/cli/scan.go
+++ b/cmd/complytime/cli/scan.go
@@ -25,7 +25,8 @@ const assessmentResultsLocationMd = "assessment-results.md"
 // scanOptions defined options for the scan subcommand.
 type scanOptions struct {
 	*option.Common
-	complyTimeOpts *option.ComplyTime
+	complyTimeOpts   *option.ComplyTime
+	withPluginConfig string
 }
 
 // scanCmd creates a new cobra.Command for the version subcommand.
@@ -44,6 +45,7 @@ func scanCmd(common *option.Common) *cobra.Command {
 			return runScan(cmd, scanOpts)
 		},
 	}
+	cmd.Flags().StringVarP(&scanOpts.withPluginConfig, "plugin-config", "c", "", "Directory where user customized plugin manifests located.")
 	cmd.Flags().BoolP("with-md", "m", false, "If true, assessement-result markdown will be generated")
 	scanOpts.complyTimeOpts.BindFlags(cmd.Flags())
 	return cmd
@@ -92,6 +94,7 @@ func runScan(cmd *cobra.Command, opts *scanOptions) error {
 	logger.Debug(fmt.Sprintf("Framework property was successfully read from the assessment plan: %v.", frameworkProp))
 
 	pluginOptions := opts.complyTimeOpts.ToPluginOptions()
+	pluginOptions.UserConfigRoot = opts.withPluginConfig
 	plugins, cleanup, err := complytime.Plugins(manager, inputContext, pluginOptions)
 	if cleanup != nil {
 		defer cleanup()

--- a/cmd/complytime/cli/scan.go
+++ b/cmd/complytime/cli/scan.go
@@ -95,7 +95,7 @@ func runScan(cmd *cobra.Command, opts *scanOptions) error {
 
 	pluginOptions := opts.complyTimeOpts.ToPluginOptions()
 	pluginOptions.UserConfigRoot = opts.withPluginConfig
-	plugins, cleanup, err := complytime.Plugins(manager, inputContext, pluginOptions)
+	plugins, cleanup, err := complytime.Plugins(manager, inputContext, pluginOptions, logger)
 	if cleanup != nil {
 		defer cleanup()
 	}

--- a/internal/complytime/configuration.go
+++ b/internal/complytime/configuration.go
@@ -21,13 +21,14 @@ import (
 )
 
 const (
-	compDefSuffix       = "component-definition.json"
-	ApplicationDir      = "complytime"
-	PluginDir           = "plugins"
-	BundlesDir          = "bundles"
-	ControlsDir         = "controls"
-	DataRootDir         = "/usr/share"
-	PluginBinaryRootDir = "/usr/libexec/"
+	compDefSuffix          = "component-definition.json"
+	ApplicationDir         = "complytime"
+	PluginDir              = "plugins"
+	BundlesDir             = "bundles"
+	ControlsDir            = "controls"
+	DataRootDir            = "/usr/share"
+	PluginBinaryRootDir    = "/usr/libexec/"
+	DefaultPluginConfigDir = "/etc/complytime/config.d/"
 )
 
 // ErrNoComponentDefinitionsFound returns an error indicated the supplied directory

--- a/internal/complytime/plugins.go
+++ b/internal/complytime/plugins.go
@@ -84,6 +84,10 @@ func (p PluginOptions) ToMap(pluginId string, logger hclog.Logger) (map[string]s
 				continue
 			} else {
 				if configOption.Default == nil {
+					if pluginId == "openscap" && configOption.Name == "datastream" {
+						selections[configOption.Name] = ""
+						continue
+					}
 					return selections, fmt.Errorf("missing %s default in %s", configOption.Name, configPath)
 				}
 				selections[configOption.Name] = *configOption.Default

--- a/internal/complytime/plugins_test.go
+++ b/internal/complytime/plugins_test.go
@@ -3,10 +3,13 @@
 package complytime
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+var testPluginConfigRoot = filepath.Join("testdata", "complytime", "plugins")
 
 func TestPluginOptions(t *testing.T) {
 	tests := []struct {
@@ -16,7 +19,7 @@ func TestPluginOptions(t *testing.T) {
 		wantErr    string
 	}{
 		{
-			name: "Valid/Selections",
+			name: "Valid/MinimalSelections",
 			selections: PluginOptions{
 				Workspace: "testworkspace",
 				Profile:   "testprofile",
@@ -27,9 +30,31 @@ func TestPluginOptions(t *testing.T) {
 			},
 		},
 		{
+			name: "Valid/Selections",
+			selections: PluginOptions{
+				Workspace:      "testworkspace",
+				Profile:        "testprofile",
+				UserConfigRoot: testPluginConfigRoot,
+			},
+			wantMap: map[string]string{
+				"workspace": "testworkspace",
+				"profile":   "testprofile",
+				"results":   "results_test.xml",
+			},
+		},
+		{
 			name:       "Invalid/MissingOptions",
 			selections: PluginOptions{},
 			wantErr:    "workspace must be set",
+		},
+		{
+			name: "Invalid/IncorrectOptions",
+			selections: PluginOptions{
+				Workspace:      "testworkspace",
+				Profile:        "testprofile",
+				UserConfigRoot: "nonexistpath",
+			},
+			wantErr: "user config root does not exist",
 		},
 	}
 
@@ -40,7 +65,7 @@ func TestPluginOptions(t *testing.T) {
 				require.EqualError(t, err, c.wantErr)
 			} else {
 				require.NoError(t, err)
-				gotMap := c.selections.ToMap()
+				gotMap, _ := c.selections.ToMap("openscap")
 				require.Equal(t, c.wantMap, gotMap)
 			}
 		})

--- a/internal/complytime/plugins_test.go
+++ b/internal/complytime/plugins_test.go
@@ -6,12 +6,14 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 )
 
 var testPluginConfigRoot = filepath.Join("testdata", "complytime", "plugins")
 
 func TestPluginOptions(t *testing.T) {
+	testLogger := hclog.NewNullLogger()
 	tests := []struct {
 		name       string
 		selections PluginOptions
@@ -65,7 +67,7 @@ func TestPluginOptions(t *testing.T) {
 				require.EqualError(t, err, c.wantErr)
 			} else {
 				require.NoError(t, err)
-				gotMap, _ := c.selections.ToMap("openscap")
+				gotMap, _ := c.selections.ToMap("openscap", testLogger)
 				require.Equal(t, c.wantMap, gotMap)
 			}
 		})

--- a/internal/complytime/testdata/complytime/plugins/c2p-openscap-manifest.json
+++ b/internal/complytime/testdata/complytime/plugins/c2p-openscap-manifest.json
@@ -1,0 +1,21 @@
+{
+  "configuration": [
+    {
+      "name": "workspace",
+      "description": "Directory for writing plugin artifacts",
+      "default": "./complytime",
+      "required": true
+    },
+    {
+      "name": "profile",
+      "description": "The OpenSCAP profile to run for assessment",
+      "required": true
+    },
+    {
+      "name": "results",
+      "description": "The name of the generated results file",
+      "default": "results_test.xml",
+      "required": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
_With this change, user could apply customized plugin options via drop-in configuration file._

## Related Issues
_Inform any issues relevant to this PR. For example:_

- _Closes CPLYTM-817_

## Review Hints

- _Create a plugin configuration json file with options specified in plugin manifest, then add its directory as the value of withPluginConfig of commands._
```
$ complytime generate -c /etc/complytime/config.d --debug
$ complytime scan -c /etc/complytime/config.d
```
