### PR TITLE
chore: bump c2p version to 2.0.0-alpha.2

### DIFF
--- a/cmd/openscap-plugin/server/server.go
+++ b/cmd/openscap-plugin/server/server.go
@@ -4,6 +4,7 @@ package server
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -42,11 +43,11 @@ func New() PluginServer {
 	}
 }
 
-func (s PluginServer) Configure(configMap map[string]string) error {
+func (s PluginServer) Configure(_ context.Context, configMap map[string]string) error {
 	return s.Config.LoadSettings(configMap)
 }
 
-func (s PluginServer) Generate(policy policy.Policy) error {
+func (s PluginServer) Generate(_ context.Context, policy policy.Policy) error {
 	hclog.Default().Info("Generating a tailoring file")
 	tailoringXML, err := xccdf.PolicyToXML(policy, s.Config)
 	if err != nil {
@@ -73,7 +74,7 @@ func (s PluginServer) Generate(policy policy.Policy) error {
 	return nil
 }
 
-func (s PluginServer) GetResults(oscalPolicy policy.Policy) (policy.PVPResult, error) {
+func (s PluginServer) GetResults(_ context.Context, oscalPolicy policy.Policy) (policy.PVPResult, error) {
 	pvpResults := policy.PVPResult{}
 	policyChecks := newChecks()
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/goccy/go-yaml v1.18.0
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.6.3
-	github.com/oscal-compass/compliance-to-policy-go/v2 v2.0.0-20250612165759-929b7bb27d96
+	github.com/oscal-compass/compliance-to-policy-go/v2 v2.0.0-alpha.2
 	github.com/oscal-compass/oscal-sdk-go v0.0.5
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.7

--- a/go.sum
+++ b/go.sum
@@ -241,8 +241,8 @@ github.com/openshift/library-go v0.0.0-20250129210218-fe56c2cf5d70 h1:VLj8CU9q00
 github.com/openshift/library-go v0.0.0-20250129210218-fe56c2cf5d70/go.mod h1:TQx0VEhZ/92qRXIMDu2Wg4bUPmw5HRNE6wpSZ+IsP0Y=
 github.com/openshift/machine-config-operator v0.0.1-0.20250401081735-9026ff2d802e h1:0K0ZZ2VYP21IiaPak4dt5cH1UWMacmWFHCE1txvtJag=
 github.com/openshift/machine-config-operator v0.0.1-0.20250401081735-9026ff2d802e/go.mod h1:wmBAHvqHXXSFa0yz3scg0RZLxcs5B51ZTeaVlCSPaDk=
-github.com/oscal-compass/compliance-to-policy-go/v2 v2.0.0-20250612165759-929b7bb27d96 h1:xW4+zQf7BMwfzzpOZ9t5ipJuevfvMQcinst6MNosnOw=
-github.com/oscal-compass/compliance-to-policy-go/v2 v2.0.0-20250612165759-929b7bb27d96/go.mod h1:CK6EAtX9c07mrR1uOS/CCZyb3PKlLQLShoDluz6TjYU=
+github.com/oscal-compass/compliance-to-policy-go/v2 v2.0.0-alpha.2 h1:G8uSTnshPa6lBnjxiVeD8grSSs8zxCYCS6hoFTIN8jA=
+github.com/oscal-compass/compliance-to-policy-go/v2 v2.0.0-alpha.2/go.mod h1:cvomwC5jU4cJMzoc0JMXG0z6bgeizhBRHVrzqEAFD1Q=
 github.com/oscal-compass/oscal-sdk-go v0.0.5 h1:2i+vAtsahQMZq90i9AwJ45mrIMEymirprBYEVvwM32E=
 github.com/oscal-compass/oscal-sdk-go v0.0.5/go.mod h1:oFWnMk4BqxtJHJSf8paEjef2p412UpLa7HajkFhceGM=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=

--- a/internal/complytime/configuration.go
+++ b/internal/complytime/configuration.go
@@ -186,7 +186,7 @@ func ActionsContextFromPlan(assessmentPlan *oscalTypes.AssessmentPlan) (*actions
 		compAdapter := components.NewSystemComponentAdapter(component)
 		allComponents = append(allComponents, compAdapter)
 	}
-	inputContext, err := actions.NewContext(allComponents)
+	inputContext, err := actions.NewContextFromComponents(allComponents)
 	if err != nil {
 		return nil, fmt.Errorf("error generating context from plan %s: %w", assessmentPlan.Metadata.Title, err)
 	}

--- a/internal/complytime/plugins.go
+++ b/internal/complytime/plugins.go
@@ -3,6 +3,7 @@
 package complytime
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -128,7 +129,7 @@ func Plugins(manager *framework.PluginManager, inputs *actions.InputContext, sel
 	getSelections := func(pluginId plugin.ID) map[string]string {
 		return pluginSelectionsMap[pluginId]
 	}
-	plugins, err := manager.LaunchPolicyPlugins(manifests, getSelections)
+	plugins, err := manager.LaunchPolicyPlugins(context.Background(), manifests, getSelections)
 	// Plugin subprocess has now been launched; cleanup always required below
 	if err != nil {
 		return nil, manager.Clean, err

--- a/vendor/github.com/oscal-compass/compliance-to-policy-go/v2/framework/actions/generate.go
+++ b/vendor/github.com/oscal-compass/compliance-to-policy-go/v2/framework/actions/generate.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 
 	"github.com/oscal-compass/oscal-sdk-go/settings"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/oscal-compass/compliance-to-policy-go/v2/logging"
 	"github.com/oscal-compass/compliance-to-policy-go/v2/plugin"
@@ -24,24 +25,37 @@ import (
 func GeneratePolicy(ctx context.Context, inputContext *InputContext, pluginSet map[plugin.ID]policy.Provider) error {
 	log := logging.GetLogger("generator")
 
+	eg, egCtx := errgroup.WithContext(ctx)
+	eg.SetLimit(inputContext.MaxConcurrency)
 	for providerId, policyPlugin := range pluginSet {
-		componentTitle, err := inputContext.ProviderTitle(providerId)
-		if err != nil {
-			if errors.Is(err, ErrMissingProvider) {
-				log.Warn(fmt.Sprintf("skipping %s provider: missing validation component", providerId))
-				continue
-			}
-			return err
-		}
-		log.Debug(fmt.Sprintf("Generating policy for provider %s", providerId))
+		func(providerId plugin.ID, plugin policy.Provider) {
+			eg.Go(func() error {
+				select {
+				case <-egCtx.Done():
+					return fmt.Errorf("%s skipped due to context cancellation/timeout: %w", providerId.String(), egCtx.Err())
+				default:
+				}
+				componentTitle, err := inputContext.ProviderTitle(providerId)
+				if err != nil {
+					if errors.Is(err, ErrMissingProvider) {
+						log.Warn(fmt.Sprintf("skipping %s provider: missing validation component", providerId))
+						return nil
+					}
+					return err
+				}
+				log.Debug(fmt.Sprintf("Generating policy for provider %s", providerId))
 
-		appliedRuleSet, err := settings.ApplyToComponent(ctx, componentTitle, inputContext.Store(), inputContext.Settings)
-		if err != nil {
-			return fmt.Errorf("failed to get rule sets for component %s: %w", componentTitle, err)
-		}
-		if err := policyPlugin.Generate(appliedRuleSet); err != nil {
-			return fmt.Errorf("plugin %s: %w", providerId, err)
-		}
+				appliedRuleSet, err := settings.ApplyToComponent(ctx, componentTitle, inputContext.Store(), inputContext.Settings)
+				if err != nil {
+					return fmt.Errorf("failed to get rule sets for component %s: %w", componentTitle, err)
+				}
+				if err := policyPlugin.Generate(egCtx, appliedRuleSet); err != nil {
+					return fmt.Errorf("plugin %s: %w", providerId, err)
+				}
+				return nil
+			})
+		}(providerId, policyPlugin)
 	}
-	return nil
+
+	return eg.Wait()
 }

--- a/vendor/github.com/oscal-compass/compliance-to-policy-go/v2/framework/actions/report.go
+++ b/vendor/github.com/oscal-compass/compliance-to-policy-go/v2/framework/actions/report.go
@@ -17,8 +17,8 @@ import (
 	"github.com/oscal-compass/oscal-sdk-go/rules"
 	"github.com/oscal-compass/oscal-sdk-go/transformers"
 
+	"github.com/oscal-compass/compliance-to-policy-go/v2/internal/utils"
 	"github.com/oscal-compass/compliance-to-policy-go/v2/logging"
-	"github.com/oscal-compass/compliance-to-policy-go/v2/pkg"
 	"github.com/oscal-compass/compliance-to-policy-go/v2/policy"
 )
 
@@ -160,7 +160,7 @@ func Report(ctx context.Context, inputContext *InputContext, planHref string, pl
 		}
 	}
 
-	assessmentResults.Results[0].Findings = pkg.NilIfEmpty(&oscalFindings)
+	assessmentResults.Results[0].Findings = utils.NilIfEmpty(&oscalFindings)
 
 	// If inventory items were created then add to result
 	if len(invItemMap) > 0 {
@@ -350,8 +350,8 @@ func toOscalObservation(observationByCheck policy.ObservationByCheck, ruleSet ex
 		Description:      observationByCheck.Description,
 		Methods:          observationByCheck.Methods,
 		Collected:        observationByCheck.Collected,
-		Subjects:         pkg.NilIfEmpty(&subjects),
-		RelevantEvidence: pkg.NilIfEmpty(&relevantEvidences),
+		Subjects:         utils.NilIfEmpty(&subjects),
+		RelevantEvidence: utils.NilIfEmpty(&relevantEvidences),
 	}
 
 	props := []oscalTypes.Property{

--- a/vendor/github.com/oscal-compass/compliance-to-policy-go/v2/internal/utils/gitutils.go
+++ b/vendor/github.com/oscal-compass/compliance-to-policy-go/v2/internal/utils/gitutils.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pkg
+package utils
 
 import (
 	"encoding/json"
@@ -151,7 +151,7 @@ func (g *GitUtils) gitClone(url string) (string, error) {
 		}
 		if username != "" && token != "" {
 			logger.Info("Git Clone with Auth given by 'username' and 'token' in environment variables ")
-			cloneOption.Auth = &githttp.BasicAuth{Username: username, Password: token}
+			cloneOption.Auth = &githttp.BasicAuth{Username: username, Password: token} // pragma: allowlist secret
 		}
 		if _, err := git.PlainClone(dir, false, cloneOption); err != nil {
 			return "", err

--- a/vendor/github.com/oscal-compass/compliance-to-policy-go/v2/plugin/discovery.go
+++ b/vendor/github.com/oscal-compass/compliance-to-policy-go/v2/plugin/discovery.go
@@ -160,7 +160,8 @@ func manifestMatchesType(manifest Manifest, pluginType string) bool {
 
 // readManifestFile reads and parses the manifest from JSON.
 func readManifestFile(pluginName ID, manifestPath string) (Manifest, error) {
-	manifestFile, err := os.Open(manifestPath)
+	cleanedPath := filepath.Clean(manifestPath)
+	manifestFile, err := os.Open(cleanedPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return Manifest{}, &ManifestNotFoundError{File: manifestPath, PluginID: pluginName.String()}

--- a/vendor/github.com/oscal-compass/compliance-to-policy-go/v2/plugin/initialization.go
+++ b/vendor/github.com/oscal-compass/compliance-to-policy-go/v2/plugin/initialization.go
@@ -61,8 +61,11 @@ func ClientFactory(logger hclog.Logger) ClientFactoryFunc {
 			Managed:          true,
 			AutoMTLS:         true,
 			AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
-			Cmd:              exec.Command(manifest.ExecutablePath),
-			Plugins:          SupportedPlugins,
+			// The #nosec comment is added with justification that by using manifest.ResolvePath()
+			// the manifest.ExecutablePath is validated as a plugin in the user-specified directory
+			// and sanitized.
+			Cmd:     exec.Command(manifest.ExecutablePath), /* #nosec G204 */
+			Plugins: SupportedPlugins,
 			SecureConfig: &plugin.SecureConfig{
 				Checksum: manifestSum,
 				Hash:     sha256.New(),

--- a/vendor/github.com/oscal-compass/compliance-to-policy-go/v2/plugin/policy_client.go
+++ b/vendor/github.com/oscal-compass/compliance-to-policy-go/v2/plugin/policy_client.go
@@ -19,29 +19,29 @@ type pvpClient struct {
 	client proto.PolicyEngineClient
 }
 
-func (pvp *pvpClient) Configure(configuration map[string]string) error {
+func (pvp *pvpClient) Configure(ctx context.Context, configuration map[string]string) error {
 	request := proto.ConfigureRequest{
 		Settings: configuration,
 	}
-	_, err := pvp.client.Configure(context.Background(), &request)
+	_, err := pvp.client.Configure(ctx, &request)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (pvp *pvpClient) Generate(p policy.Policy) error {
+func (pvp *pvpClient) Generate(ctx context.Context, p policy.Policy) error {
 	request := PolicyToProto(p)
-	_, err := pvp.client.Generate(context.Background(), request)
+	_, err := pvp.client.Generate(ctx, request)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (pvp *pvpClient) GetResults(p policy.Policy) (policy.PVPResult, error) {
+func (pvp *pvpClient) GetResults(ctx context.Context, p policy.Policy) (policy.PVPResult, error) {
 	request := PolicyToProto(p)
-	resp, err := pvp.client.GetResults(context.Background(), request)
+	resp, err := pvp.client.GetResults(ctx, request)
 	if err != nil {
 		return policy.PVPResult{}, err
 	}

--- a/vendor/github.com/oscal-compass/compliance-to-policy-go/v2/plugin/policy_plugin.go
+++ b/vendor/github.com/oscal-compass/compliance-to-policy-go/v2/plugin/policy_plugin.go
@@ -31,7 +31,7 @@ func FromPVP(pe policy.Provider) proto.PolicyEngineServer {
 }
 
 func (p *pvpService) Configure(ctx context.Context, request *proto.ConfigureRequest) (*proto.ConfigureResponse, error) {
-	if err := p.Impl.Configure(request.Settings); err != nil {
+	if err := p.Impl.Configure(ctx, request.Settings); err != nil {
 		return &proto.ConfigureResponse{}, status.Error(codes.Internal, err.Error())
 	}
 
@@ -41,7 +41,7 @@ func (p *pvpService) Configure(ctx context.Context, request *proto.ConfigureRequ
 
 func (p *pvpService) Generate(ctx context.Context, request *proto.PolicyRequest) (*proto.GenerateResponse, error) {
 	policy := NewPolicyFromProto(request)
-	if err := p.Impl.Generate(policy); err != nil {
+	if err := p.Impl.Generate(ctx, policy); err != nil {
 		return &proto.GenerateResponse{}, status.Error(codes.Internal, err.Error())
 	}
 
@@ -51,7 +51,7 @@ func (p *pvpService) Generate(ctx context.Context, request *proto.PolicyRequest)
 
 func (p *pvpService) GetResults(ctx context.Context, request *proto.PolicyRequest) (*proto.ResultsResponse, error) {
 	policy := NewPolicyFromProto(request)
-	result, err := p.Impl.GetResults(policy)
+	result, err := p.Impl.GetResults(ctx, policy)
 	if err != nil {
 		return &proto.ResultsResponse{}, status.Error(codes.Internal, err.Error())
 	}

--- a/vendor/github.com/oscal-compass/compliance-to-policy-go/v2/policy/provider.go
+++ b/vendor/github.com/oscal-compass/compliance-to-policy-go/v2/policy/provider.go
@@ -5,14 +5,16 @@
 
 package policy
 
+import "context"
+
 // Provider defines methods for a policy engine C2P plugin.
 type Provider interface {
 	// Configure send configuration options and selected values to the
 	// plugin.
-	Configure(map[string]string) error
+	Configure(context.Context, map[string]string) error
 	// Generate policy artifacts for a specific policy engine.
-	Generate(Policy) error
+	Generate(context.Context, Policy) error
 	// GetResults from a specific policy engine and transform into
 	// PVPResults.
-	GetResults(Policy) (PVPResult, error)
+	GetResults(context.Context, Policy) (PVPResult, error)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -349,14 +349,14 @@ github.com/openshift/api/machineconfiguration/v1alpha1
 # github.com/openshift/library-go v0.0.0-20250129210218-fe56c2cf5d70
 ## explicit; go 1.23.0
 github.com/openshift/library-go/pkg/crypto
-# github.com/oscal-compass/compliance-to-policy-go/v2 v2.0.0-20250612165759-929b7bb27d96
+# github.com/oscal-compass/compliance-to-policy-go/v2 v2.0.0-alpha.2
 ## explicit; go 1.24.0
 github.com/oscal-compass/compliance-to-policy-go/v2/api/proto
 github.com/oscal-compass/compliance-to-policy-go/v2/framework
 github.com/oscal-compass/compliance-to-policy-go/v2/framework/actions
 github.com/oscal-compass/compliance-to-policy-go/v2/framework/template
+github.com/oscal-compass/compliance-to-policy-go/v2/internal/utils
 github.com/oscal-compass/compliance-to-policy-go/v2/logging
-github.com/oscal-compass/compliance-to-policy-go/v2/pkg
 github.com/oscal-compass/compliance-to-policy-go/v2/plugin
 github.com/oscal-compass/compliance-to-policy-go/v2/policy
 # github.com/oscal-compass/oscal-sdk-go v0.0.5


### PR DESCRIPTION
## Summary
_This PR bumps the c2p version to 2.0.0-alpha.2 with related codes update in complyctl._

## Related Issues
_https://github.com/complytime/complyctl/pull/216_

