### PR TITLE
chore: [CPLYTM-941] add e2e pipeline

### DIFF
--- a/.github/actions/setup-complyctl/action.yml
+++ b/.github/actions/setup-complyctl/action.yml
@@ -2,14 +2,14 @@ name: "Setup complyctl environment"
 description: "Setup environment for complyctl running"
 
 inputs:
-  catalog_path:
-    description: "OSCAL content repo catalog path"
+  product:
+    description: "The chosen product"
     required: true
-  profile_path:
-    description: "OSCAL content repo profile path"
+  catalog:
+    description: "OSCAL content catalog of the chosen product"
     required: true
-  component_definition_path:
-    description: "OSCAL content repo component-definition path"
+  profile:
+    description: "OSCAL content profile of the chosen product"
     required: true
 
 runs:
@@ -31,72 +31,7 @@ runs:
       with:
         go-version-file: './go.mod'
 
-    # Build complyctl
-    - name: Build complyctl
-      run: make build
-      shell: bash
-
-    # Configure complyctl
-    - name: Config compyctl
-      run: |
-        cp ./bin/complyctl /usr/local/bin
-        complyctl list 2>/dev/null || true
-        # download OSCAL content
-        wget https://raw.githubusercontent.com/ComplianceAsCode/oscal-content/refs/heads/main/${{ inputs.profile_path }} -O $HOME/.local/share/complytime/controls/profile.json
-        wget https://raw.githubusercontent.com/ComplianceAsCode/oscal-content/refs/heads/main/${{ inputs.catalog_path }} -O $HOME/.local/share/complytime/controls/catalog.json
-        wget https://raw.githubusercontent.com/ComplianceAsCode/oscal-content/refs/heads/main/${{ inputs.component_definition_path }} -O $HOME/.local/share/complytime/bundles/component-definition.json
-        # update OSCAL content trestle path
-        sed -i 's|trestle://${{ inputs.catalog_path }}|trestle://controls/catalog.json|' $HOME/.local/share/complytime/controls/profile.json
-        sed -i 's|trestle://${{ inputs.profile_path }}|trestle://controls/profile.json|' $HOME/.local/share/complytime/bundles/component-definition.json
-        cp -rp bin/openscap-plugin $HOME/.local/share/complytime/plugins
-        checksum=$(sha256sum $HOME/.local/share/complytime/plugins/openscap-plugin| cut -d ' ' -f 1 )
-        cat > $HOME/.local/share/complytime/plugins/c2p-openscap-manifest.json << EOF
-        {
-          "metadata": {
-            "id": "openscap",
-            "description": "My openscap plugin",
-            "version": "0.0.1",
-            "types": [
-              "pvp"
-            ]
-          },
-          "executablePath": "openscap-plugin",
-          "sha256": "$checksum",
-          "configuration": [
-            {
-              "name": "workspace",
-              "description": "Directory for writing plugin artifacts",
-              "required": true
-            },
-            {
-              "name": "profile",
-              "description": "The OpenSCAP profile to run for assessment",
-              "required": true
-            },
-            {
-              "name": "datastream",
-              "description": "The OpenSCAP datastream to use. If not set, the plugin will try to determine it based on system information",
-              "required": false
-            },
-            {
-              "name": "policy",
-              "description": "The name of the generated tailoring file",
-              "default": "tailoring_policy.xml",
-              "required": false
-            },
-            {
-              "name": "arf",
-              "description": "The name of the generated ARF file",
-              "default": "arf.xml",
-              "required": false
-            },
-            {
-              "name": "results",
-              "description": "The name of the generated results file",
-              "default": "results.xml",
-              "required": false
-            }
-          ]
-        }
-        EOF
+    # Build complyctl and setup complyctl
+    - name: Build complyctl and setup complyctl
+      run: sh tests/build_init_env.sh ${{ inputs.product }} ${{ inputs.catalog }} ${{ inputs.profile }}
       shell: bash

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,7 +1,9 @@
 name: e2e
 
 on:
-  # Triggers the workflow on pull request events for the main branch
+  push:
+    branches:
+      - main
   pull_request:
     types:
       - opened
@@ -10,51 +12,26 @@ on:
 permissions:
   contents: read
 
-jobs:
-  run-e2e-on-fedora-vm:
-    runs-on: ubuntu-latest
+env:
+  COMPLYTIME_DEV_MODE: 1
 
+jobs:
+  run-e2e:
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:latest
     steps:
       # Checkout the code from the repository
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       
-      # Set up Lima, the tool that will create our fedora VM.
-      - name: Set up Lima
-        uses: lima-vm/lima-actions/setup@03b96d61959e83b2c737e44162c3088e81de0886 # v1.0.1
-        id: lima
+      - name: Install the dependences
+        run: dnf install git wget make scap-security-guide go tree -y
 
