### PR TITLE
fix: CPLYTM-767 - detect datastream files without versions

### DIFF
--- a/cmd/openscap-plugin/config/config.go
+++ b/cmd/openscap-plugin/config/config.go
@@ -319,13 +319,11 @@ func findMatchingDatastream() (string, error) {
 						return filepath.SkipDir
 					}
 				}
-				if distroVersions == nil {
-					// In case of non-versioned or rolling release
-					pattern := fmt.Sprintf("ssg-%s-ds.xml", distroIds[id])
-					if info.Name() == pattern {
-						foundFile = path
-						return filepath.SkipDir
-					}
+				// In case of non-versioned or rolling release
+				pattern := fmt.Sprintf("ssg-%s-ds.xml", distroIds[id])
+				if info.Name() == pattern {
+					foundFile = path
+					return filepath.SkipDir
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Some datastreams provided by `scap-security-guide` does not contain the product version in the file name.
For example, when using `complyctl` in a Fedora system, it would report this error:
```
complyctl generate
...
ERROR error running complyctl: errors launching plugins: failed to configure plugin openscap: rpc error: code = Internal desc = could not determine a datastream file for a system with ids: [fedora] and versions: [42 42]
```
In these case it should detect the `ssg-fedora-ds.xml` file.
```
ls /usr/share/xml/scap/ssg/content/
ssg-al2023-ds.xml      ssg-anolis8-ds.xml   ssg-debian11-ds.xml  ssg-kylinserver10-ds.xml  ssg-ol9-ds.xml            ssg-rhel10-ds.xml  ssg-sle15-ds.xml       ssg-ubuntu2004-ds.xml
ssg-alinux2-ds.xml     ssg-centos8-ds.xml   ssg-debian12-ds.xml  ssg-ocp4-ds.xml           ssg-openembedded-ds.xml   ssg-rhel8-ds.xml   ssg-slmicro5-ds.xml    ssg-ubuntu2204-ds.xml
ssg-alinux3-ds.xml     ssg-chromium-ds.xml  ssg-eks-ds.xml       ssg-ol10-ds.xml           ssg-openeuler2203-ds.xml  ssg-rhel9-ds.xml   ssg-tencentos4-ds.xml  ssg-ubuntu2404-ds.xml
ssg-almalinux9-ds.xml  ssg-cs10-ds.xml      ssg-fedora-ds.xml    ssg-ol7-ds.xml            ssg-opensuse-ds.xml       ssg-rhv4-ds.xml    ssg-ubuntu1604-ds.xml
ssg-anolis23-ds.xml    ssg-cs9-ds.xml       ssg-firefox-ds.xml   ssg-ol8-ds.xml            ssg-rhcos4-ds.xml         ssg-sle12-ds.xml   ssg-ubuntu1804-ds.xml
```

## Related Issues

- https://issues.redhat.com/browse/CPLYTM-767

## Review Hints

It can be tested using `complytime-demos` in a Fedora VM.