### PR TITLE
doc: expand example command usage with scope config

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,51 +17,88 @@ ComplyCTL leverages [OSCAL](https://github.com/usnistgov/OSCAL/) to perform comp
 Determine the baseline you want to run a scan for and create an OSCAL [Assessment Plan](https://pages.nist.gov/OSCAL/learn/concepts/layer/assessment/assessment-plan/). The Assessment
 Plan will act as configuration to guide the complyctl generation and scanning operations.
 
+### `list` command
 ```bash
 complyctl list
 ...
 # Table appears with options. Look at the Framework ID column.
 ```
 
+### `info` command
 ```bash
 complyctl info <framework-id>
-...
 # Display information about a framework's controls and rules.
+
+complyctl info <framework-id> --control <control-id>
+# Display details about a specific control.
+
+complyctl info <framework-id> --rule <rule-id>
+# Display details about a specific rule.
 ```
 
+### `plan` command
 ```bash
 complyctl plan <framework-id>
 ...
 # The file will be written out to assessment-plan.json in the specified workspace.
 # Defaults to current working directory.
 
-cat assessment-plan.json
+cat complytime/assessment-plan.json
 # The default assessment-plan.json will be available in the complytime workspace (complytime/assessment-plan.json).
 
 complyctl plan <framework-id> --dry-run
 # See the default contents of the assessment-plan.json.
-
-complyctl plan <framework-id> --dry-run --out config.yml
-# Customize the assessment-plan.json with the "out" flag. Updates can be made in the config.yml.
-
-complyctl plan <framework-id> --scope-config config.yml
-# The config.yml will be loaded when passing "scope-config" to customize the assessment-plan.json.
 ```
 
-Run the generate command to `generate` policy artifacts in the workspace and run the `scan` command to execute the generated artifacts and get results.
 
+Use a scope config file to customize the assessment plan:
+```bash
+complyctl plan <framework-id> --dry-run --out config.yml
+# Customize the assessment-plan.json with the 'out' flag. Updates can be made to the config.yml.
+```
+Open the `config.yml` file in a text editor and modify the YAML as desired.  The example below shows various options for including and excluding rules.
+
+```yaml
+frameworkId: example-framework
+includeControls:
+- controlId: control-01
+  controlTitle: Title of Control 01
+  includeRules:
+  - "*" # all rules included by default
+- controlId: control-02
+  controlTitle: Title of Control 02
+  includeRules:
+  - "rule-02" # only rule-02 will be included for this control
+- controlId: control-03
+  controlTitle: Title of Control 03
+  includeRules:
+  - "*"
+  excludeRules:
+  - "rule-03" # exclude rule-03 specific rule from control-03
+
+globalExcludeRules:
+  - "rule-99" # will be excluded for all controls, this takes priority over any includeRules clauses above
+```
+
+The edited `config.yml` can then be used with the `plan` command to customize the assessment plan.
+```bash
+complyctl plan <framework-id> --scope-config config.yml
+# The config.yml will be loaded by passing '--scope-config' to customize the assessment-plan.json.
+```
+
+### `generate` command
 ```bash
 complyctl generate
-...
-complyctl scan
+# Run the `generate` command to generate the plugin specific policy artifacts in the workspace.
+```
 
-# The results will be written to assessment-results.json in the specified workspace.
-# Defaults to current working directory under folder "complytime".
+### `scan` command
+```bash
+complyctl scan
+# Run the `scan` command to execute the PVP plugins and create results artifacts. The results will be written to assessment-results.json in the specified workspace.
 
 complyctl scan --with-md
-
-# Both assessment-results.md and assessment-results.json will be written in the specified workspace.
-# Defaults to current working directory under folder "complytime".
+# Results can also be created in Markdown format by passing the `--with-md` flag.
 ```
 
 ## Contributing


### PR DESCRIPTION
## Summary
This PR updates the README to include details on using the `--scope-config` flag to exclude rules  when generating an assessment plan.