-      # Use a cache for Lima to speed up subsequent runs.
-      # This is a recommended best practice to make your workflows faster.
-      - name: Cache Lima downloads
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/.cache/lima
-          key: lima-${{ runner.os }}-${{ steps.lima.outputs.version }}
-
-      # Start the Fedora VM.
-      # 'limactl start' downloads the Fedora cloud image and boots it as a VM.
-      # The template://fedora shorthand makes it easy to specify.
-      - name: Start Fedora VM
-        run: limactl start --name=fedora template://fedora 
-
-      - name: Install the dependences on fedora VM
+      - name: Build complyctl and init complyctl
         run: |
-          limactl shell fedora bash -c '
-            sudo dnf install git wget make scap-security-guide go tree -y
-          '
-      - name: Build complyctl and Init complyctl
-        run: |
-          limactl shell fedora bash -c '
-            cp -R ../complyctl /tmp && cd /tmp/complyctl
-            sudo chown -R runner:runner /usr/local/
-            export COMPLYTIME_DEV_MODE=1
-            sh tests/build_init_env.sh
-            '
+          git config --global --add safe.directory /__w/complyctl/complyctl
+          sh tests/build_init_env.sh
+
       - name: Run e2e tests
-        run: |
-          limactl shell fedora bash -c '
-            cd /tmp/complyctl
-            export COMPLYTIME_DEV_MODE=1
-            go test tests/e2e/e2e_test.go -v
-            '
+        run: go test tests/e2e/e2e_test.go -v

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,60 @@
+name: e2e
+
+on:
+  # Triggers the workflow on pull request events for the main branch
+  pull_request:
+    types:
+      - opened
+      - synchronize 
+
+permissions:
+  contents: read
+
+jobs:
+  run-e2e-on-fedora-vm:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the code from the repository
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      
+      # Set up Lima, the tool that will create our fedora VM.
+      - name: Set up Lima
+        uses: lima-vm/lima-actions/setup@03b96d61959e83b2c737e44162c3088e81de0886 # v1.0.1
+        id: lima
+
+      # Use a cache for Lima to speed up subsequent runs.
+      # This is a recommended best practice to make your workflows faster.
+      - name: Cache Lima downloads
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ~/.cache/lima
+          key: lima-${{ runner.os }}-${{ steps.lima.outputs.version }}
+
+      # Start the Fedora VM.
+      # 'limactl start' downloads the Fedora cloud image and boots it as a VM.
+      # The template://fedora shorthand makes it easy to specify.
+      - name: Start Fedora VM
+        run: limactl start --name=fedora template://fedora 
+
+      - name: Install the dependences on fedora VM
+        run: |
+          limactl shell fedora bash -c '
+            sudo dnf install git wget make scap-security-guide go tree -y
+          '
+      - name: Build complyctl and Init complyctl
+        run: |
+          limactl shell fedora bash -c '
+            cp -R ../complyctl /tmp && cd /tmp/complyctl
+            sudo chown -R runner:runner /usr/local/
+            export COMPLYTIME_DEV_MODE=1
+            sh tests/build_init_env.sh
+            '
+      - name: Run e2e tests
+        run: |
+          limactl shell fedora bash -c '
+            cd /tmp/complyctl
+            export COMPLYTIME_DEV_MODE=1
+            go test tests/e2e/e2e_test.go -v
+            '

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -1,4 +1,4 @@
-name: e2e
+name: e2e-test
 
 on:
   push:
@@ -16,7 +16,7 @@ env:
   COMPLYTIME_DEV_MODE: 1
 
 jobs:
-  run-e2e:
+  e2e-test:
     runs-on: ubuntu-latest
     container:
       image: fedora:latest
@@ -25,13 +25,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       
-      - name: Install the dependences
-        run: dnf install git wget make scap-security-guide go tree -y
+      # Build and setup complyctl
+      - name: Setup compyctl
+        uses: ./.github/actions/setup-complyctl
+        # This is the test data for a specific product, and it may be updated in the future if necessary.
+        with:
+          product: 'fedora'
+          catalog: 'cusp_fedora'
+          profile: 'fedora-cusp_fedora-default'
 
-      - name: Build complyctl and init complyctl
-        run: |
-          git config --global --add safe.directory /__w/complyctl/complyctl
-          sh tests/build_init_env.sh
-
+      # Run e2e tests
       - name: Run e2e tests
         run: go test tests/e2e/e2e_test.go -v

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -1,10 +1,13 @@
-name: integration_test.yml
+name: integration-test
 
 on:
   push:
     branches:
       - main
   pull_request:
