### PR TITLE
ci: automate Fedora package update process with Packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,14 +1,15 @@
-files_to_sync:
-    - complyctl.spec
-    - .packit.yaml
-
-upstream_package_name: complyctl
+upstream_project_url: https://github.com/complytime/complyctl
 upstream_tag_template: v{version}
-specfile_path: complyctl.spec
-
+upstream_package_name: complyctl
 downstream_package_name: complyctl
 
+specfile_path: complyctl.spec
+
+files_to_sync:
+    - complyctl.spec
+
 jobs:
+# For testing before merging PRs
 - job: copr_build
   trigger: pull_request
   targets:
@@ -16,3 +17,24 @@ jobs:
     - fedora-rawhide-x86_64
     - centos-stream-9-x86_64
     - centos-stream-10-x86_64
+
+# https://packit.dev/docs/fedora-releases-guide
+# Propose Downstream PRs once a Upstream release is out
+- job: propose_downstream
+  trigger: release
+  dist_git_branches:
+    - rawhide
+    - f42
+
+# Automatically submit builds to Koji after PR is merged into dist-git
+- job: koji_build
+  trigger: commit
+  dist_git_branches:
+    - rawhide
+    - f42
+
+# Trigger Bodhi update for released Fedora versions
+- job: bodhi_update
+  trigger: commit
+  dist_git_branches:
+    - f42

--- a/complyctl.spec
+++ b/complyctl.spec
@@ -4,6 +4,7 @@
 %global base_url https://%{goipath}
 %global app_dir complytime
 %global gopath %{_builddir}/go
+%global debug_package %{nil}
 
 Name:           complyctl
 Version:        0.0.8

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -35,7 +35,13 @@ Releases are currently expected every three weeks. Project maintainers always di
 
 Once a new release is out, the [Fedora Package](https://src.fedoraproject.org/rpms/complyctl) also needs to be updated.
 
-### Preparation
+The process is automated by [Packit](https://packit.dev/docs/fedora-releases-guide) according to [.packit.yaml](https://github.com/complytime/complyctl/blob/main/.packit.yaml) configuration file and should only demand a PR review from a Fedora package [maintainer](https://src.fedoraproject.org/rpms/complyctl)
+
+This automation will create PRs for the specified branches. Once the PRs are reviewed and merged:
+- [Koji builds](https://koji.fedoraproject.org/koji/packageinfo?packageID=42298) will be created
+- [Bodhi updates](https://bodhi.fedoraproject.org/updates/?packages=complyctl) will be submitted
+
+### Preparation (only necessary for Manual Process)
 
 To update a Fedora package, it is ultimately necessary to be a member of Fedora Packager group.
 Here is the main documentation on how to become a Fedora Packager:


### PR DESCRIPTION
## Summary

Increment the packit configuration in order to automate the Fedora release process described in https://github.com/complytime/complyctl/blob/main/docs/RELEASE_PROCESS.md#fedora-package

## Related Issues

- Minimal manual work to update Fedora packages after releasing in Upstream.

## Review Hints

- https://packit.dev/docs/fedora-releases-guide
- It is expected to work as planned, but can only be fully tested in the next release.