### PR TITLE
chore: improvements based on Fedora package review

### DIFF
--- a/complyctl.spec
+++ b/complyctl.spec
@@ -13,8 +13,6 @@ License:        Apache-2.0
 URL:            %{base_url}
 Source0:        %{base_url}/archive/refs/tags/v%{version}.tar.gz
 
-# git is temporarily used
-BuildRequires:  git
 BuildRequires:  golang
 BuildRequires:  go-rpm-macros
 
@@ -22,7 +20,7 @@ BuildRequires:  go-rpm-macros
 
 %description
 %{name} leverages OSCAL to perform compliance assessment activities, using
-plugins for each stage of the lifecycle.
+plugins for each stage of the life-cycle.
 
 %package        openscap-plugin
 Summary:        A plugin which extends complyctl capabilities to use OpenSCAP
@@ -30,9 +28,9 @@ Requires:       %{name}%{?_isa} = %{version}-%{release}
 Requires:       scap-security-guide
 %description    openscap-plugin
 openscap-plugin is a plugin which extends the complyctl capabilities to use
-OpenSCAP. The plugin communicates with complyctl via gRPC, providing a
-standard and consistent communication mechanism that gives independence for
-plugin developers to choose their preferred languages.
+OpenSCAP. The plugin communicates with complyctl using Remote Procedure Calls,
+providing a standard and consistent communication mechanism that allows plugin
+developers to use their preferred programming languages.
 
 %prep
 %autosetup -n %{name}-%{version}

--- a/complyctl.spec
+++ b/complyctl.spec
@@ -33,7 +33,7 @@ providing a standard and consistent communication mechanism that allows plugin
 developers to use their preferred programming languages.
 
 %prep
-%autosetup -n %{name}-%{version}
+%goprep -k
 
 %build
 BUILD_DATE_GO=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
@@ -55,7 +55,7 @@ GO_BUILD_BINDIR=./bin
 mkdir -p ${GO_BUILD_BINDIR}
 
 # Not calling the macro for more control on go env variables
-go build -mod=vendor -o ${GO_BUILD_BINDIR}/ -ldflags="${GO_LD_EXTRAFLAGS}" ./cmd/...
+go build -buildmode=pie -o ${GO_BUILD_BINDIR}/ -ldflags="${GO_LD_EXTRAFLAGS}" ./cmd/...
 
 %install
 # Install complyctl directories

--- a/complyctl.spec
+++ b/complyctl.spec
@@ -2,10 +2,11 @@
 
 %global goipath github.com/complytime/complyctl
 %global base_url https://%{goipath}
+%global app_dir complytime
 %global gopath %{_builddir}/go
 
 Name:           complyctl
-Version:        0.0.6
+Version:        0.0.7
 Release:        %autorelease
 Summary:        Tool to perform compliance assessment activities, scaled by plugins
 License:        Apache-2.0
@@ -61,20 +62,20 @@ go build -mod=vendor -o ${GO_BUILD_BINDIR}/ -ldflags="${GO_LD_EXTRAFLAGS}" ./cmd
 %install
 # Install complyctl directories
 install -d %{buildroot}%{_bindir}
-install -d -m 0755 %{buildroot}%{_datadir}/%{name}/{plugins,bundles,controls}
-install -d -m 0755 %{buildroot}%{_libexecdir}/%{name}/plugins
-install -d -m 0755 %{buildroot}%{_sysconfdir}/%{name}/config.d
+install -d -m 0755 %{buildroot}%{_datadir}/%{app_dir}/{plugins,bundles,controls}
+install -d -m 0755 %{buildroot}%{_libexecdir}/%{app_dir}/plugins
+install -d -m 0755 %{buildroot}%{_sysconfdir}/%{app_dir}/config.d
 install -d -m 0755 %{buildroot}%{_mandir}/{man1,man5}
 
 # Copy sample data to be consumed by complyctl CLI
-cp -rp docs/samples %{buildroot}%{_datadir}/%{name}
+cp -rp docs/samples %{buildroot}%{_datadir}/%{app_dir}
 
 # Install files for complyctl CLI
 install -p -m 0755 bin/complyctl %{buildroot}%{_bindir}/complyctl
 install -p -m 0644 docs/man/complyctl.1 %{buildroot}%{_mandir}/man1/complyctl.1
 
 # Install files for openscap-plugin package
-install -p -m 0755 bin/openscap-plugin %{buildroot}%{_libexecdir}/%{name}/plugins/openscap-plugin
+install -p -m 0755 bin/openscap-plugin %{buildroot}%{_libexecdir}/%{app_dir}/plugins/openscap-plugin
 install -p -m 0644 docs/man/c2p-openscap-manifest.5 %{buildroot}%{_mandir}/man5/c2p-openscap-manifest.5
 
 %check
@@ -82,16 +83,20 @@ install -p -m 0644 docs/man/c2p-openscap-manifest.5 %{buildroot}%{_mandir}/man5/
 go test -mod=vendor -race -v ./...
 
 %files
-%defattr(0644, root, root, 0755)
 %attr(0755, root, root) %{_bindir}/complyctl
 %license LICENSE
 %{_mandir}/man1/complyctl.1*