+    types:
+      - opened
+      - synchronize
 
 env:
   COMPLYTIME_DEV_MODE: 1
@@ -25,10 +28,11 @@ jobs:
       # Setup complyctl for further testing
       - name: Setup compyctl
         uses: ./.github/actions/setup-complyctl
+        # This is the test data for a specific product, and it may be updated in the future if necessary.
         with:
-          catalog_path: 'catalogs/cusp_fedora/catalog.json'
-          profile_path: 'profiles/fedora-cusp_fedora-default/profile.json'
-          component_definition_path: 'component-definitions/fedora/fedora-cusp_fedora-default/component-definition.json'
+          product: 'fedora'
+          catalog: 'cusp_fedora'
+          profile: 'fedora-cusp_fedora-default'
 
       # Test complyctl
       - name: Test complyctl

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -30,4 +30,4 @@ jobs:
 
       # Step 4: Run Go tests
       - name: Run unit tests
-        run: go test -v ./...
+        run: go test -v $(go list ./... | grep -v /tests)

--- a/tests/build_init_env.sh
+++ b/tests/build_init_env.sh
@@ -4,17 +4,24 @@
 #
 # This script performs the following setup tasks:
 #  - Build complyctl and initializes the complytime workspace.
-#  - Downloads required controls and component definitions.
+#  - Downloads the chosen product's controls and component definitions.
 #  - Sets up necessary plugins.
 #
 # Usage:
-#   sh build_init_env.sh
+#   sh build_init_env.sh $product $catalog $profile
+#   sh build_init_env.sh fedora cusp_fedora fedora-cusp_fedora-default
 
 URL="https://raw.githubusercontent.com/ComplianceAsCode/oscal-content/refs/heads/main/"
-CATALOG="cusp_fedora"
-PROFILE="fedora-cusp_fedora-default"
-PRODUCT="fedora"
 WDIR=".local/share/complytime"
