### PR TITLE
feat: CPLYTM-814 add support for excluding rules in a scope config

### DIFF
--- a/internal/complytime/plan/scope.go
+++ b/internal/complytime/plan/scope.go
@@ -13,8 +13,9 @@ import (
 
 // ControlEntry represents a control in the assessment scope
 type ControlEntry struct {
-	ControlID string   `yaml:"controlId"`
-	Rules     []string `yaml:"includeRules"`
+	ControlID    string   `yaml:"controlId"`
+	IncludeRules []string `yaml:"includeRules"`
+	ExcludeRules []string `yaml:"excludeRules,omitempty"`
 }
 
 // AssessmentScope sets up the yaml mapping type for writing to config file.
@@ -25,7 +26,8 @@ type AssessmentScope struct {
 	FrameworkID string `yaml:"frameworkId"`
 	// IncludeControls defines controls that are in scope
 	// of an assessment.
-	IncludeControls []ControlEntry `yaml:"includeControls"`
+	IncludeControls    []ControlEntry `yaml:"includeControls"`
+	GlobalExcludeRules []string       `yaml:"globalExcludeRules,omitempty"`
 }
 
 // NewAssessmentScope creates an AssessmentScope struct for a given framework id.
@@ -74,8 +76,8 @@ func NewAssessmentScopeFromCDs(frameworkId string, cds ...oscalTypes.ComponentDe
 	scope.IncludeControls = make([]ControlEntry, len(controlIDs))
 	for i, id := range controlIDs {
 		scope.IncludeControls[i] = ControlEntry{
-			ControlID: id,
-			Rules:     []string{"*"}, // by default, include all rules
+			ControlID:    id,
+			IncludeRules: []string{"*"}, // by default, include all rules
 		}
 	}
 	sort.Slice(scope.IncludeControls, func(i, j int) bool {
@@ -91,6 +93,7 @@ func (a AssessmentScope) ApplyScope(assessmentPlan *oscalTypes.AssessmentPlan, l
 	// This is a thin wrapper right now, but the goal to expand to different areas
 	// of customization.
 	a.applyControlScope(assessmentPlan, logger)
+	a.applyRuleScope(assessmentPlan, logger)
 }
 
 // applyControlScope alters the AssessedControls of the given OSCAL Assessment Plan by the AssessmentScope
@@ -168,6 +171,105 @@ func (a AssessmentScope) applyControlScope(assessmentPlan *oscalTypes.Assessment
 	}
 }
 
+// applyRuleScope alters the AssessedControls of activities based on IncludeRules and ExcludeRules configuration
+func (a AssessmentScope) applyRuleScope(assessmentPlan *oscalTypes.AssessmentPlan, logger hclog.Logger) {
+	// Convert global exclude rules to a map for fast lookup
+	globalExcludeRules := make(map[string]struct{})
+	for _, rule := range a.GlobalExcludeRules {
+		globalExcludeRules[rule] = struct{}{}
+	}
+
+	// Check if globalExcludeRules contains "*" (exclude all rules globally)
+	_, hasGlobalWildcard := globalExcludeRules["*"]
+	if hasGlobalWildcard {
+		logger.Warn("Global exclude rules contains '*' - all rules will be excluded from all controls")
+	}
+
+	// Build a map of control ID to ControlEntry for quick lookup
+	controlRuleConfig := make(map[string]ControlEntry)
+	for _, entry := range a.IncludeControls {
+		// Normalize the entry before storing it in the map
+		normalizedEntry := entry
+
+		// If globalExcludeRules contains "*", all rules are globally excluded
+		if hasGlobalWildcard {
+			normalizedEntry.IncludeRules = []string{} // Clear includeRules since all rules are globally excluded
+			normalizedEntry.ExcludeRules = []string{} // Clear excludeRules since global takes precedence
+		} else if a.isRuleInList("*", normalizedEntry.ExcludeRules) {
+			// If excludeRules contains "*", includeRules doesn't matter
+			normalizedEntry.IncludeRules = []string{} // Clear includeRules since they don't matter
+		} else if len(normalizedEntry.IncludeRules) == 0 {
+			normalizedEntry.IncludeRules = []string{"*"}
+		}
+		controlRuleConfig[entry.ControlID] = normalizedEntry
+	}
+	logger.Debug("Applying rule scope filtering", "globalExcludeRules", len(globalExcludeRules))
+
+	if assessmentPlan.LocalDefinitions != nil {
+		if assessmentPlan.LocalDefinitions.Activities != nil {
+			for activityI := range *assessmentPlan.LocalDefinitions.Activities {
+				activity := &(*assessmentPlan.LocalDefinitions.Activities)[activityI]
+
+				// Get the rules this activity implements
+				activityRules := a.getActivityRules(activity)
+				if len(activityRules) == 0 {
+					continue // No rules to filter
+				}
+
+				if activity.RelatedControls != nil && activity.RelatedControls.ControlSelections != nil {
+					controlSelections := activity.RelatedControls.ControlSelections
+					for controlSelectionI := range controlSelections {
+						controlSelection := &controlSelections[controlSelectionI]
+						a.filterControlSelectionByRules(controlSelection, activityRules, controlRuleConfig, globalExcludeRules, logger, activity.Title)
+						if controlSelection.IncludeControls == nil {
+							activity.RelatedControls = nil
+							if activity.Props == nil {
+								activity.Props = &[]oscalTypes.Property{}
+							}
+							skippedActivity := oscalTypes.Property{
+								Name:  "skipped",
+								Value: "true",
+								Ns:    extensions.TrestleNameSpace,
+							}
+							*activity.Props = append(*activity.Props, skippedActivity)
+						}
+					}
+				}
+
+				if activity.Steps != nil {
+					for stepI := range *activity.Steps {
+						step := &(*activity.Steps)[stepI]
+						if step.ReviewedControls == nil {
+							continue
+						}
+						if step.ReviewedControls.ControlSelections == nil {
+							continue
+						}
+						controlSelections := step.ReviewedControls.ControlSelections
+						for controlSelectionI := range controlSelections {
+							controlSelection := &controlSelections[controlSelectionI]
+							a.filterControlSelectionByRules(controlSelection, activityRules, controlRuleConfig, globalExcludeRules, logger, activity.Title)
+							if controlSelection.IncludeControls == nil {
+								activity.RelatedControls.ControlSelections = nil
+								step.ReviewedControls = nil
+								if step.Props == nil {
+									step.Props = &[]oscalTypes.Property{}
+								}
+								skipped := oscalTypes.Property{
+									Name:  "skipped",
+									Value: "true",
+									Ns:    extensions.TrestleNameSpace,
+								}
+								*step.Props = append(*step.Props, skipped)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
 func filterControlSelection(controlSelection *oscalTypes.AssessedControls, includedControls includeControlsSet) {
 	// The new included controls should be the intersection of
 	// the originally included controls and the newly included controls.
@@ -196,6 +298,112 @@ func filterControlSelection(controlSelection *oscalTypes.AssessedControls, inclu
 	} else {
 		controlSelection.IncludeControls = nil
 	}
+}
+
+// getActivityRules extracts rule IDs from an activity's properties and step properties
+func (a AssessmentScope) getActivityRules(activity *oscalTypes.Activity) []string {
+	var rules []string
+	ruleSet := make(map[string]struct{}) // For deduplication
+
+	// Check activity-level properties for Rule_Id
+	if activity.Props != nil {
+		for _, prop := range *activity.Props {
+			if prop.Name == extensions.RuleIdProp {
+				if _, exists := ruleSet[prop.Value]; !exists {
+					rules = append(rules, prop.Value)
+					ruleSet[prop.Value] = struct{}{}
+				}
+			}
+		}
+	}
+
+	// Check step-level properties for Rule_Id
+	if activity.Steps != nil {
+		for _, step := range *activity.Steps {
+			if step.Props != nil {
+				for _, prop := range *step.Props {
+					if prop.Name == extensions.RuleIdProp {
+						if _, exists := ruleSet[prop.Value]; !exists {
+							rules = append(rules, prop.Value)
+							ruleSet[prop.Value] = struct{}{}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return rules
+}
+
+// filterControlSelectionByRules removes controls from a selection if the activity's rules should be excluded for those controls
+func (a AssessmentScope) filterControlSelectionByRules(controlSelection *oscalTypes.AssessedControls, activityRules []string, controlRuleConfig map[string]ControlEntry, globalExcludeRules map[string]struct{}, logger hclog.Logger, activityTitle string) {
+	if controlSelection.IncludeControls == nil {
+		return
+	}
+
+	var filteredControls []oscalTypes.AssessedControlsSelectControlById
+
+	for _, control := range *controlSelection.IncludeControls {
+		controlEntry, exists := controlRuleConfig[control.ControlId]
+		if !exists {
+			// Control not in our scope configuration, keep it
+			filteredControls = append(filteredControls, control)
+			continue
+		}
+
+		shouldKeepControl := true
+		for _, ruleID := range activityRules {
+			// Check global exclude rules first (highest priority)
+			if _, isGloballyExcluded := globalExcludeRules[ruleID]; isGloballyExcluded {
+				shouldKeepControl = false
+				logger.Debug("Removing control from activity due to globally excluded rule", "control", control.ControlId, "rule", ruleID, "activity", activityTitle)
+				break
+			}
+
+			// Check if "*" is globally excluded (exclude all rules)
+			if _, isAllGloballyExcluded := globalExcludeRules["*"]; isAllGloballyExcluded {
+				shouldKeepControl = false
+				logger.Debug("Removing control from activity due to global exclude all rules", "control", control.ControlId, "rule", ruleID, "activity", activityTitle)
+				break
+			}
+
+			// Check if rule is in control-specific exclude list
+			if a.isRuleInList(ruleID, controlEntry.ExcludeRules) {
+				shouldKeepControl = false
+				logger.Debug("Removing control from activity due to control-specific excluded rule", "control", control.ControlId, "rule", ruleID, "activity", activityTitle)
+				break
+			}
+
+			// Check if rule should be included (if not using wildcard)
+			if !a.isRuleInList("*", controlEntry.IncludeRules) && !a.isRuleInList(ruleID, controlEntry.IncludeRules) {
+				shouldKeepControl = false
+				logger.Debug("Removing control from activity due to rule not in include list", "control", control.ControlId, "rule", ruleID, "activity", activityTitle)
+				break
+			}
+		}
+
+		if shouldKeepControl {
+			filteredControls = append(filteredControls, control)
+		}
+	}
+
+	// Update the control selection
+	if len(filteredControls) == 0 {
+		controlSelection.IncludeControls = nil
+	} else {
+		*controlSelection.IncludeControls = filteredControls
+	}
+}
+
+// isRuleInList checks if a rule ID exists in a list of rules
+func (a AssessmentScope) isRuleInList(ruleID string, ruleList []string) bool {
+	for _, rule := range ruleList {
+		if rule == ruleID {
+			return true
+		}
+	}
+	return false
 }
 
 type includeControlsSet map[string]struct{}

--- a/internal/complytime/plan/scope_test.go
+++ b/internal/complytime/plan/scope_test.go
@@ -290,13 +290,6 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 					Activities: &[]oscalTypes.Activity{
 						{
 							Title: "rule-1",
-							Props: &[]oscalTypes.Property{
-								{
-									Name:  extensions.RuleIdProp,
-									Value: "rule-1",
-									Ns:    extensions.TrestleNameSpace,
-								},
-							},
 							RelatedControls: &oscalTypes.ReviewedControls{
 								ControlSelections: []oscalTypes.AssessedControls{
 									{
@@ -314,13 +307,6 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 						},
 						{
 							Title: "rule-2",
-							Props: &[]oscalTypes.Property{
-								{
-									Name:  extensions.RuleIdProp,
-									Value: "rule-2",
-									Ns:    extensions.TrestleNameSpace,
-								},
-							},
 							RelatedControls: &oscalTypes.ReviewedControls{
 								ControlSelections: []oscalTypes.AssessedControls{
 									{
@@ -346,13 +332,6 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 			wantActivities: &[]oscalTypes.Activity{
 				{
 					Title: "rule-1",
-					Props: &[]oscalTypes.Property{
-						{
-							Name:  extensions.RuleIdProp,
-							Value: "rule-1",
-							Ns:    extensions.TrestleNameSpace,
-						},
-					},
 					RelatedControls: &oscalTypes.ReviewedControls{
 						ControlSelections: []oscalTypes.AssessedControls{
 							{
@@ -367,13 +346,6 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 				},
 				{
 					Title: "rule-2",
-					Props: &[]oscalTypes.Property{
-						{
-							Name:  extensions.RuleIdProp,
-							Value: "rule-2",
-							Ns:    extensions.TrestleNameSpace,
-						},
-					},
 					RelatedControls: &oscalTypes.ReviewedControls{
 						ControlSelections: []oscalTypes.AssessedControls{
 							{
@@ -395,13 +367,6 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 					Activities: &[]oscalTypes.Activity{
 						{
 							Title: "rule-1",
-							Props: &[]oscalTypes.Property{
-								{
-									Name:  extensions.RuleIdProp,
-									Value: "rule-1",
-									Ns:    extensions.TrestleNameSpace,
-								},
-							},
 							RelatedControls: &oscalTypes.ReviewedControls{
 								ControlSelections: []oscalTypes.AssessedControls{
 									{
@@ -416,13 +381,6 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 						},
 						{
 							Title: "rule-2",
-							Props: &[]oscalTypes.Property{
-								{
-									Name:  extensions.RuleIdProp,
-									Value: "rule-2",
-									Ns:    extensions.TrestleNameSpace,
-								},
-							},
 							RelatedControls: &oscalTypes.ReviewedControls{
 								ControlSelections: []oscalTypes.AssessedControls{
 									{
@@ -450,11 +408,6 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 					Title: "rule-1",
 					Props: &[]oscalTypes.Property{
 						{
-							Name:  extensions.RuleIdProp,
-							Value: "rule-1",
-							Ns:    extensions.TrestleNameSpace,
-						},
-						{
 							Name:  "skipped",
 							Value: "true",
 							Ns:    extensions.TrestleNameSpace,
@@ -464,13 +417,6 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 				},
 				{
 					Title: "rule-2",
-					Props: &[]oscalTypes.Property{
-						{
-							Name:  extensions.RuleIdProp,
-							Value: "rule-2",
-							Ns:    extensions.TrestleNameSpace,
-						},
-					},
 					RelatedControls: &oscalTypes.ReviewedControls{
 						ControlSelections: []oscalTypes.AssessedControls{
 							{
@@ -492,13 +438,6 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 					Activities: &[]oscalTypes.Activity{
 						{
 							Title: "rule-1",
-							Props: &[]oscalTypes.Property{
-								{
-									Name:  extensions.RuleIdProp,
-									Value: "rule-1",
-									Ns:    extensions.TrestleNameSpace,
-								},
-							},
 							RelatedControls: &oscalTypes.ReviewedControls{
 								ControlSelections: []oscalTypes.AssessedControls{
 									{
@@ -513,13 +452,6 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 						},
 						{
 							Title: "rule-2",
-							Props: &[]oscalTypes.Property{
-								{
-									Name:  extensions.RuleIdProp,
-									Value: "rule-2",
-									Ns:    extensions.TrestleNameSpace,
-								},
-							},
 							RelatedControls: &oscalTypes.ReviewedControls{
 								ControlSelections: []oscalTypes.AssessedControls{
 									{
@@ -546,11 +478,6 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 					Title: "rule-1",
 					Props: &[]oscalTypes.Property{
 						{
-							Name:  extensions.RuleIdProp,
-							Value: "rule-1",
-							Ns:    extensions.TrestleNameSpace,
-						},
-						{
 							Name:  "skipped",
 							Value: "true",
 							Ns:    extensions.TrestleNameSpace,
@@ -560,13 +487,6 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 				},
 				{
 					Title: "rule-2",
-					Props: &[]oscalTypes.Property{
-						{
-							Name:  extensions.RuleIdProp,
-							Value: "rule-2",
-							Ns:    extensions.TrestleNameSpace,
-						},
-					},
 					RelatedControls: &oscalTypes.ReviewedControls{
 						ControlSelections: []oscalTypes.AssessedControls{
 							{
@@ -588,13 +508,6 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 					Activities: &[]oscalTypes.Activity{
 						{
 							Title: "rule-1",
-							Props: &[]oscalTypes.Property{
-								{
-									Name:  extensions.RuleIdProp,
-									Value: "rule-1",
-									Ns:    extensions.TrestleNameSpace,
-								},
-							},
 							RelatedControls: &oscalTypes.ReviewedControls{
 								ControlSelections: []oscalTypes.AssessedControls{
 									{
@@ -609,13 +522,6 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 						},
 						{
 							Title: "rule-2",
-							Props: &[]oscalTypes.Property{
-								{
-									Name:  extensions.RuleIdProp,
-									Value: "rule-2",
-									Ns:    extensions.TrestleNameSpace,
-								},
-							},
 							RelatedControls: &oscalTypes.ReviewedControls{
 								ControlSelections: []oscalTypes.AssessedControls{
 									{
@@ -642,11 +548,6 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 					Title: "rule-1",
 					Props: &[]oscalTypes.Property{
 						{
-							Name:  extensions.RuleIdProp,
-							Value: "rule-1",
-							Ns:    extensions.TrestleNameSpace,
-						},
-						{
 							Name:  "skipped",
 							Value: "true",
 							Ns:    extensions.TrestleNameSpace,
@@ -657,11 +558,6 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 				{
 					Title: "rule-2",
 					Props: &[]oscalTypes.Property{
-						{
-							Name:  extensions.RuleIdProp,
-							Value: "rule-2",
-							Ns:    extensions.TrestleNameSpace,
-						},
 						{
 							Name:  "skipped",
 							Value: "true",
@@ -679,13 +575,6 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 					Activities: &[]oscalTypes.Activity{
 						{
 							Title: "rule-1",
-							Props: &[]oscalTypes.Property{
-								{
-									Name:  extensions.RuleIdProp,
-									Value: "rule-1",
-									Ns:    extensions.TrestleNameSpace,
-								},
-							},
 							RelatedControls: &oscalTypes.ReviewedControls{
 								ControlSelections: []oscalTypes.AssessedControls{
 									{
@@ -700,13 +589,6 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 						},
 						{
 							Title: "rule-2",
-							Props: &[]oscalTypes.Property{
-								{
-									Name:  extensions.RuleIdProp,
-									Value: "rule-2",
-									Ns:    extensions.TrestleNameSpace,
-								},
-							},
 							RelatedControls: &oscalTypes.ReviewedControls{
 								ControlSelections: []oscalTypes.AssessedControls{
 									{
@@ -734,11 +616,6 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 					Title: "rule-1",
 					Props: &[]oscalTypes.Property{
 						{
-							Name:  extensions.RuleIdProp,
-							Value: "rule-1",
-							Ns:    extensions.TrestleNameSpace,
-						},
-						{
 							Name:  "skipped",
 							Value: "true",
 							Ns:    extensions.TrestleNameSpace,
@@ -748,13 +625,6 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 				},
 				{
 					Title: "rule-2",
-					Props: &[]oscalTypes.Property{
-						{
-							Name:  extensions.RuleIdProp,
-							Value: "rule-2",
-							Ns:    extensions.TrestleNameSpace,
-						},
-					},
 					RelatedControls: &oscalTypes.ReviewedControls{
 						ControlSelections: []oscalTypes.AssessedControls{
 							{

--- a/internal/complytime/plan/scope_test.go
+++ b/internal/complytime/plan/scope_test.go
@@ -44,8 +44,8 @@ func TestNewAssessmentScopeFromCDs(t *testing.T) {
 	wantScope := AssessmentScope{
 		FrameworkID: "example",
 		IncludeControls: []ControlEntry{
-			{ControlID: "control-1", Rules: []string{"*"}},
-			{ControlID: "control-2", Rules: []string{"*"}},
+			{ControlID: "control-1", IncludeRules: []string{"*"}},
+			{ControlID: "control-2", IncludeRules: []string{"*"}},
 		},
 	}
 	scope, err := NewAssessmentScopeFromCDs("example", cd)
@@ -112,7 +112,7 @@ func TestAssessmentScope_ApplyScope(t *testing.T) {
 			scope: AssessmentScope{
 				FrameworkID: "test",
 				IncludeControls: []ControlEntry{
-					{ControlID: "example-2", Rules: []string{"*"}},
+					{ControlID: "example-2", IncludeRules: []string{"*"}},
 				},
 			},
 			wantSelections: []oscalTypes.AssessedControls{
@@ -169,8 +169,8 @@ func TestAssessmentScope_ApplyScope(t *testing.T) {
 			scope: AssessmentScope{
 				FrameworkID: "test",
 				IncludeControls: []ControlEntry{
-					{ControlID: "example-1", Rules: []string{"*"}},
-					{ControlID: "example-2", Rules: []string{"*"}},
+					{ControlID: "example-1", IncludeRules: []string{"*"}},
+					{ControlID: "example-2", IncludeRules: []string{"*"}},
 				},
 			},
 			wantSelections: []oscalTypes.AssessedControls{
@@ -184,14 +184,598 @@ func TestAssessmentScope_ApplyScope(t *testing.T) {
 			},
 		},
 	}
-	{
-	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			scope := tt.scope
 			scope.ApplyScope(tt.basePlan, testLogger)
 			require.Equal(t, tt.wantSelections, tt.basePlan.ReviewedControls.ControlSelections)
+		})
+	}
+}
+
+func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
+	testLogger := hclog.NewNullLogger()
+
+	tests := []struct {
+		name           string
+		basePlan       *oscalTypes.AssessmentPlan
+		scope          AssessmentScope
+		wantActivities *[]oscalTypes.Activity
+	}{
+		{
+			name: "Success/Default",
+			basePlan: &oscalTypes.AssessmentPlan{
+				LocalDefinitions: &oscalTypes.LocalDefinitions{
+					Activities: &[]oscalTypes.Activity{
+						{
+							Title: "rule-1",
+							RelatedControls: &oscalTypes.ReviewedControls{
+								ControlSelections: []oscalTypes.AssessedControls{
+									{
+										IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+											{
+												ControlId: "example-1",
+											},
+											{
+												ControlId: "example-2",
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Title: "rule-2",
+							RelatedControls: &oscalTypes.ReviewedControls{
+								ControlSelections: []oscalTypes.AssessedControls{
+									{
+										IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+											{
+												ControlId: "example-1",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			scope: AssessmentScope{
+				FrameworkID: "test",
+				IncludeControls: []ControlEntry{
+					{ControlID: "example-1", IncludeRules: []string{"*"}},
+					{ControlID: "example-2", IncludeRules: []string{"*"}},
+				},
+			},
+			wantActivities: &[]oscalTypes.Activity{
+				{
+					Title: "rule-1",
+					RelatedControls: &oscalTypes.ReviewedControls{
+						ControlSelections: []oscalTypes.AssessedControls{
+							{
+								IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+									{
+										ControlId: "example-1",
+									},
+									{
+										ControlId: "example-2",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Title: "rule-2",
+					RelatedControls: &oscalTypes.ReviewedControls{
+						ControlSelections: []oscalTypes.AssessedControls{
+							{
+								IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+									{
+										ControlId: "example-1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Success/ExcludeRuleForControl",
+			basePlan: &oscalTypes.AssessmentPlan{
+				LocalDefinitions: &oscalTypes.LocalDefinitions{
+					Activities: &[]oscalTypes.Activity{
+						{
+							Title: "rule-1",
+							Props: &[]oscalTypes.Property{
+								{
+									Name:  extensions.RuleIdProp,
+									Value: "rule-1",
+									Ns:    extensions.TrestleNameSpace,
+								},
+							},
+							RelatedControls: &oscalTypes.ReviewedControls{
+								ControlSelections: []oscalTypes.AssessedControls{
+									{
+										IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+											{
+												ControlId: "control-1",
+											},
+											{
+												ControlId: "control-2",
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Title: "rule-2",
+							Props: &[]oscalTypes.Property{
+								{
+									Name:  extensions.RuleIdProp,
+									Value: "rule-2",
+									Ns:    extensions.TrestleNameSpace,
+								},
+							},
+							RelatedControls: &oscalTypes.ReviewedControls{
+								ControlSelections: []oscalTypes.AssessedControls{
+									{
+										IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+											{
+												ControlId: "control-1",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			scope: AssessmentScope{
+				FrameworkID: "test",
+				IncludeControls: []ControlEntry{
+					{ControlID: "control-1", IncludeRules: []string{"*"}, ExcludeRules: []string{"rule-1"}},
+					{ControlID: "control-2", IncludeRules: []string{"*"}},
+				},
+			},
+			wantActivities: &[]oscalTypes.Activity{
+				{
+					Title: "rule-1",
+					Props: &[]oscalTypes.Property{
+						{
+							Name:  extensions.RuleIdProp,
+							Value: "rule-1",
+							Ns:    extensions.TrestleNameSpace,
+						},
+					},
+					RelatedControls: &oscalTypes.ReviewedControls{
+						ControlSelections: []oscalTypes.AssessedControls{
+							{
+								IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+									{
+										ControlId: "control-2",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Title: "rule-2",
+					Props: &[]oscalTypes.Property{
+						{
+							Name:  extensions.RuleIdProp,
+							Value: "rule-2",
+							Ns:    extensions.TrestleNameSpace,
+						},
+					},
+					RelatedControls: &oscalTypes.ReviewedControls{
+						ControlSelections: []oscalTypes.AssessedControls{
+							{
+								IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+									{
+										ControlId: "control-1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Success/ActivityMarkedSkipped",
+			basePlan: &oscalTypes.AssessmentPlan{
+				LocalDefinitions: &oscalTypes.LocalDefinitions{
+					Activities: &[]oscalTypes.Activity{
+						{
+							Title: "rule-1",
+							Props: &[]oscalTypes.Property{
+								{
+									Name:  extensions.RuleIdProp,
+									Value: "rule-1",
+									Ns:    extensions.TrestleNameSpace,
+								},
+							},
+							RelatedControls: &oscalTypes.ReviewedControls{
+								ControlSelections: []oscalTypes.AssessedControls{
+									{
+										IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+											{
+												ControlId: "control-1",
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Title: "rule-2",
+							Props: &[]oscalTypes.Property{
+								{
+									Name:  extensions.RuleIdProp,
+									Value: "rule-2",
+									Ns:    extensions.TrestleNameSpace,
+								},
+							},
+							RelatedControls: &oscalTypes.ReviewedControls{
+								ControlSelections: []oscalTypes.AssessedControls{
+									{
+										IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+											{
+												ControlId: "control-2",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			scope: AssessmentScope{
+				FrameworkID: "test",
+				IncludeControls: []ControlEntry{
+					{ControlID: "control-1", IncludeRules: []string{"*"}, ExcludeRules: []string{"rule-1"}},
+					{ControlID: "control-2", IncludeRules: []string{"*"}},
+				},
+			},
+			wantActivities: &[]oscalTypes.Activity{
+				{
+					Title: "rule-1",
+					Props: &[]oscalTypes.Property{
+						{
+							Name:  extensions.RuleIdProp,
+							Value: "rule-1",
+							Ns:    extensions.TrestleNameSpace,
+						},
+						{
+							Name:  "skipped",
+							Value: "true",
+							Ns:    extensions.TrestleNameSpace,
+						},
+					},
+					RelatedControls: nil,
+				},
+				{
+					Title: "rule-2",
+					Props: &[]oscalTypes.Property{
+						{
+							Name:  extensions.RuleIdProp,
+							Value: "rule-2",
+							Ns:    extensions.TrestleNameSpace,
+						},
+					},
+					RelatedControls: &oscalTypes.ReviewedControls{
+						ControlSelections: []oscalTypes.AssessedControls{
+							{
+								IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+									{
+										ControlId: "control-2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Success/MissingIncludeRules",
+			basePlan: &oscalTypes.AssessmentPlan{
+				LocalDefinitions: &oscalTypes.LocalDefinitions{
+					Activities: &[]oscalTypes.Activity{
+						{
+							Title: "rule-1",
+							Props: &[]oscalTypes.Property{
+								{
+									Name:  extensions.RuleIdProp,
+									Value: "rule-1",
+									Ns:    extensions.TrestleNameSpace,
+								},
+							},
+							RelatedControls: &oscalTypes.ReviewedControls{
+								ControlSelections: []oscalTypes.AssessedControls{
+									{
+										IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+											{
+												ControlId: "control-1",
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Title: "rule-2",
+							Props: &[]oscalTypes.Property{
+								{
+									Name:  extensions.RuleIdProp,
+									Value: "rule-2",
+									Ns:    extensions.TrestleNameSpace,
+								},
+							},
+							RelatedControls: &oscalTypes.ReviewedControls{
+								ControlSelections: []oscalTypes.AssessedControls{
+									{
+										IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+											{
+												ControlId: "control-1",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			scope: AssessmentScope{
+				FrameworkID: "test",
+				IncludeControls: []ControlEntry{
+					{ControlID: "control-1", ExcludeRules: []string{"rule-1"}}, // Missing includeRules should default to "*"
+				},
+			},
+			wantActivities: &[]oscalTypes.Activity{
+				{
+					Title: "rule-1",
+					Props: &[]oscalTypes.Property{
+						{
+							Name:  extensions.RuleIdProp,
+							Value: "rule-1",
+							Ns:    extensions.TrestleNameSpace,
+						},
+						{
+							Name:  "skipped",
+							Value: "true",
+							Ns:    extensions.TrestleNameSpace,
+						},
+					},
+					RelatedControls: nil,
+				},
+				{
+					Title: "rule-2",
+					Props: &[]oscalTypes.Property{
+						{
+							Name:  extensions.RuleIdProp,
+							Value: "rule-2",
+							Ns:    extensions.TrestleNameSpace,
+						},
+					},
+					RelatedControls: &oscalTypes.ReviewedControls{
+						ControlSelections: []oscalTypes.AssessedControls{
+							{
+								IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+									{
+										ControlId: "control-1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Success/ExcludeAllRules",
+			basePlan: &oscalTypes.AssessmentPlan{
+				LocalDefinitions: &oscalTypes.LocalDefinitions{
+					Activities: &[]oscalTypes.Activity{
+						{
+							Title: "rule-1",
+							Props: &[]oscalTypes.Property{
+								{
+									Name:  extensions.RuleIdProp,
+									Value: "rule-1",
+									Ns:    extensions.TrestleNameSpace,
+								},
+							},
+							RelatedControls: &oscalTypes.ReviewedControls{
+								ControlSelections: []oscalTypes.AssessedControls{
+									{
+										IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+											{
+												ControlId: "control-1",
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Title: "rule-2",
+							Props: &[]oscalTypes.Property{
+								{
+									Name:  extensions.RuleIdProp,
+									Value: "rule-2",
+									Ns:    extensions.TrestleNameSpace,
+								},
+							},
+							RelatedControls: &oscalTypes.ReviewedControls{
+								ControlSelections: []oscalTypes.AssessedControls{
+									{
+										IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+											{
+												ControlId: "control-1",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			scope: AssessmentScope{
+				FrameworkID: "test",
+				IncludeControls: []ControlEntry{
+					{ControlID: "control-1", IncludeRules: []string{"rule-1", "rule-2"}, ExcludeRules: []string{"*"}}, // ExcludeRules="*" should override includeRules
+				},
+			},
+			wantActivities: &[]oscalTypes.Activity{
+				{
+					Title: "rule-1",
+					Props: &[]oscalTypes.Property{
+						{
+							Name:  extensions.RuleIdProp,
+							Value: "rule-1",
+							Ns:    extensions.TrestleNameSpace,
+						},
+						{
+							Name:  "skipped",
+							Value: "true",
+							Ns:    extensions.TrestleNameSpace,
+						},
+					},
+					RelatedControls: nil,
+				},
+				{
+					Title: "rule-2",
+					Props: &[]oscalTypes.Property{
+						{
+							Name:  extensions.RuleIdProp,
+							Value: "rule-2",
+							Ns:    extensions.TrestleNameSpace,
+						},
+						{
+							Name:  "skipped",
+							Value: "true",
+							Ns:    extensions.TrestleNameSpace,
+						},
+					},
+					RelatedControls: nil,
+				},
+			},
+		},
+		{
+			name: "Success/GlobalExcludeOverridesInclude",
+			basePlan: &oscalTypes.AssessmentPlan{
+				LocalDefinitions: &oscalTypes.LocalDefinitions{
+					Activities: &[]oscalTypes.Activity{
+						{
+							Title: "rule-1",
+							Props: &[]oscalTypes.Property{
+								{
+									Name:  extensions.RuleIdProp,
+									Value: "rule-1",
+									Ns:    extensions.TrestleNameSpace,
+								},
+							},
+							RelatedControls: &oscalTypes.ReviewedControls{
+								ControlSelections: []oscalTypes.AssessedControls{
+									{
+										IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+											{
+												ControlId: "control-1",
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Title: "rule-2",
+							Props: &[]oscalTypes.Property{
+								{
+									Name:  extensions.RuleIdProp,
+									Value: "rule-2",
+									Ns:    extensions.TrestleNameSpace,
+								},
+							},
+							RelatedControls: &oscalTypes.ReviewedControls{
+								ControlSelections: []oscalTypes.AssessedControls{
+									{
+										IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+											{
+												ControlId: "control-1",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			scope: AssessmentScope{
+				FrameworkID:        "test",
+				GlobalExcludeRules: []string{"rule-1"}, // Global exclude should override control-specific include
+				IncludeControls: []ControlEntry{
+					{ControlID: "control-1", IncludeRules: []string{"rule-1", "rule-2"}}, // Explicitly includes rule-1, but global exclude wins
+				},
+			},
+			wantActivities: &[]oscalTypes.Activity{
+				{
+					Title: "rule-1",
+					Props: &[]oscalTypes.Property{
+						{
+							Name:  extensions.RuleIdProp,
+							Value: "rule-1",
+							Ns:    extensions.TrestleNameSpace,
+						},
+						{
+							Name:  "skipped",
+							Value: "true",
+							Ns:    extensions.TrestleNameSpace,
+						},
+					},
+					RelatedControls: nil,
+				},
+				{
+					Title: "rule-2",
+					Props: &[]oscalTypes.Property{
+						{
+							Name:  extensions.RuleIdProp,
+							Value: "rule-2",
+							Ns:    extensions.TrestleNameSpace,
+						},
+					},
+					RelatedControls: &oscalTypes.ReviewedControls{
+						ControlSelections: []oscalTypes.AssessedControls{
+							{
+								IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+									{
+										ControlId: "control-1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scope := tt.scope
+			scope.ApplyScope(tt.basePlan, testLogger)
+			require.Equal(t, tt.wantActivities, tt.basePlan.LocalDefinitions.Activities)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

This PR adds support for excluding rules within a scope config.  There are two ways to exclude a rule:
- per control, by specifying an `excludeRules` section under that control in the yaml
- for all controls, by specify `globalExcludeRules` as a root key in the yaml

The order of priority is: 
- `globalExcludeRules` take highest priority.  If a rule is listed here then it is excluded for all controls regardless if a control has it included (or if a control has `includeRules: "*"`
- `excludeRules` takes priority over `includeRules` within a control.  This allows the user to keep the default content of `includeRules: "*"` and simply list the few rules they want to exclude.

Note: there is effectively a 1-to-1 relationship between "rules" and "activities".  If a rule is used by more than one control, then those control IDs will be listed inside that activity. 

When a rule is "excluded" there are a few possibilities:
- if that rule is only used by a single control, the action for that rule will have a new `property` to mark it as "skipped".  
- if a rule is used by > 1 control, then the control for which the rule has been "excluded" will have it's control ID removed from the activity, but the activity will not be marked as skipped (since it is still used by at least one control)

## Review Hints

[This code block ](https://github.com/gvauter/complyctl/blob/10d669e1ffd347485420052d8373d93fd07bfaf3/internal/complytime/plan/scope.go#L190) contains logic to normalize the `includeRules`, `excludeRules` and `globalExcludeRules` so that a user does not need to explicitly specify every section.

[This loop](https://github.com/gvauter/complyctl/blob/10d669e1ffd347485420052d8373d93fd07bfaf3/internal/complytime/plan/scope.go#L356) handles the order of priority for excluding/including.  globalExcludeRules > excludeRules > includeRules.

[This loop](https://github.com/gvauter/complyctl/blob/10d669e1ffd347485420052d8373d93fd07bfaf3/internal/complytime/plan/scope.go#L210) removes the control from the activity or marks activity as skipped depending on how many "included control" remain for that activity.

Example `config.yml`:

```
frameworkId: anssi_bp28_minimal
includeControls:
- controlId: r31
  includeRules:
  - "enable_authselect" # only this will will be included
- controlId: r59
  includeRules:
  - "*" # all rules will be included except `ensure_redhat_gpgkey_installed` which is excluded globally

globalExcludeRules:
  - "ensure_redhat_gpgkey_installed" # will be excluded for all controls
```