-%{_datadir}/%{name}/samples/{sample-catalog.json,sample-component-definition.json,sample-profile.json}
-%{_datadir}/%{name}/{plugins,bundles,controls}
-%{_sysconfdir}/%{name}/config.d
+%dir %{_datadir}/%{app_dir}
+%dir %{_datadir}/%{app_dir}/{plugins,bundles,controls,samples}
+%dir %{_libexecdir}/%{app_dir}
+%dir %{_libexecdir}/%{app_dir}/plugins
+%dir %{_sysconfdir}/%{app_dir}
+%dir %{_sysconfdir}/%{app_dir}/config.d
+%{_datadir}/%{app_dir}/samples/{sample-catalog.json,sample-component-definition.json,sample-profile.json}
 
 %files          openscap-plugin
-%attr(0755, root, root) %{_libexecdir}/%{name}/plugins/openscap-plugin
+%attr(0755, root, root) %{_libexecdir}/%{app_dir}/plugins/openscap-plugin
+%license LICENSE
 %{_mandir}/man5/c2p-openscap-manifest.5*
 
 %changelog

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -33,57 +33,11 @@ cp docs/samples/sample-profile.json docs/samples/sample-catalog.json ~/.local/sh
 Each plugin requires a plugin manifest. For more information about plugin discovery see [PLUGIN_GUIDE.md](PLUGIN_GUIDE.md).
 
 ```bash
-cp bin/openscap-plugin ~/.local/share/complytime/plugins
-checksum=$(sha256sum ~/.local/share/complytime/plugins/openscap-plugin| cut -d ' ' -f 1 )
-cat > ~/.local/share/complytime/plugins/c2p-openscap-manifest.json << EOF
-{
-  "metadata": {
-    "id": "openscap",
-    "description": "My openscap plugin",
-    "version": "0.0.1",
-    "types": [
-      "pvp"
-    ]
-  },
-  "executablePath": "openscap-plugin",
-  "sha256": "$checksum",
-  "configuration": [
-    {
-      "name": "workspace",
-      "description": "Directory for writing plugin artifacts",
-      "required": true
-    },
-    {
-      "name": "profile",
-      "description": "The OpenSCAP profile to run for assessment",
-      "required": true
-    },
-    {
-      "name": "datastream",
-      "description": "The OpenSCAP datastream to use. If not set, the plugin will try to determine it based on system information",
-      "required": false
-    },
-    {
-      "name": "policy",
-      "description": "The name of the generated tailoring file",
-      "default": "tailoring_policy.xml",
-      "required": false
-    },
-    {
-      "name": "arf",
-      "description": "The name of the generated ARF file",
-      "default": "arf.xml",
-      "required": false
-    },
-    {
-      "name": "results",
-      "description": "The name of the generated results file",
-      "default": "results.xml",
-      "required": false
-    }
-  ]
-}
-EOF
+plugin_dir="$HOME/.local/share/complytime/plugins"
+cp "bin/openscap-plugin" "docs/samples/c2p-openscap-manifest.json" "$plugin_dir"
+checksum=$(sha256sum ~/.local/share/complytime/plugins/openscap-plugin | awk '{ print $1 }' )
+version=$(bin/complyctl version | head -n1 | awk '{ print $2 }' | sed -E 's/^v([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+sed -i -e "s|checksum_placeholder|$checksum|" -e "s|version_placeholder|$version|" "$plugin_dir/c2p-openscap-manifest.json"
 ```
 
 ## Step 4: Edit plugin configuration (optional)

--- a/docs/samples/c2p-openscap-manifest.json
+++ b/docs/samples/c2p-openscap-manifest.json
@@ -1,0 +1,47 @@
+{
+  "metadata": {
+    "id": "openscap",
+    "description": "OpenSCAP Plugin for complyctl",
+    "version": "version_placeholder",
+    "types": [
+      "pvp"
+    ]
+  },
+  "executablePath": "openscap-plugin",
+  "sha256": "checksum_placeholder",
+  "configuration": [
+    {
+      "name": "workspace",
+      "description": "Directory for writing plugin artifacts",
+      "required": true
+    },
+    {
+      "name": "profile",
+      "description": "The OpenSCAP profile to run for assessment",
+      "required": true
+    },
+    {
+      "name": "datastream",
+      "description": "The OpenSCAP datastream to use. If not set, the plugin will try to determine it based on system information",
+      "required": false
+    },
+    {
+      "name": "results",
+      "description": "The name of the generated results file",
+      "default": "results.xml",
+      "required": false
+    },
+    {
+      "name": "arf",
+      "description": "The name of the generated ARF file",
+      "default": "arf.xml",
+      "required": false
+    },
+    {
+      "name": "policy",
+      "description": "The name of the generated tailoring file",
+      "default": "tailoring_policy.xml",
+      "required": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

In the process to introduce `complyctl` in Fedora, some improvement opportunities were detected and addressed.
This PR includes the changes made during the Fedora Package review process.

## Related Issues

- https://bugzilla.redhat.com/show_bug.cgi?id=2375155
- https://pagure.io/releng/fedora-scm-requests/issue/77129

## Review Hints

This SPEC file can't be built in Fedora 41 because it depends on go 1.24 and Fedora 41 uses go 1.23.
In Fedora 42 it should work fine, but complytime-demos still needs to be updated to use Fedora 42 but there is a PR already updating the RPM Playbook: https://github.com/complytime/complytime-demos/pull/18

- https://docs.fedoraproject.org/en-US/packaging-guidelines/Golang/#_prep_goprep_removing_vendoring
- https://fedoraproject.org/wiki/Changes/GolangPackagesVendoredByDefault
- https://pagure.io/fesco/issue/3431