### PR TITLE
chore: ensure included controls are ordered

### DIFF
--- a/internal/complytime/plan/scope.go
+++ b/internal/complytime/plan/scope.go
@@ -264,6 +264,10 @@ func filterControlSelection(controlSelection *oscalTypes.AssessedControls, inclu
 		}
 	}
 	if newIncludedControls != nil {
+		// Sort newIncludedControls by ControlId to ensure consistency after filtering
+		sort.Slice(newIncludedControls, func(i, j int) bool {
+			return newIncludedControls[i].ControlId < newIncludedControls[j].ControlId
+		})
 		controlSelection.IncludeControls = &newIncludedControls
 	} else {
 		controlSelection.IncludeControls = nil


### PR DESCRIPTION
## Summary

This should not affect the results but make the unit tests more reliable and could also help humans to review the files.

## Related Issues

- https://koji.fedoraproject.org/koji/taskinfo?taskID=134701093
- https://kojipkgs.fedoraproject.org//work/tasks/1111/134701111/build.log

## Review Hints

Run unit tests multiple times:
`make test-unit`

It was first noticed when building Fedora packages. I could randomly reproduce it locally.
It could also be possible to update the unit tests, but ensuring ordering may bring more benefits too.