### PR TITLE
feat: CPLYTM-900 CPLYTM-901 regeneration updates

### DIFF
--- a/cmd/complyctl/cli/plan.go
+++ b/cmd/complyctl/cli/plan.go
@@ -124,7 +124,7 @@ func runPlan(cmd *cobra.Command, opts *planOptions) error {
 		if err := yaml.Unmarshal(configBytes, &assessmentScope); err != nil {
 			return fmt.Errorf("error unmarshaling assessment plan: %w", err)
 		}
-		if err := assessmentScope.ApplyScope(assessmentPlan, logger); err != nil {
+		if err := assessmentScope.ApplyScope(assessmentPlan, logger, componentDefs...); err != nil {
 			return fmt.Errorf("error applying assessment scope: %w", err)
 		}
 	}

--- a/internal/complytime/scope.go
+++ b/internal/complytime/scope.go
@@ -96,11 +96,14 @@ func NewAssessmentScopeFromCDs(frameworkId string, appDir ApplicationDirectory, 
 					continue
 				}
 
-				// Load control titles from source if needed
+				// Load control titles from source on control implementation if needed
 				if validator != nil {
+					// Check if source was already loaded
 					if _, sourceLoaded := controlTitlesBySource[ci.Source]; !sourceLoaded {
+						// Load all titles from this source
 						loadedTitles, err := loadControlTitlesFromSource(ci.Source, appDir, validator)
 						if err != nil {
+							// Empty map if source can't be loaded
 							controlTitlesBySource[ci.Source] = make(map[string]string)
 						} else {
 							controlTitlesBySource[ci.Source] = loadedTitles
@@ -116,12 +119,15 @@ func NewAssessmentScopeFromCDs(frameworkId string, appDir ApplicationDirectory, 
 						// Set control title if not already set
 						if _, exists := result.controlTitles[ir.ControlId]; !exists {
 							if validator != nil {
+								// Get the title from the loaded source
 								if title, found := controlTitlesBySource[ci.Source][ir.ControlId]; found {
 									result.controlTitles[ir.ControlId] = title
 								} else {
+									// Empty string if title isn't available
 									result.controlTitles[ir.ControlId] = ""
 								}
 							} else {
+								// Empty string if the title isn't available
 								result.controlTitles[ir.ControlId] = ""
 							}
 						}
@@ -170,7 +176,7 @@ func processSetParameters(ci oscalTypes.ControlImplementationSet, result *compon
 					if prop.Name == extensions.RuleIdProp {
 						ruleID = prop.Value
 					}
-					if prop.Name == extensions.ParameterIdProp || strings.HasPrefix(prop.Name, extensions.ParameterIdProp+"_") {
+					if isParameterIdProperty(prop.Name) {
 						parametersInGroup = append(parametersInGroup, prop.Value)
 					}
 				}
@@ -480,8 +486,7 @@ func (a AssessmentScope) getRelatedControlIDs(activity *oscalTypes.Activity) []s
 	return controlIDs
 }
 
-// findParameterValueForControls finds the appropriate parameter value for the given parameter name
-// from the related controls.
+// findParameterValueForControls finds the parameter value from related controls.
 func (a AssessmentScope) findParameterValueForControls(paramName string, relatedControlIDs []string, controlParams map[string]map[string]string) string {
 	// Check each related control in order for the parameter
 	for _, controlID := range relatedControlIDs {


### PR DESCRIPTION
## Summary

This PR updates the assessment plan regeneration logic for selecting parameters. The attached docs [regeneration/notes](https://docs.google.com/document/d/1jilafjuCaapzfqgLULUYCOcdF2Pn0x-o3xip-R0nP_A/edit?tab=t.bn9m1lr80jbt) & [notes for regeneration](https://docs.google.com/document/d/1_DakM48LiirXyowJsbI5ho_sawWP4nX0Lh4pLXkwtbg/edit?tab=t.ofaj7sp7nabz) outlines the expected output when configuring parameters of the assessment plan. The updates regenerate the assessment plan using the `remarks` values. The implemented requirements map the `control-id` to the rules' remarks property that populates the associated `selectParameters`. The control-ids with no `selectParameters` values will be marked "N/A." Otherwise, for all rules associated with a `control-id`, the parameter-ids that share the same remarks value will be present in the `selectParameters` field. When the user passes the `config.yml` back using the `--scope-config config.yml`,  the validation will check the implemented-requirements and find the parameter alternative values using the numeric suffix. 

Several functions were added to maintain the `NewAssessmentScopeFromCDs` factory functionality. The smaller functions build around the `NewAssessmentScopeFromCDs` to help separate parsing and processing the control implementations. 

## Related Issues

- Depends on #229 
- Related to #228 
- Closes #231 

## Review Hints

- Test by passing the `./bin/complyctl info <framework-id> --parameter <parameter-id>` to see the alternative selections for the particular `parameter-id`.
- Use the `./bin/complyctl plan <framework-id> --dry-run --out config.yml` to configure the `selectParameters` yaml key and second-level yaml keys for the parameter value alternatives seen in the info command. 
- Pass the updated `config.yml` to the `./bin/complyctl plan <framework-id> --scope-config config.yml` and the assessment plan will be regenerated with the new selected parameter values. 
- Test the error functionality by updating the `selectParameters:` `value` field with an incorrect alternative value. The result will throw an error and inform the user of the available alternative values.
<img width="500" height="90" alt="image" src="https://github.com/user-attachments/assets/ab7a8c63-6b25-4d11-af2d-8444e28dce10" />


> This PR was assisted by `Cursor v1.24.0`. The coding assistant was used to validate and expand on the use-case and tests with provided structure and logic. 

