### PR TITLE
feat: CPLYTM-932 introducing parameter flag to info command

### DIFF
--- a/cmd/complyctl/cli/info_test.go
+++ b/cmd/complyctl/cli/info_test.go
@@ -132,16 +132,19 @@ func TestGetRuleParametersColumnsAndRows(t *testing.T) {
 			ruleInfo: rule{
 				ID:          "rule-1",
 				Description: "Rule 1",
-				Parameters:  []string{"param-1", "param-2"},
+				Parameters: []parameter{
+					{ID: "param-1", Description: "Parameter 1 description"},
+					{ID: "param-2", Description: "Parameter 2 description"},
+				},
 			},
 			setParameters: map[string][]string{
 				"param-1": []string{"param-1-value"},
 				"param-2": []string{"param-2-value-1", "param-2-value-2"},
 			},
-			expectedColumnTitles: []string{"Parameter ID", "Set  Value(s)"},
+			expectedColumnTitles: []string{"Parameter ID", "Parameter Description", "Set  Value(s)"},
 			expectedRows: []table.Row{
-				{"param-1", "param-1-value"},
-				{"param-2", "param-2-value-1, param-2-value-2"},
+				{"param-1", "Parameter 1 description", "param-1-value"},
+				{"param-2", "Parameter 2 description", "param-2-value-1, param-2-value-2"},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

This PR introduces the `--parameter` flag to print a styled table informing the user of the content below. This PR will be part of a larger effort to edit parameters of the assessment plan.

**Table 1:** 
* `Parameter ID`: name/id of parameter.
* `Description`: Elaborating on description of parameter.
* `Used By Rules`: Rules that use the parameter.

**Table 2:**

`Parameter Value(s)`: The possible values for the parameter (including current value)
`Status`: The **current** selection and the **alternative** selection(s)

The goal of the `complyctl info <framework-id> --parameter <parameter-id>` command is to see the available parameter alternatives. This will be coupled with a future PR that will populate fields for alternative selections in the `config.yml` for selecting which alternative to consider during assessment. 

## Related Issues

- CPLYTM-932
- Closes #212 

## Review Hints

<img width="1489" height="636" alt="image" src="https://github.com/user-attachments/assets/272929f2-1de4-4bdf-bdec-84b4a08a3a8f" />


* **Styled format:** `./bin/complyctl info <framework-id> --parameter <--parameter-id> --limit 5`
*  **Plain text:** `./bin/complyctl info <framework-id> --parameter <--parameter-id> --limit 5 --plain`
*  The `./bin/complyctl info <framework-id> --parameter <parameter-id>` command will find the available parameter selections associated with the `ParameterID`. The `--parameter` flag will also print the rules using the parameters. 

>  The contents of this PR were created as a _prototype_ and provided to Cursor IDE to expand on formatting and suggestions. **This PR was assisted by Cursor v1.3.9**
