### PR TITLE
feat: CPLYTM-900 CPLYTM-899 dry run logic

### DIFF
--- a/cmd/complyctl/cli/plan.go
+++ b/cmd/complyctl/cli/plan.go
@@ -124,7 +124,9 @@ func runPlan(cmd *cobra.Command, opts *planOptions) error {
 		if err := yaml.Unmarshal(configBytes, &assessmentScope); err != nil {
 			return fmt.Errorf("error unmarshaling assessment plan: %w", err)
 		}
-		assessmentScope.ApplyScope(assessmentPlan, logger)
+		if err := assessmentScope.ApplyScope(assessmentPlan, logger); err != nil {
+			return fmt.Errorf("error applying assessment scope: %w", err)
+		}
 	}
 
 	filePath := filepath.Join(opts.complyTimeOpts.UserWorkspace, assessmentPlanLocation)

--- a/internal/complytime/scope.go
+++ b/internal/complytime/scope.go
@@ -47,6 +47,13 @@ func NewAssessmentScope(frameworkID string) AssessmentScope {
 	}
 }
 
+// componentDefResult holds the results from processing component definitions
+type componentDefResult struct {
+	includeControls   includeControlsSet
+	controlTitles     map[string]string
+	controlParameters map[string]map[string][]string
+}
+
 // NewAssessmentScopeFromCDs creates and populates an AssessmentScope struct for a given framework id and set of
 // OSCAL Component Definitions.
 func NewAssessmentScopeFromCDs(frameworkId string, appDir ApplicationDirectory, validator validation.Validator, cds ...oscalTypes.ComponentDefinition) (AssessmentScope, error) {
@@ -56,14 +63,17 @@ func NewAssessmentScopeFromCDs(frameworkId string, appDir ApplicationDirectory, 
 		return AssessmentScope{}, fmt.Errorf("no component definitions found")
 	}
 
-	// Process control implementations and build control relationships
-	includeControls := make(includeControlsSet)
-	controlTitles := make(map[string]string)
-	controlParameters := make(map[string]map[string][]string) // control -> parameter -> values
+	// Initialize processing results
+	result := &componentDefResult{
+		includeControls:   make(includeControlsSet),
+		controlTitles:     make(map[string]string),
+		controlParameters: make(map[string]map[string][]string),
+	}
 
 	// Map to store control titles by source to avoid loading the same source multiple times
 	controlTitlesBySource := make(map[string]map[string]string)
 
+	// Process control implementations and build control relationships
 	for _, componentDef := range cds {
 		if componentDef.Components == nil {
 			continue
@@ -76,114 +86,119 @@ func NewAssessmentScopeFromCDs(frameworkId string, appDir ApplicationDirectory, 
 				if ci.ImplementedRequirements == nil {
 					continue
 				}
-				if ci.Props != nil {
-					frameworkProp, found := extensions.GetTrestleProp(extensions.FrameworkProp, *ci.Props)
-					if !found || frameworkProp.Value != frameworkId {
-						continue
-					}
 
-					// Checking once for control titles from source on the control implementation
-					if validator != nil {
-						// Check if source was already loaded
-						if _, sourceLoaded := controlTitlesBySource[ci.Source]; !sourceLoaded {
-							// Load all titles from this source
-							loadedTitles, err := loadControlTitlesFromSource(ci.Source, appDir, validator)
-							if err != nil {
-								// Empty map if source can't be loaded
-								controlTitlesBySource[ci.Source] = make(map[string]string)
-							} else {
-								controlTitlesBySource[ci.Source] = loadedTitles
-							}
+				if ci.Props == nil {
+					continue
+				}
+
+				frameworkProp, found := extensions.GetTrestleProp(extensions.FrameworkProp, *ci.Props)
+				if !found || frameworkProp.Value != frameworkId {
+					continue
+				}
+
+				// Load control titles from source if needed
+				if validator != nil {
+					if _, sourceLoaded := controlTitlesBySource[ci.Source]; !sourceLoaded {
+						loadedTitles, err := loadControlTitlesFromSource(ci.Source, appDir, validator)
+						if err != nil {
+							controlTitlesBySource[ci.Source] = make(map[string]string)
+						} else {
+							controlTitlesBySource[ci.Source] = loadedTitles
 						}
 					}
+				}
 
-					for _, ir := range ci.ImplementedRequirements {
-						if ir.ControlId != "" {
-							includeControls.Add(ir.ControlId)
+				// Process implemented requirements
+				for _, ir := range ci.ImplementedRequirements {
+					if ir.ControlId != "" {
+						result.includeControls.Add(ir.ControlId)
 
-							// Getting control title for id from map lookup
+						// Set control title if not already set
+						if _, exists := result.controlTitles[ir.ControlId]; !exists {
 							if validator != nil {
-								if _, exists := controlTitles[ir.ControlId]; !exists {
-									// Get the title from the loaded source
-									if title, found := controlTitlesBySource[ci.Source][ir.ControlId]; found {
-										controlTitles[ir.ControlId] = title
-									} else {
-										// Empty string if title isn't available
-										controlTitles[ir.ControlId] = ""
-									}
+								if title, found := controlTitlesBySource[ci.Source][ir.ControlId]; found {
+									result.controlTitles[ir.ControlId] = title
+								} else {
+									result.controlTitles[ir.ControlId] = ""
 								}
 							} else {
-								// Empty string if title isn't available
-								controlTitles[ir.ControlId] = ""
+								result.controlTitles[ir.ControlId] = ""
 							}
 						}
 					}
+				}
 
-					// Process set parameters - match by remarks groups with control rules
-					if ci.SetParameters != nil {
-						// Create map of available set parameters
-						implementedSetParams := make(map[string][]string)
-						for _, sp := range *ci.SetParameters {
-							if sp.ParamId != "" && len(sp.Values) > 0 {
-								implementedSetParams[sp.ParamId] = sp.Values
-							}
-						}
-
-						remarksProps := extractRemarksProperties(cds)
-
-						// For each control, find parameters used by included rules in controls
-						for _, ir := range ci.ImplementedRequirements {
-							if ir.ControlId != "" && ir.Props != nil {
-								controlRules := make(map[string]bool)
-								for _, prop := range *ir.Props {
-									if prop.Name == extensions.RuleIdProp {
-										controlRules[prop.Value] = true
-									}
-								}
-
-								// Find parameters used by rules in control
-								for _, props := range remarksProps {
-									var ruleID string
-									var parametersInGroup []string
-
-									for _, prop := range props {
-										if prop.Name == extensions.RuleIdProp {
-											ruleID = prop.Value
-										}
-										if prop.Name == extensions.ParameterIdProp || strings.HasPrefix(prop.Name, extensions.ParameterIdProp+"_") {
-											parametersInGroup = append(parametersInGroup, prop.Value)
-										}
-									}
-
-									if ruleID != "" && controlRules[ruleID] {
-										for _, paramID := range parametersInGroup {
-											if paramValues, hasSetParam := implementedSetParams[paramID]; hasSetParam {
-												if controlParameters[ir.ControlId] == nil {
-													controlParameters[ir.ControlId] = make(map[string][]string)
-												}
-												controlParameters[ir.ControlId][paramID] = paramValues
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-
+				// Process set parameters
+				if ci.SetParameters != nil {
+					processSetParameters(ci, result, cds)
 				}
 			}
 		}
 	}
 
 	// Build control entries from extracted data
-	controlIDs := includeControls.All()
-	scope.IncludeControls = make([]ControlEntry, len(controlIDs))
+	scope.IncludeControls = buildControlEntries(result)
+
+	return scope, nil
+}
+
+// processSetParameters processes set parameters for a control implementation
+func processSetParameters(ci oscalTypes.ControlImplementationSet, result *componentDefResult, cds []oscalTypes.ComponentDefinition) {
+	implementedSetParams := make(map[string][]string)
+	for _, sp := range *ci.SetParameters {
+		if sp.ParamId != "" && len(sp.Values) > 0 {
+			implementedSetParams[sp.ParamId] = sp.Values
+		}
+	}
+
+	remarksProps := extractRemarksProperties(cds)
+
+	for _, ir := range ci.ImplementedRequirements {
+		if ir.ControlId != "" && ir.Props != nil {
+			controlRules := make(map[string]bool)
+			for _, prop := range *ir.Props {
+				if prop.Name == extensions.RuleIdProp {
+					controlRules[prop.Value] = true
+				}
+			}
+
+			for _, props := range remarksProps {
+				var ruleID string
+				var parametersInGroup []string
+
+				for _, prop := range props {
+					if prop.Name == extensions.RuleIdProp {
+						ruleID = prop.Value
+					}
+					if prop.Name == extensions.ParameterIdProp || strings.HasPrefix(prop.Name, extensions.ParameterIdProp+"_") {
+						parametersInGroup = append(parametersInGroup, prop.Value)
+					}
+				}
+
+				if ruleID != "" && controlRules[ruleID] {
+					for _, paramID := range parametersInGroup {
+						if paramValues, hasSetParam := implementedSetParams[paramID]; hasSetParam {
+							if result.controlParameters[ir.ControlId] == nil {
+								result.controlParameters[ir.ControlId] = make(map[string][]string)
+							}
+							result.controlParameters[ir.ControlId][paramID] = paramValues
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// buildControlEntries builds the final control entries from the processing results
+func buildControlEntries(result *componentDefResult) []ControlEntry {
+	controlIDs := result.includeControls.All()
+	controlEntries := make([]ControlEntry, len(controlIDs))
+
 	for i, id := range controlIDs {
-		// Create parameter entries only for used parameters
 		var parameterSelections []ParameterEntry
-		if controlParams, exists := controlParameters[id]; exists {
+		if controlParams, exists := result.controlParameters[id]; exists {
 			for paramID, values := range controlParams {
-				// Use set parameter values as the default value
 				paramValue := ""
 				if len(values) > 0 {
 					paramValue = values[0]
@@ -196,32 +211,34 @@ func NewAssessmentScopeFromCDs(frameworkId string, appDir ApplicationDirectory, 
 			}
 		}
 
-		// If no specific parameters found, add N/A
 		if len(parameterSelections) == 0 {
 			parameterSelections = []ParameterEntry{{Name: "N/A", Value: "N/A"}}
 		}
 
-		scope.IncludeControls[i] = ControlEntry{
+		controlEntries[i] = ControlEntry{
 			ControlID:        id,
-			ControlTitle:     controlTitles[id],
+			ControlTitle:     result.controlTitles[id],
 			IncludeRules:     []string{"*"}, // by default, include all rules
 			SelectParameters: parameterSelections,
 		}
 	}
-	sort.Slice(scope.IncludeControls, func(i, j int) bool {
-		return scope.IncludeControls[i].ControlID < scope.IncludeControls[j].ControlID
+
+	sort.Slice(controlEntries, func(i, j int) bool {
+		return controlEntries[i].ControlID < controlEntries[j].ControlID
 	})
 
-	return scope, nil
+	return controlEntries
 }
 
 // ApplyScope alters the given OSCAL Assessment Plan based on the AssessmentScope.
-func (a AssessmentScope) ApplyScope(assessmentPlan *oscalTypes.AssessmentPlan, logger hclog.Logger) {
+// If componentDefs is provided, it will be used for parameter validation; otherwise validation is skipped.
+func (a AssessmentScope) ApplyScope(assessmentPlan *oscalTypes.AssessmentPlan, logger hclog.Logger, componentDefs ...oscalTypes.ComponentDefinition) error {
 
 	// This is a thin wrapper right now, but the goal to expand to different areas
 	// of customization.
 	a.applyControlScope(assessmentPlan, logger)
 	a.applyRuleScope(assessmentPlan, logger)
+	return a.applyParameterScope(assessmentPlan, componentDefs, logger)
 }
 
 // applyControlScope alters the AssessedControls of the given OSCAL Assessment Plan by the AssessmentScope
@@ -376,6 +393,166 @@ func (a AssessmentScope) applyRuleScope(assessmentPlan *oscalTypes.AssessmentPla
 		}
 	}
 }
+
+// applyParameterScope updates activity properties based on SelectParameters values
+// If componentDefs is provided, validates against component definitions; otherwise validates against assessment plan
+func (a AssessmentScope) applyParameterScope(assessmentPlan *oscalTypes.AssessmentPlan, componentDefs []oscalTypes.ComponentDefinition, logger hclog.Logger) error {
+	// Build map of control ID to parameters for that control
+	controlParams := make(map[string]map[string]string)
+
+	for _, entry := range a.IncludeControls {
+		if len(entry.SelectParameters) > 0 {
+			controlParams[entry.ControlID] = make(map[string]string)
+			for _, p := range entry.SelectParameters {
+				if p.Name == "" {
+					continue
+				}
+				controlParams[entry.ControlID][p.Name] = p.Value
+			}
+		}
+	}
+
+	if len(controlParams) == 0 {
+		return nil
+	}
+
+	if assessmentPlan.LocalDefinitions == nil || assessmentPlan.LocalDefinitions.Activities == nil {
+		return nil
+	}
+
+	// Validate all selected parameters by control before updating the assessment plan
+	if err := a.validateAllControlParameterSelections(controlParams, componentDefs); err != nil {
+		logger.Debug("Parameter validation failed", "error", err)
+		return err // Return immediately without modifying the assessment plan.
+	}
+
+	logger.Debug("Parameter validation passed, applying parameter updates")
+
+	// Update activity parameters based on control relationships
+	for activityI := range *assessmentPlan.LocalDefinitions.Activities {
+		activity := &(*assessmentPlan.LocalDefinitions.Activities)[activityI]
+		if activity.Props == nil {
+			continue
+		}
+
+		logger.Debug("Scoping activity parameters", "activity", activity.Title)
+
+		// Get control IDs related to this activity
+		relatedControlIDs := a.getRelatedControlIDs(activity)
+
+		// Apply parameters for the related controls
+		props := *activity.Props
+		for i := range props {
+			if props[i].Class == extensions.TestParameterClass {
+				var newValue string
+
+				if len(relatedControlIDs) > 0 {
+					// Find the appropriate parameter value from the related controls
+					newValue = a.findParameterValueForControls(props[i].Name, relatedControlIDs, controlParams)
+				}
+
+				if newValue != "" {
+					props[i].Value = newValue
+				}
+			}
+		}
+		*activity.Props = props
+	}
+	return nil
+}
+
+// getRelatedControlIDs extracts control IDs from an activity's RelatedControls
+func (a AssessmentScope) getRelatedControlIDs(activity *oscalTypes.Activity) []string {
+	var controlIDs []string
+
+	if activity.RelatedControls == nil || activity.RelatedControls.ControlSelections == nil {
+		return controlIDs
+	}
+
+	for _, controlSelection := range activity.RelatedControls.ControlSelections {
+		if controlSelection.IncludeControls != nil {
+			for _, control := range *controlSelection.IncludeControls {
+				controlIDs = append(controlIDs, control.ControlId)
+			}
+		}
+	}
+
+	return controlIDs
+}
+
+// findParameterValueForControls finds the appropriate parameter value for the given parameter name
+// from the related controls.
+func (a AssessmentScope) findParameterValueForControls(paramName string, relatedControlIDs []string, controlParams map[string]map[string]string) string {
+	// Check each related control in order for the parameter
+	for _, controlID := range relatedControlIDs {
+		if params, ok := controlParams[controlID]; ok {
+			if value, exists := params[paramName]; exists {
+				return value
+			}
+		}
+	}
+
+	return "" // No value found for this parameter in any related control
+}
+
+// validateAllControlParameterSelections validates parameter selections
+func (a AssessmentScope) validateAllControlParameterSelections(controlParams map[string]map[string]string, componentDefs []oscalTypes.ComponentDefinition) error {
+	remarksProps := extractRemarksProperties(componentDefs)
+	var validationErrors []string
+
+	for controlID, params := range controlParams {
+		for paramID, selectedValue := range params {
+			isValid, availableAlternatives := filterParameterSelection(paramID, selectedValue, remarksProps)
+			if !isValid {
+				errorMsg := fmt.Sprintf("control '%s': parameter '%s' has invalid value '%s'. Available alternatives: [%s]",
+					controlID, paramID, selectedValue, strings.Join(availableAlternatives, ", "))
+				validationErrors = append(validationErrors, errorMsg)
+			}
+		}
+	}
+
+	if len(validationErrors) > 0 {
+		return fmt.Errorf("parameter validation failed:\n%s", strings.Join(validationErrors, "\n"))
+	}
+
+	return nil
+}
+
+// extractRemarksProperties extracts remarks-grouped properties
+func extractRemarksProperties(componentDefs []oscalTypes.ComponentDefinition) map[string][]oscalTypes.Property {
+	remarksProps := make(map[string][]oscalTypes.Property)
+
+	for _, compDef := range componentDefs {
+		if compDef.Components == nil {
+			continue
+		}
+		for _, component := range *compDef.Components {
+			if component.Props != nil {
+				for _, prop := range *component.Props {
+					if prop.Remarks != "" {
+						remarksProps[prop.Remarks] = append(remarksProps[prop.Remarks], prop)
+					}
+				}
+			}
+		}
+	}
+
+	return remarksProps
+}
+
+// ValidateParameterValue validates a parameter value to configure the assessment plan.
+func ValidateParameterValue(parameterID, selectedValue string, componentDefinitions []oscalTypes.ComponentDefinition) error {
+	remarksProps := extractRemarksProperties(componentDefinitions)
+	isValid, availableAlternatives := filterParameterSelection(parameterID, selectedValue, remarksProps)
+
+	if !isValid {
+		return fmt.Errorf("parameter '%s' has invalid value '%s'. Available alternatives: [%s]",
+			parameterID, selectedValue, strings.Join(availableAlternatives, ", "))
+	}
+
+	return nil
+}
+
 func filterControlSelection(controlSelection *oscalTypes.AssessedControls, includedControls includeControlsSet) {
 	// The new included controls should be the intersection of
 	// the originally included controls and the newly included controls.
@@ -470,26 +647,109 @@ func (a AssessmentScope) isRuleInList(ruleID string, ruleList []string) bool {
 	return false
 }
 
-// extractRemarksProperties extracts remarks-grouped properties
-func extractRemarksProperties(componentDefs []oscalTypes.ComponentDefinition) map[string][]oscalTypes.Property {
-	remarksProps := make(map[string][]oscalTypes.Property)
+// filterParameterSelection validates a parameter selection against alternatives
+func filterParameterSelection(parameterID, selectedValue string, remarksProps map[string][]oscalTypes.Property) (bool, []string) {
+	if selectedValue == "" || selectedValue == "N/A" {
+		return true, nil
+	}
 
-	for _, compDef := range componentDefs {
-		if compDef.Components == nil {
-			continue
+	var allPossibleAlternatives []string
+	var hasAlternatives bool
+
+	for _, props := range remarksProps {
+		var foundParameterID bool
+		var parameterSuffix string
+
+		// Look for the parameter ID in this remarks group to get its suffix
+		for _, prop := range props {
+			if prop.Value == parameterID && isParameterIdProperty(prop.Name) {
+				foundParameterID = true
+				if prop.Name == extensions.ParameterIdProp {
+					parameterSuffix = ""
+				} else {
+					parameterSuffix = strings.TrimPrefix(prop.Name, extensions.ParameterIdProp+"_")
+				}
+				break
+			}
 		}
-		for _, component := range *compDef.Components {
-			if component.Props != nil {
-				for _, prop := range *component.Props {
-					if prop.Remarks != "" {
-						remarksProps[prop.Remarks] = append(remarksProps[prop.Remarks], prop)
+
+		if foundParameterID {
+			var alternativesPropertyName string
+			if parameterSuffix == "" {
+				alternativesPropertyName = "Parameter_Value_Alternatives"
+			} else {
+				alternativesPropertyName = "Parameter_Value_Alternatives_" + parameterSuffix
+			}
+
+			for _, prop := range props {
+				if prop.Name == alternativesPropertyName {
+					alternatives := parseParameterAlternatives(prop.Value)
+					if len(alternatives) > 0 {
+						hasAlternatives = true
+						for _, altValue := range alternatives {
+							if altValue == selectedValue {
+								return true, alternatives
+							}
+						}
+						allPossibleAlternatives = append(allPossibleAlternatives, alternatives...)
 					}
+					break
 				}
 			}
 		}
 	}
 
-	return remarksProps
+	if hasAlternatives {
+		cleanedAlternatives := removeDuplicates(allPossibleAlternatives)
+		return false, cleanedAlternatives
+	}
+
+	return true, nil
+}
+
+// isParameterIdProperty checks if a property matches Parameter_Id.
+func isParameterIdProperty(propertyName string) bool {
+	return propertyName == extensions.ParameterIdProp || strings.HasPrefix(propertyName, extensions.ParameterIdProp+"_")
+}
+
+// parseParameterAlternatives parses the Parameter_Value_Alternatives value to extract choice options
+// Returns the keys that users can input as alternatives.
+func parseParameterAlternatives(alternativesValue string) []string {
+	var alternatives []string
+
+	cleaned := strings.Trim(alternativesValue, "\"'")
+	cleaned = strings.Trim(cleaned, "{}")
+
+	if cleaned == "" {
+		return alternatives
+	}
+
+	// Split by comma and extract keys
+	pairs := strings.Split(cleaned, ",")
+	for _, pair := range pairs {
+		parts := strings.Split(strings.TrimSpace(pair), ":")
+		if len(parts) == 2 {
+			key := strings.Trim(strings.TrimSpace(parts[0]), "\"'")
+			if key != "" {
+				alternatives = append(alternatives, key)
+			}
+		}
+	}
+	return removeDuplicates(alternatives)
+}
+
+// removeDuplicates removes duplicate items from a slice
+func removeDuplicates(slice []string) []string {
+	seen := make(map[string]bool)
+	result := []string{}
+
+	for _, val := range slice {
+		if _, ok := seen[val]; !ok {
+			seen[val] = true
+			result = append(result, val)
+		}
+	}
+	return result
 }
 
 type includeControlsSet map[string]struct{}

--- a/internal/complytime/scope_test.go
+++ b/internal/complytime/scope_test.go
@@ -22,6 +22,28 @@ func TestNewAssessmentScopeFromCDs(t *testing.T) {
 		Components: &[]oscalTypes.DefinedComponent{
 			{
 				Title: "Component",
+				Props: &[]oscalTypes.Property{
+					{
+						Name:    extensions.RuleIdProp,
+						Value:   "rule-1",
+						Remarks: "remarks-group-1",
+					},
+					{
+						Name:    extensions.ParameterIdProp,
+						Value:   "param-1",
+						Remarks: "remarks-group-1",
+					},
+					{
+						Name:    extensions.RuleIdProp,
+						Value:   "rule-2",
+						Remarks: "remarks-group-2",
+					},
+					{
+						Name:    extensions.ParameterIdProp,
+						Value:   "param-2",
+						Remarks: "remarks-group-2",
+					},
+				},
 				ControlImplementations: &[]oscalTypes.ControlImplementationSet{
 					{
 						Props: &[]oscalTypes.Property{
@@ -31,12 +53,34 @@ func TestNewAssessmentScopeFromCDs(t *testing.T) {
 								Ns:    extensions.TrestleNameSpace,
 							},
 						},
+						SetParameters: &[]oscalTypes.SetParameter{
+							{
+								ParamId: "param-1",
+								Values:  []string{"value-1"},
+							},
+							{
+								ParamId: "param-2",
+								Values:  []string{"value-2"},
+							},
+						},
 						ImplementedRequirements: []oscalTypes.ImplementedRequirementControlImplementation{
 							{
 								ControlId: "control-1",
+								Props: &[]oscalTypes.Property{
+									{
+										Name:  extensions.RuleIdProp,
+										Value: "rule-1",
+									},
+								},
 							},
 							{
 								ControlId: "control-2",
+								Props: &[]oscalTypes.Property{
+									{
+										Name:  extensions.RuleIdProp,
+										Value: "rule-2",
+									},
+								},
 							},
 						},
 					},
@@ -48,13 +92,51 @@ func TestNewAssessmentScopeFromCDs(t *testing.T) {
 	wantScope := AssessmentScope{
 		FrameworkID: "example",
 		IncludeControls: []ControlEntry{
-			{ControlID: "control-1", ControlTitle: "", IncludeRules: []string{"*"}},
-			{ControlID: "control-2", ControlTitle: "", IncludeRules: []string{"*"}},
+			{
+				ControlID:    "control-1",
+				ControlTitle: "",
+				IncludeRules: []string{"*"},
+				SelectParameters: []ParameterEntry{
+					{Name: "param-1", Value: "value-1"},
+				},
+			},
+			{
+				ControlID:    "control-2",
+				ControlTitle: "",
+				IncludeRules: []string{"*"},
+				SelectParameters: []ParameterEntry{
+					{Name: "param-2", Value: "value-2"},
+				},
+			},
 		},
 	}
 	scope, err := NewAssessmentScopeFromCDs("example", testAppDir, validator, cd)
 	require.NoError(t, err)
-	require.Equal(t, wantScope, scope)
+
+	// Check the basic structure
+	require.Equal(t, wantScope.FrameworkID, scope.FrameworkID)
+	require.Len(t, scope.IncludeControls, len(wantScope.IncludeControls))
+
+	// Check each control entry, allowing for different parameter orders
+	for i, wantControl := range wantScope.IncludeControls {
+		actualControl := scope.IncludeControls[i]
+		require.Equal(t, wantControl.ControlID, actualControl.ControlID)
+		require.Equal(t, wantControl.ControlTitle, actualControl.ControlTitle)
+		require.Equal(t, wantControl.IncludeRules, actualControl.IncludeRules)
+
+		// Check parameters exist regardless of order
+		require.Len(t, actualControl.SelectParameters, len(wantControl.SelectParameters))
+		for _, wantParam := range wantControl.SelectParameters {
+			found := false
+			for _, actualParam := range actualControl.SelectParameters {
+				if actualParam.Name == wantParam.Name && actualParam.Value == wantParam.Value {
+					found = true
+					break
+				}
+			}
+			require.True(t, found, "Expected parameter %s=%s not found", wantParam.Name, wantParam.Value)
+		}
+	}
 
 	// Reproduce duplicates
 	anotherComponent := oscalTypes.DefinedComponent{
@@ -71,9 +153,21 @@ func TestNewAssessmentScopeFromCDs(t *testing.T) {
 				ImplementedRequirements: []oscalTypes.ImplementedRequirementControlImplementation{
 					{
 						ControlId: "control-1",
+						Props: &[]oscalTypes.Property{
+							{
+								Name:  extensions.RuleIdProp,
+								Value: "rule-1",
+							},
+						},
 					},
 					{
 						ControlId: "control-2",
+						Props: &[]oscalTypes.Property{
+							{
+								Name:  extensions.RuleIdProp,
+								Value: "rule-2",
+							},
+						},
 					},
 				},
 			},
@@ -82,6 +176,215 @@ func TestNewAssessmentScopeFromCDs(t *testing.T) {
 	*cd.Components = append(*cd.Components, anotherComponent)
 
 	scope, err = NewAssessmentScopeFromCDs("example", testAppDir, validator, cd)
+	require.NoError(t, err)
+
+	// Check the basic structure again after adding duplicates
+	require.Equal(t, wantScope.FrameworkID, scope.FrameworkID)
+	require.Len(t, scope.IncludeControls, len(wantScope.IncludeControls))
+
+	// Check each control entry again, allowing for different parameter orders
+	for i, wantControl := range wantScope.IncludeControls {
+		actualControl := scope.IncludeControls[i]
+		require.Equal(t, wantControl.ControlID, actualControl.ControlID)
+		require.Equal(t, wantControl.ControlTitle, actualControl.ControlTitle)
+		require.Equal(t, wantControl.IncludeRules, actualControl.IncludeRules)
+
+		// Check parameters exist regardless of order
+		require.Len(t, actualControl.SelectParameters, len(wantControl.SelectParameters))
+		for _, wantParam := range wantControl.SelectParameters {
+			found := false
+			for _, actualParam := range actualControl.SelectParameters {
+				if actualParam.Name == wantParam.Name && actualParam.Value == wantParam.Value {
+					found = true
+					break
+				}
+			}
+			require.True(t, found, "Expected parameter %s=%s not found", wantParam.Name, wantParam.Value)
+		}
+	}
+}
+
+func TestNewAssessmentScopeFromCDs_ParameterRuleMatching(t *testing.T) {
+	testAppDir := ApplicationDirectory{}
+	validator := validation.NoopValidator{}
+
+	cd := oscalTypes.ComponentDefinition{
+		Components: &[]oscalTypes.DefinedComponent{
+			{
+				Title: "Component",
+				Props: &[]oscalTypes.Property{
+					// Remarks group 1: rule-1 with param-1 and param-2
+					{
+						Name:    extensions.RuleIdProp,
+						Value:   "rule-1",
+						Remarks: "remarks-group-1",
+					},
+					{
+						Name:    extensions.ParameterIdProp + "_1",
+						Value:   "param-1",
+						Remarks: "remarks-group-1",
+					},
+					{
+						Name:    extensions.ParameterIdProp + "_2",
+						Value:   "param-2",
+						Remarks: "remarks-group-1",
+					},
+					// Remarks group 2: rule-2 with param-3
+					{
+						Name:    extensions.RuleIdProp,
+						Value:   "rule-2",
+						Remarks: "remarks-group-2",
+					},
+					{
+						Name:    extensions.ParameterIdProp,
+						Value:   "param-3",
+						Remarks: "remarks-group-2",
+					},
+					// Remarks group 3: rule-3 with param-4 (not used by any control)
+					{
+						Name:    extensions.RuleIdProp,
+						Value:   "rule-3",
+						Remarks: "remarks-group-3",
+					},
+					{
+						Name:    extensions.ParameterIdProp,
+						Value:   "param-4",
+						Remarks: "remarks-group-3",
+					},
+				},
+				ControlImplementations: &[]oscalTypes.ControlImplementationSet{
+					{
+						Props: &[]oscalTypes.Property{
+							{
+								Name:  extensions.FrameworkProp,
+								Value: "example",
+								Ns:    extensions.TrestleNameSpace,
+							},
+						},
+						SetParameters: &[]oscalTypes.SetParameter{
+							{
+								ParamId: "param-1",
+								Values:  []string{"value-1"},
+							},
+							{
+								ParamId: "param-2",
+								Values:  []string{"value-2"},
+							},
+							{
+								ParamId: "param-3",
+								Values:  []string{"value-3"},
+							},
+							{
+								ParamId: "param-4",
+								Values:  []string{"value-4"},
+							},
+						},
+						ImplementedRequirements: []oscalTypes.ImplementedRequirementControlImplementation{
+							{
+								ControlId: "control-1",
+								Props: &[]oscalTypes.Property{
+									{
+										Name:  extensions.RuleIdProp,
+										Value: "rule-1",
+									},
+								},
+							},
+							{
+								ControlId: "control-2",
+								Props: &[]oscalTypes.Property{
+									{
+										Name:  extensions.RuleIdProp,
+										Value: "rule-2",
+									},
+								},
+							},
+							{
+								ControlId: "control-3",
+								// No rules - should have default N/A parameter
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	scope, err := NewAssessmentScopeFromCDs("example", testAppDir, validator, cd)
+	require.NoError(t, err)
+
+	// Check that control-1 gets param-1 and param-2 (from rule-1's remarks group)
+	require.Len(t, scope.IncludeControls, 3)
+
+	control1 := scope.IncludeControls[0]
+	require.Equal(t, "control-1", control1.ControlID)
+	require.Len(t, control1.SelectParameters, 2)
+
+	paramNames := make([]string, len(control1.SelectParameters))
+	for i, param := range control1.SelectParameters {
+		paramNames[i] = param.Name
+	}
+	require.Contains(t, paramNames, "param-1")
+	require.Contains(t, paramNames, "param-2")
+
+	// Check that control-2 gets param-3 (from rule-2's remarks group)
+	control2 := scope.IncludeControls[1]
+	require.Equal(t, "control-2", control2.ControlID)
+	require.Len(t, control2.SelectParameters, 1)
+	require.Equal(t, "param-3", control2.SelectParameters[0].Name)
+	require.Equal(t, "value-3", control2.SelectParameters[0].Value)
+
+	// Check that control-3 gets default N/A parameter (no rules)
+	control3 := scope.IncludeControls[2]
+	require.Equal(t, "control-3", control3.ControlID)
+	require.Len(t, control3.SelectParameters, 1)
+	require.Equal(t, "N/A", control3.SelectParameters[0].Name)
+	require.Equal(t, "N/A", control3.SelectParameters[0].Value)
+}
+
+func TestNewAssessmentScopeFromCDs_NoParameters(t *testing.T) {
+	testAppDir := ApplicationDirectory{}
+	validator := validation.NoopValidator{}
+
+	cd := oscalTypes.ComponentDefinition{
+		Components: &[]oscalTypes.DefinedComponent{
+			{
+				Title: "Component",
+				ControlImplementations: &[]oscalTypes.ControlImplementationSet{
+					{
+						Props: &[]oscalTypes.Property{
+							{
+								Name:  extensions.FrameworkProp,
+								Value: "example",
+								Ns:    extensions.TrestleNameSpace,
+							},
+						},
+						ImplementedRequirements: []oscalTypes.ImplementedRequirementControlImplementation{
+							{
+								ControlId: "control-1",
+								// No SetParameters
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	wantScope := AssessmentScope{
+		FrameworkID: "example",
+		IncludeControls: []ControlEntry{
+			{
+				ControlID:    "control-1",
+				ControlTitle: "",
+				IncludeRules: []string{"*"},
+				SelectParameters: []ParameterEntry{
+					{Name: "N/A", Value: "N/A"},
+				},
+			},
+		},
+	}
+
+	scope, err := NewAssessmentScopeFromCDs("example", testAppDir, validator, cd)
 	require.NoError(t, err)
 	require.Equal(t, wantScope, scope)
 }
@@ -192,7 +495,8 @@ func TestAssessmentScope_ApplyScope(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			scope := tt.scope
-			scope.ApplyScope(tt.basePlan, testLogger)
+			err := scope.ApplyScope(tt.basePlan, testLogger)
+			require.NoError(t, err)
 			require.Equal(t, tt.wantSelections, tt.basePlan.ReviewedControls.ControlSelections)
 		})
 	}
@@ -648,8 +952,381 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			scope := tt.scope
-			scope.ApplyScope(tt.basePlan, testLogger)
+			err := scope.ApplyScope(tt.basePlan, testLogger)
+			require.NoError(t, err)
 			require.Equal(t, tt.wantActivities, tt.basePlan.LocalDefinitions.Activities)
+		})
+	}
+}
+
+func TestAssessmentScope_ApplyParameterScope(t *testing.T) {
+	testLogger := hclog.NewNullLogger()
+
+	tests := []struct {
+		name           string
+		assessmentPlan *oscalTypes.AssessmentPlan
+		componentDefs  []oscalTypes.ComponentDefinition
+		scope          AssessmentScope
+		expectError    bool
+		expectedProps  []oscalTypes.Property
+	}{
+		{
+			name: "Success/ParameterUpdate",
+			assessmentPlan: &oscalTypes.AssessmentPlan{
+				LocalDefinitions: &oscalTypes.LocalDefinitions{
+					Activities: &[]oscalTypes.Activity{
+						{
+							Title: "test-activity",
+							Props: &[]oscalTypes.Property{
+								{
+									Name:  "param-1",
+									Value: "old-value",
+									Class: extensions.TestParameterClass,
+								},
+							},
+							RelatedControls: &oscalTypes.ReviewedControls{
+								ControlSelections: []oscalTypes.AssessedControls{
+									{
+										IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+											{ControlId: "control-1"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			scope: AssessmentScope{
+				IncludeControls: []ControlEntry{
+					{
+						ControlID: "control-1",
+						SelectParameters: []ParameterEntry{
+							{Name: "param-1", Value: "new-value"},
+						},
+					},
+				},
+			},
+			expectError: false,
+			expectedProps: []oscalTypes.Property{
+				{
+					Name:  "param-1",
+					Value: "new-value",
+					Class: extensions.TestParameterClass,
+				},
+			},
+		},
+		{
+			name: "Success/NoParametersToUpdate",
+			assessmentPlan: &oscalTypes.AssessmentPlan{
+				LocalDefinitions: &oscalTypes.LocalDefinitions{
+					Activities: &[]oscalTypes.Activity{
+						{
+							Title: "test-activity",
+							Props: &[]oscalTypes.Property{
+								{
+									Name:  "param-1",
+									Value: "old-value",
+									Class: extensions.TestParameterClass,
+								},
+							},
+						},
+					},
+				},
+			},
+			scope: AssessmentScope{
+				IncludeControls: []ControlEntry{},
+			},
+			expectError: false,
+			expectedProps: []oscalTypes.Property{
+				{
+					Name:  "param-1",
+					Value: "old-value",
+					Class: extensions.TestParameterClass,
+				},
+			},
+		},
+		{
+			name: "Success/EmptyParameterName",
+			assessmentPlan: &oscalTypes.AssessmentPlan{
+				LocalDefinitions: &oscalTypes.LocalDefinitions{
+					Activities: &[]oscalTypes.Activity{
+						{
+							Title: "test-activity",
+							Props: &[]oscalTypes.Property{
+								{
+									Name:  "param-1",
+									Value: "old-value",
+									Class: extensions.TestParameterClass,
+								},
+							},
+						},
+					},
+				},
+			},
+			scope: AssessmentScope{
+				IncludeControls: []ControlEntry{
+					{
+						ControlID: "control-1",
+						SelectParameters: []ParameterEntry{
+							{Name: "", Value: "new-value"}, // Empty name should be ignored
+						},
+					},
+				},
+			},
+			expectError: false,
+			expectedProps: []oscalTypes.Property{
+				{
+					Name:  "param-1",
+					Value: "old-value",
+					Class: extensions.TestParameterClass,
+				},
+			},
+		},
+		{
+			name: "Success/NoSelectParameters",
+			assessmentPlan: &oscalTypes.AssessmentPlan{
+				LocalDefinitions: &oscalTypes.LocalDefinitions{
+					Activities: &[]oscalTypes.Activity{
+						{
+							Title: "test-activity",
+							Props: &[]oscalTypes.Property{
+								{
+									Name:  "param-1",
+									Value: "old-value",
+									Class: extensions.TestParameterClass,
+								},
+							},
+						},
+					},
+				},
+			},
+			scope: AssessmentScope{
+				IncludeControls: []ControlEntry{
+					{
+						ControlID: "control-1",
+						// No SelectParameters
+					},
+				},
+			},
+			expectError: false,
+			expectedProps: []oscalTypes.Property{
+				{
+					Name:  "param-1",
+					Value: "old-value",
+					Class: extensions.TestParameterClass,
+				},
+			},
+		},
+		{
+			name:           "Success/NoLocalDefinitions",
+			assessmentPlan: &oscalTypes.AssessmentPlan{
+				// No LocalDefinitions
+			},
+			scope: AssessmentScope{
+				IncludeControls: []ControlEntry{
+					{
+						ControlID: "control-1",
+						SelectParameters: []ParameterEntry{
+							{Name: "param-1", Value: "new-value"},
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scope := tt.scope
+			err := scope.applyParameterScope(tt.assessmentPlan, tt.componentDefs, testLogger)
+
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				if tt.expectedProps != nil && tt.assessmentPlan.LocalDefinitions != nil &&
+					tt.assessmentPlan.LocalDefinitions.Activities != nil {
+					activity := (*tt.assessmentPlan.LocalDefinitions.Activities)[0]
+					if activity.Props != nil {
+						require.Equal(t, tt.expectedProps, *activity.Props)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestValidateParameterValue(t *testing.T) {
+	componentDefs := []oscalTypes.ComponentDefinition{
+		{
+			Components: &[]oscalTypes.DefinedComponent{
+				{
+					Props: &[]oscalTypes.Property{
+						{
+							Name:    extensions.ParameterIdProp,
+							Value:   "test-param",
+							Remarks: "group1",
+						},
+						{
+							Name:    "Parameter_Value_Alternatives",
+							Value:   `{"option1": "description1", "option2": "description2"}`,
+							Remarks: "group1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		parameterID   string
+		selectedValue string
+		componentDefs []oscalTypes.ComponentDefinition
+		expectError   bool
+	}{
+		{
+			name:          "Error/InvalidParameterValue",
+			parameterID:   "test-param",
+			selectedValue: "invalid-option",
+			componentDefs: componentDefs,
+			expectError:   true,
+		},
+		{
+			name:          "Success/ValidParameterValue",
+			parameterID:   "test-param",
+			selectedValue: "option1",
+			componentDefs: componentDefs,
+			expectError:   false,
+		},
+		{
+			name:          "Success/NoAlternativesAcceptAnyValue",
+			parameterID:   "unknown-param",
+			selectedValue: "any-value",
+			componentDefs: componentDefs,
+			expectError:   false,
+		},
+		{
+			name:          "Success/EmptyValueAccepted",
+			parameterID:   "test-param",
+			selectedValue: "",
+			componentDefs: componentDefs,
+			expectError:   false,
+		},
+		{
+			name:          "Success/NAValueAccepted",
+			parameterID:   "test-param",
+			selectedValue: "N/A",
+			componentDefs: componentDefs,
+			expectError:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateParameterValue(tt.parameterID, tt.selectedValue, tt.componentDefs)
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestFilterParameterSelection(t *testing.T) {
+	remarksProps := map[string][]oscalTypes.Property{
+		"group1": {
+			{
+				Name:  extensions.ParameterIdProp,
+				Value: "param1",
+			},
+			{
+				Name:  "Parameter_Value_Alternatives",
+				Value: `{"valid1": "desc1", "valid2": "desc2"}`,
+			},
+		},
+		"group2": {
+			{
+				Name:  extensions.ParameterIdProp + "_1",
+				Value: "param2",
+			},
+			{
+				Name:  "Parameter_Value_Alternatives_1",
+				Value: `{"validA": "descA", "validB": "descB"}`,
+			},
+		},
+	}
+
+	tests := []struct {
+		name                 string
+		parameterID          string
+		selectedValue        string
+		remarksProps         map[string][]oscalTypes.Property
+		expectedValid        bool
+		expectedAlternatives []string
+	}{
+		{
+			name:                 "Success/ValidValueInAlternatives",
+			parameterID:          "param1",
+			selectedValue:        "valid1",
+			remarksProps:         remarksProps,
+			expectedValid:        true,
+			expectedAlternatives: []string{"valid1", "valid2"},
+		},
+		{
+			name:                 "Error/InvalidValueNotInAlternatives",
+			parameterID:          "param1",
+			selectedValue:        "invalid",
+			remarksProps:         remarksProps,
+			expectedValid:        false,
+			expectedAlternatives: []string{"valid1", "valid2"},
+		},
+		{
+			name:                 "Success/IndexedParameterValidAlternatives",
+			parameterID:          "param2",
+			selectedValue:        "validA",
+			remarksProps:         remarksProps,
+			expectedValid:        true,
+			expectedAlternatives: []string{"validA", "validB"},
+		},
+		{
+			name:                 "Success/EmptyValueAccepted",
+			parameterID:          "param1",
+			selectedValue:        "",
+			remarksProps:         remarksProps,
+			expectedValid:        true,
+			expectedAlternatives: nil,
+		},
+		{
+			name:                 "Success/NAValueAccepted",
+			parameterID:          "param1",
+			selectedValue:        "N/A",
+			remarksProps:         remarksProps,
+			expectedValid:        true,
+			expectedAlternatives: nil,
+		},
+		{
+			name:                 "Success/NoAlternativesAcceptAnyValue",
+			parameterID:          "unknown",
+			selectedValue:        "any-value",
+			remarksProps:         remarksProps,
+			expectedValid:        true,
+			expectedAlternatives: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			valid, alternatives := filterParameterSelection(tt.parameterID, tt.selectedValue, tt.remarksProps)
+			require.Equal(t, tt.expectedValid, valid)
+			if tt.expectedAlternatives != nil {
+				require.ElementsMatch(t, tt.expectedAlternatives, alternatives)
+			} else {
+				require.Nil(t, alternatives)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary
This PR updates the existing `--dry-run` logic for the `complyctl plan` command. The `selectParameters` YAML key was added to inform the user of the parameters that are available in their assessment plan when passing the `--dry-run` flag. The included controls of the assessment plan will have their own `selectParameters` YAML key that has `name` and `value` for each of the parameterIDs that are associated with the control ID. 

Several functions were added to maintain the `NewAssessmentScopeFromCDs` factory functionality. The smaller functions build around the `NewAssessmentScopeFromCDs` to help separate parsing and processing the control implementations. 

## Related Issues

- Related to #212 
- CPLYTM-899

## Review Hints


- Test the dry-run output with the command:  `./bin/complyctl plan <framework-id> --dry-run` 
<img width="233.25" height="172.75" alt="image" src="https://github.com/user-attachments/assets/a84591f6-2de1-494b-8911-77810013fc8c" />

- Test the output written to the `config.yml` using the command: `./bin/complyctl plan <framework-id> --dry-run --out config.yml`
<img width="293" height="182.5" alt="image" src="https://github.com/user-attachments/assets/69fb5389-caa8-4fbe-8617-402ceafb2261" />


**Example:**
* **Framework ID:** anssi_bp28_minimal

> This PR includes assisted code. The assisted code uses Cursor v 1.24.0