+
+product=$1
+catalog=$2
+profile=$3
+
+if [ $# -lt 3 ]; then
+    echo "Please provide the necessary inputs."
+    exit 1
+fi
 
 # Build the compyctl
 make build && cp ./bin/complyctl /usr/local/bin
@@ -22,14 +29,14 @@ make build && cp ./bin/complyctl /usr/local/bin
 echo "Attempting to run the command complyctl list."
 set +e
 complyctl list 2>/dev/null
-echo "An error occurred, but script continues after the complyctl list."
-# Download fedora cusp OSCAL content
-wget $URL/profiles/$PROFILE/profile.json -O $HOME/$WDIR/controls/profile.json
-wget $URL/catalogs/$CATALOG/catalog.json -O $HOME/$WDIR/controls/catalog.json
-wget $URL/component-definitions/$PRODUCT/$PROFILE/component-definition.json -O $HOME/$WDIR/bundles/component-definition.json
+echo "The error is expected because there is no content, this will create needed directoris for further test."
+# Download OSCAL content
+wget $URL/profiles/$3/profile.json -O $HOME/$WDIR/controls/profile.json
+wget $URL/catalogs/$2/catalog.json -O $HOME/$WDIR/controls/catalog.json
+wget $URL/component-definitions/$1/$3/component-definition.json -O $HOME/$WDIR/bundles/component-definition.json
 # Update trestle path
-sed -i "s|trestle://catalogs/$CATALOG/catalog.json|trestle://controls/catalog.json|" $HOME/$WDIR/controls/profile.json
-sed -i "s|trestle://profiles/$PROFILE/profile.json|trestle://controls/profile.json|" $HOME/$WDIR/bundles/component-definition.json
+sed -i "s|trestle://catalogs/$2/catalog.json|trestle://controls/catalog.json|" $HOME/$WDIR/controls/profile.json
+sed -i "s|trestle://profiles/$3/profile.json|trestle://controls/profile.json|" $HOME/$WDIR/bundles/component-definition.json
 # Setup plugin
 cp -rp bin/openscap-plugin $HOME/$WDIR/plugins
 checksum=$(sha256sum $HOME/$WDIR/plugins/openscap-plugin| cut -d " " -f 1 )

--- a/tests/build_init_env.sh
+++ b/tests/build_init_env.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Initializes the complyctl environment for e2e and integration tests.
+#
+# This script performs the following setup tasks:
+#  - Build complyctl and initializes the complytime workspace.
+#  - Downloads required controls and component definitions.
+#  - Sets up necessary plugins.
+#
+# Usage:
+#   sh build_init_env.sh
+
+URL="https://raw.githubusercontent.com/ComplianceAsCode/oscal-content/refs/heads/main/"
+CATALOG="cusp_fedora"
+PROFILE="fedora-cusp_fedora-default"
+PRODUCT="fedora"
+WDIR=".local/share/complytime"
+
+# Build the compyctl
+make build && cp ./bin/complyctl /usr/local/bin
+# Running list command that will fail due to no requirements files
+echo "Attempting to run the command complyctl list."
+set +e
+complyctl list 2>/dev/null
+echo "An error occurred, but script continues after the complyctl list."
+# Download fedora cusp OSCAL content
+wget $URL/profiles/$PROFILE/profile.json -O $HOME/$WDIR/controls/profile.json
+wget $URL/catalogs/$CATALOG/catalog.json -O $HOME/$WDIR/controls/catalog.json
+wget $URL/component-definitions/$PRODUCT/$PROFILE/component-definition.json -O $HOME/$WDIR/bundles/component-definition.json
+# Update trestle path
+sed -i "s|trestle://catalogs/$CATALOG/catalog.json|trestle://controls/catalog.json|" $HOME/$WDIR/controls/profile.json
+sed -i "s|trestle://profiles/$PROFILE/profile.json|trestle://controls/profile.json|" $HOME/$WDIR/bundles/component-definition.json
+# Setup plugin
+cp -rp bin/openscap-plugin $HOME/$WDIR/plugins
+checksum=$(sha256sum $HOME/$WDIR/plugins/openscap-plugin| cut -d " " -f 1 )
+cp docs/samples/c2p-openscap-manifest.json $HOME/$WDIR/plugins
+echo "Build and init finished."

--- a/tests/build_init_env.sh
+++ b/tests/build_init_env.sh
@@ -33,5 +33,6 @@ sed -i "s|trestle://profiles/$PROFILE/profile.json|trestle://controls/profile.js
 # Setup plugin
 cp -rp bin/openscap-plugin $HOME/$WDIR/plugins
 checksum=$(sha256sum $HOME/$WDIR/plugins/openscap-plugin| cut -d " " -f 1 )
+sed -i "s/checksum_placeholder/$checksum/" docs/samples/c2p-openscap-manifest.json
 cp docs/samples/c2p-openscap-manifest.json $HOME/$WDIR/plugins
 echo "Build and init finished."

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -1,0 +1,59 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComplyctlHelp(t *testing.T) {
+	// Run the "complyctl --help" command
+	cmd := exec.Command("complyctl", "--help")
+	output, err := cmd.CombinedOutput()
+
+	// Ensure there is no error when running the command
+	if err != nil {
+		t.Fatalf("Error running complyctl --help: %v\nOutput: %s", err, string(output))
+	}
+
+	// Convert the output to a string and check if expected text is present
+	outputStr := string(output)
+
+	// Assert that "Usage" or the expected help message is part of the output
+	// Use a table-driven test for clear, maintainable assertions
+	expectedSubstrings := []string{
+		"Usage:",
+		"Aliases:",
+		"Available Commands:",
+		"Flags:",
+		"complyctl [command]",
+	}
+
+	for _, expected := range expectedSubstrings {
+		t.Run("Contains "+expected, func(t *testing.T) {
+			assert.True(t, strings.Contains(outputStr, expected), "Help output should contain '%s'", expected)
+		})
+	}
+}
+
+func TestComplyctlList(t *testing.T) {
+	// Run the "complyctl list" command
+	cmd := exec.Command("complyctl", "list", "--plain")
+	output, err := cmd.CombinedOutput()
+
+	// Ensure there is no error when running the command
+	if err != nil {
+		t.Fatalf("Error running complyctl list: %v\nOutput: %s", err, string(output))
+	}
+
+	// Convert the output to a string and check if expected content is returned
+	outputStr := string(output)
+
+	// Check if the output contains expected text
+	assert.True(t, len(outputStr) > 0, "Output from 'complyctl list' should not be empty")
+	assert.True(t, strings.Contains(outputStr, "cusp_fedora"), "The output should contain 'cusp_fedora'")
+}


### PR DESCRIPTION
## Summary
This PR is to add the pipeline for e2e. It includes the e2e pipeline workflow and initiates the test environment on Fedora container. The test cases will be included in another PR. 
## Related Issues
[CPLYTM-940](https://issues.redhat.com/browse/CPLYTM-940)
[CPLYTM-943](https://issues.redhat.com/browse/CPLYTM-943)

- _Closes #[CPLYTM-941](https://issues.redhat.com/browse/CPLYTM-941)

## Review Hints

- Install the dependencies on a Fedora container
- Build complyctl and download the contents from oscal-content to the related directories 
- Run the e2e tests(more cases will be included in another PR, the related issue is [CPLYTM-943](https://issues.redhat.com/browse/CPLYTM-943))


