### PR TITLE
chore: create exception for line ends issue

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # Use LF line endings
 * text eol=lf
+# Tells Git to treat the file as a binary file, which prevents any line ending conversions.
+vendor/github.com/go-logfmt/logfmt/README.md -text


### PR DESCRIPTION
## Summary

This PR should replace #219 and #227.

## Related Issues

- It annoys to treat the line ending issue with `vendor/github.com/go-logfmt/logfmt/README.md`
- It was also impacting packit jobs: https://download.copr.fedorainfracloud.org/results/packit/complytime-complyctl-219/srpm-builds/09381338/builder-live.log.gz

## Review Hints

When working with the repository, `vendor/github.com/go-logfmt/logfmt/README.md` should no longer be an issue.
- https://git-scm.com/docs/gitattributes