### PR TITLE
feat: adding controlTitle to configured assessment plan

### DIFF
--- a/cmd/complyctl/cli/info.go
+++ b/cmd/complyctl/cli/info.go
@@ -196,7 +196,7 @@ func processControlImplementations(components []oscalTypes.DefinedComponent, rul
 					controlDetails, ok := controlMap[ir.ControlId]
 					if !ok {
 						// Initialize controlDetails if not already present
-						controlTitle, err := getControlTitle(ir.ControlId, controlImp, appDir, validator)
+						controlTitle, err := complytime.GetControlTitle(ir.ControlId, controlImp.Source, appDir, validator)
 						if err != nil {
 							logger.Warn("could not get title for control %s: %v", ir.ControlId, err)
 							controlTitle = "N/A"
@@ -258,40 +258,6 @@ func processComponentProperties(compDefs []oscalTypes.DefinedComponent) (ruleRem
 		}
 	}
 	return ruleRemarksMap, remarksPropsMap
-}
-
-// getControlTitle retrieves the title for a given control ID from the associated catalog.
-func getControlTitle(controlID string, controlImplementation oscalTypes.ControlImplementationSet, appDir complytime.ApplicationDirectory, validator *validation.SchemaValidator) (string, error) {
-	profile, err := complytime.LoadProfile(appDir, controlImplementation.Source, validator)
-	if err != nil {
-		return "", fmt.Errorf("failed to load profile from source '%s': %w", controlImplementation.Source, err)
-	}
-
-	if profile.Imports == nil {
-		return "", fmt.Errorf("profile '%s' has no imports", controlImplementation.Source)
-	}
-
-	for _, imp := range profile.Imports {
-		catalog, err := complytime.LoadCatalogSource(appDir, imp.Href, validator)
-		if err != nil {
-			logger.Warn("failed to load catalog from href '%s': %v", imp.Href, err)
-			continue
-		}
-		if catalog.Groups == nil {
-			continue
-		}
-		for _, group := range *catalog.Groups {
-			if group.Controls == nil {
-				continue
-			}
-			for _, control := range *group.Controls {
-				if control.ID == controlID && control.Title != "" {
-					return control.Title, nil
-				}
-			}
-		}
-	}
-	return "", fmt.Errorf("title for control '%s' not found in catalog", controlID)
 }
 
 // loadComponents retrieves components from component definitions by framework ID.

--- a/cmd/complyctl/cli/info.go
+++ b/cmd/complyctl/cli/info.go
@@ -199,7 +199,7 @@ func processControlImplementations(components []oscalTypes.DefinedComponent, rul
 						controlTitle, err := complytime.GetControlTitle(ir.ControlId, controlImp.Source, appDir, validator)
 						if err != nil {
 							logger.Warn("could not get title for control %s: %v", ir.ControlId, err)
-							controlTitle = "N/A"
+							controlTitle = ""
 						}
 
 						controlDetails = control{

--- a/cmd/complyctl/cli/plan.go
+++ b/cmd/complyctl/cli/plan.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/complytime/complyctl/cmd/complyctl/option"
 	"github.com/complytime/complyctl/internal/complytime"
-	"github.com/complytime/complyctl/internal/complytime/plan"
 )
 
 const assessmentPlanLocation = "assessment-plan.json"
@@ -121,7 +120,7 @@ func runPlan(cmd *cobra.Command, opts *planOptions) error {
 		if err != nil {
 			return fmt.Errorf("error reading assessment plan: %w", err)
 		}
-		assessmentScope := plan.AssessmentScope{}
+		assessmentScope := complytime.AssessmentScope{}
 		if err := yaml.Unmarshal(configBytes, &assessmentScope); err != nil {
 			return fmt.Errorf("error unmarshaling assessment plan: %w", err)
 		}
@@ -131,7 +130,7 @@ func runPlan(cmd *cobra.Command, opts *planOptions) error {
 	filePath := filepath.Join(opts.complyTimeOpts.UserWorkspace, assessmentPlanLocation)
 	cleanedPath := filepath.Clean(filePath)
 
-	if err := plan.WritePlan(assessmentPlan, opts.complyTimeOpts.FrameworkID, cleanedPath); err != nil {
+	if err := complytime.WritePlan(assessmentPlan, opts.complyTimeOpts.FrameworkID, cleanedPath); err != nil {
 		return fmt.Errorf("error writing assessment plan to %s: %w", cleanedPath, err)
 	}
 	logger.Info(fmt.Sprintf("Assessment plan written to %s\n", cleanedPath))
@@ -142,7 +141,7 @@ func runPlan(cmd *cobra.Command, opts *planOptions) error {
 func loadPlan(opts *option.ComplyTime, validator validation.Validator) (*oscalTypes.AssessmentPlan, string, error) {
 	apPath := filepath.Join(opts.UserWorkspace, assessmentPlanLocation)
 	apCleanedPath := filepath.Clean(apPath)
-	assessmentPlan, err := plan.ReadPlan(apCleanedPath, validator)
+	assessmentPlan, err := complytime.ReadPlan(apCleanedPath, validator)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, "", fmt.Errorf("error: assessment plan does not exist in workspace %s: %w\n\nDid you run the plan command?",
@@ -157,9 +156,16 @@ func loadPlan(opts *option.ComplyTime, validator validation.Validator) (*oscalTy
 // planDryRun leverages the AssessmentScope structure to populate tailoring config.
 // The config is written to stdout.
 func planDryRun(frameworkId string, cds []oscalTypes.ComponentDefinition, output string) error {
-	scope, err := plan.NewAssessmentScopeFromCDs(frameworkId, cds...)
+	// Create application directory and validator to get control titles
+	appDir, err := complytime.NewApplicationDirectory(true)
 	if err != nil {
-		return fmt.Errorf("error creating assessment scope for %s", frameworkId)
+		return fmt.Errorf("failed to initialize application directory: %w", err)
+	}
+	validator := validation.NewSchemaValidator()
+
+	scope, err := complytime.NewAssessmentScopeFromCDs(frameworkId, appDir, validator, cds...)
+	if err != nil {
+		return fmt.Errorf("error creating assessment scope for %s: %w", frameworkId, err)
 	}
 	data, err := yaml.Marshal(&scope)
 	if err != nil {

--- a/cmd/complyctl/cli/plan.go
+++ b/cmd/complyctl/cli/plan.go
@@ -163,10 +163,12 @@ func planDryRun(frameworkId string, cds []oscalTypes.ComponentDefinition, output
 	}
 	validator := validation.NewSchemaValidator()
 
+	logger.Debug("Loading control titles for framework", "frameworkId", frameworkId)
 	scope, err := complytime.NewAssessmentScopeFromCDs(frameworkId, appDir, validator, cds...)
 	if err != nil {
 		return fmt.Errorf("error creating assessment scope for %s: %w", frameworkId, err)
 	}
+	logger.Debug("Assessment scope created", "controls", len(scope.IncludeControls))
 	data, err := yaml.Marshal(&scope)
 	if err != nil {
 		return fmt.Errorf("error marshalling yaml content: %v", err)

--- a/internal/complytime/configuration.go
+++ b/internal/complytime/configuration.go
@@ -16,8 +16,6 @@ import (
 	"github.com/oscal-compass/oscal-sdk-go/models"
 	"github.com/oscal-compass/oscal-sdk-go/models/components"
 	"github.com/oscal-compass/oscal-sdk-go/validation"
-
-	"github.com/complytime/complyctl/internal/complytime/plan"
 )
 
 const (
@@ -192,7 +190,7 @@ func ActionsContextFromPlan(assessmentPlan *oscalTypes.AssessmentPlan) (*actions
 	if err != nil {
 		return nil, fmt.Errorf("error generating context from plan %s: %w", assessmentPlan.Metadata.Title, err)
 	}
-	apSettings, err := plan.Settings(assessmentPlan)
+	apSettings, err := Settings(assessmentPlan)
 	if err != nil {
 		return nil, fmt.Errorf("cannot extract settings from plan %s: %w", assessmentPlan.Metadata.Title, err)
 	}

--- a/internal/complytime/plan.go
+++ b/internal/complytime/plan.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-package plan
+package complytime
 
 import (
 	"encoding/json"
@@ -72,4 +72,37 @@ func Settings(plan *oscalTypes.AssessmentPlan) (settings.Settings, error) {
 		return settings.NewAssessmentActivitiesSettings(*plan.LocalDefinitions.Activities), nil
 	}
 	return settings.Settings{}, ErrNoActivities
+}
+
+// GetControlTitle retrieves the title for a control from the catalog
+func GetControlTitle(controlID string, controlSource string, appDir ApplicationDirectory, validator validation.Validator) (string, error) {
+	profile, err := LoadProfile(appDir, controlSource, validator)
+	if err != nil {
+		return "", fmt.Errorf("failed to load profile from source '%s': %w", controlSource, err)
+	}
+
+	if profile.Imports == nil {
+		return "", fmt.Errorf("profile '%s' has no imports", controlSource)
+	}
+
+	for _, imp := range profile.Imports {
+		catalog, err := LoadCatalogSource(appDir, imp.Href, validator)
+		if err != nil {
+			continue
+		}
+		if catalog.Groups == nil {
+			continue
+		}
+		for _, group := range *catalog.Groups {
+			if group.Controls == nil {
+				continue
+			}
+			for _, control := range *group.Controls {
+				if control.ID == controlID && control.Title != "" {
+					return control.Title, nil
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("title for control '%s' not found in catalog", controlID)
 }

--- a/internal/complytime/plan_test.go
+++ b/internal/complytime/plan_test.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-package plan
+package complytime
 
 import (
 	"path/filepath"

--- a/internal/complytime/scope_test.go
+++ b/internal/complytime/scope_test.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package plan
+package complytime
 
 import (
 	"testing"
@@ -7,11 +7,15 @@ import (
 	oscalTypes "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-3"
 	"github.com/hashicorp/go-hclog"
 	"github.com/oscal-compass/oscal-sdk-go/extensions"
+	"github.com/oscal-compass/oscal-sdk-go/validation"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewAssessmentScopeFromCDs(t *testing.T) {
-	_, err := NewAssessmentScopeFromCDs("example")
+	testAppDir := ApplicationDirectory{}
+	validator := validation.NoopValidator{}
+
+	_, err := NewAssessmentScopeFromCDs("example", testAppDir, validator)
 	require.EqualError(t, err, "no component definitions found")
 
 	cd := oscalTypes.ComponentDefinition{
@@ -44,11 +48,11 @@ func TestNewAssessmentScopeFromCDs(t *testing.T) {
 	wantScope := AssessmentScope{
 		FrameworkID: "example",
 		IncludeControls: []ControlEntry{
-			{ControlID: "control-1", IncludeRules: []string{"*"}},
-			{ControlID: "control-2", IncludeRules: []string{"*"}},
+			{ControlID: "control-1", ControlTitle: "", IncludeRules: []string{"*"}},
+			{ControlID: "control-2", ControlTitle: "", IncludeRules: []string{"*"}},
 		},
 	}
-	scope, err := NewAssessmentScopeFromCDs("example", cd)
+	scope, err := NewAssessmentScopeFromCDs("example", testAppDir, validator, cd)
 	require.NoError(t, err)
 	require.Equal(t, wantScope, scope)
 
@@ -77,7 +81,7 @@ func TestNewAssessmentScopeFromCDs(t *testing.T) {
 	}
 	*cd.Components = append(*cd.Components, anotherComponent)
 
-	scope, err = NewAssessmentScopeFromCDs("example", cd)
+	scope, err = NewAssessmentScopeFromCDs("example", testAppDir, validator, cd)
 	require.NoError(t, err)
 	require.Equal(t, wantScope, scope)
 }


### PR DESCRIPTION
## Summary
This PR introduces the `controlTitle` field for awareness of control-id name in the `config.yml`.  The `controlTitle` in the `config.yml` will update based on the controls associated with the `frameworkID`. 

This PR refactored the `internal/complytime/plan` package originally located inside of `internal/complytime` for better portability and reduction of cyclic import issues. 

#### What was changed

- Refactored `internal/complytime` package to no longer include `internal/complytime/plan`, essentially flattening the `internal/complytime` package for ease of importing within the package. 
- The `GetControlTitle` function was added to `internal/complytime/plan.go` and is used in the `cli` package for getting the control titles for both the `complyctl info` and `complyctl plan` commands. 
- The `loadControlTitlesFromSource` grabs the control titles from the control source and stores them as a map to be used in the `GetControlTitle` function. 

The new structure with the compressed `internal/complytime`
```tree
internal
├── complytime
│   ├── catalogs.go
│   ├── catalogs_test.go
│   ├── configuration.go
│   ├── configuration_test.go
│   ├── controls.go
│   ├── controls_test.go
│   ├── plan.go
│   ├── plan_test.go
│   ├── plugins.go
│   ├── plugins_test.go
│   ├── scan.go
│   ├── scan_test.go
│   ├── scope.go
│   ├── scope_test.go
│   └── testdata
│       ├── complytime
│       │   ├── bundles
│       │   │   └── example-component-definition.json
│       │   ├── controls
│       │   │   ├── sample-catalog.json
│       │   │   └── sample-profile.json
│       │   └── plugins
│       │       └── c2p-openscap-manifest.json
│       └── openscap
│           ├── invalid.xml
│           └── ssg-rhel-ds.xml
├── terminal
│   ├── spinner.go
│   ├── spinner_test.go
│   ├── table.go
│   └── table_test.go
├── utils
└── version
    ├── version.go
    └── version_test.go
```
## Related Issues

- Related to PR #190 

## Review Hints

#### Test by running the following commands
- `./bin/complyctl plan <frameworkId> --dry-run`
-  `./bin/complyctl plan <frameworkId> --dry-run --out config.yml`
-  `./bin/complyctl plan <frameworkId> --scope-config config.yml`

<img src="https://github.com/user-attachments/assets/2c22cdae-8def-4ed0-b124-5cf729bd1fd4" alt="Alt text" width="300" height="200">


> _This PR was developed with the help of Cursor AI IDE_ 
