### PR TITLE
test: [CPLYTM-943] add e2e test cases

### DIFF
--- a/.github/actions/setup-complyctl/action.yml
+++ b/.github/actions/setup-complyctl/action.yml
@@ -17,7 +17,7 @@ runs:
   steps:
     # Install dependency on fedora
     - name: Install dependency
-      run: dnf install wget make scap-security-guide git -y
+      run: dnf install wget make scap-security-guide git jq -y
       shell: bash
 
     # Configure Git for safe directory

--- a/tests/build_init_env.sh
+++ b/tests/build_init_env.sh
@@ -40,6 +40,6 @@ sed -i "s|trestle://profiles/$3/profile.json|trestle://controls/profile.json|" $
 # Setup plugin
 cp -rp bin/openscap-plugin $HOME/$WDIR/plugins
 checksum=$(sha256sum $HOME/$WDIR/plugins/openscap-plugin| cut -d " " -f 1 )
-sed -i "s/checksum_placeholder/$checksum/" docs/samples/c2p-openscap-manifest.json
-cp docs/samples/c2p-openscap-manifest.json $HOME/$WDIR/plugins
+jq --arg new_sum "$checksum" '.sha256 = $new_sum' "docs/samples/c2p-openscap-manifest.json" > "docs/samples/c2p-openscap-manifest.json.tmp"
+mv docs/samples/c2p-openscap-manifest.json.tmp $HOME/$WDIR/plugins/c2p-openscap-manifest.json
 echo "Build and init finished."

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -8,6 +8,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	FrameworkID = "cusp_fedora"
+	controlID   = "cusp_fedora_1-1"
+	ruleID      = "file_groupowner_grub2_cfg"
+	parameterID = "var_rekey_limit_size"
+	configPath  = "../testdata/config.yml"
 )
 
 func TestComplyctlHelp(t *testing.T) {
@@ -55,5 +64,201 @@ func TestComplyctlList(t *testing.T) {
 
 	// Check if the output contains expected text
 	assert.True(t, len(outputStr) > 0, "Output from 'complyctl list' should not be empty")
-	assert.True(t, strings.Contains(outputStr, "cusp_fedora"), "The output should contain 'cusp_fedora'")
+	assert.True(t, strings.Contains(outputStr, FrameworkID))
+}
+
+func TestComplyctlInfo(t *testing.T) {
+	testCases := []struct {
+		name             string   // A descriptive name for the sub-test.
+		args             []string // The command-line arguments to pass to "complyctl info".
+		expectedFragment string   // A string we expect to find in the command's output.
+	}{
+		{
+			name:             "show info for FrameworkID",
+			args:             []string{"info", FrameworkID, "--plain"},
+			expectedFragment: FrameworkID,
+		},
+		{
+			name:             "show info for controlID",
+			args:             []string{"info", FrameworkID, "--control", controlID, "--plain"},
+			expectedFragment: controlID,
+		},
+		{
+			name:             "show info for rule",
+			args:             []string{"info", FrameworkID, "--rule", ruleID, "--plain"},
+			expectedFragment: ruleID,
+		},
+		{
+			name:             "show info for parameter",
+			args:             []string{"info", FrameworkID, "--parameter", parameterID, "--plain"},
+			expectedFragment: parameterID,
+		},
+	}
+
+	// Iterate over the test cases and run each as a sub-test.
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Execute the command
+			cmd := exec.Command("complyctl", tc.args...)
+			output, err := cmd.CombinedOutput()
+
+			// It stops the current sub-test on failure.
+			require.NoError(t, err, "command failed unexpectedly. Output: \n%s", string(output))
+
+			// Use assert.Contains for the actual test assertion.
+			assert.Contains(t, string(output), tc.expectedFragment, "output should contain the expected fragment")
+		})
+	}
+}
+
+func TestComplyctlPlan(t *testing.T) {
+	// testCases defines all scenarios we want to test for the 'plan' command.
+	testCases := []struct {
+		name           string   // A descriptive name for the sub-test.
+		args           []string // Arguments to pass to the 'complyctl plan' command.
+		expectedOutput string   // A substring we expect to find in the command's output.
+		expectedFile   string   // The path to a file that should be created.
+		expectError    bool     // Whether we expect the command to fail.
+	}{
+		{
+			name:           "DefaultWorkspace",
+			args:           []string{FrameworkID},
+			expectedOutput: "INFO Assessment plan written to complytime/assessment-plan.json",
+			expectedFile:   "complytime/assessment-plan.json",
+		},
+		{
+			name:           "CustomWorkspace",
+			args:           []string{FrameworkID, "--workspace", "custom_dir"},
+			expectedOutput: "INFO Assessment plan written to custom_dir/assessment-plan.json",
+			expectedFile:   "custom_dir/assessment-plan.json",
+		},
+		{
+			name:           "DryRun",
+			args:           []string{FrameworkID, "--dry-run"},
+			expectedOutput: "controlId:", // Check if the output contains expected text
+			expectedFile:   "",           // No file should be created.
+		},
+		{
+			name:           "DryRunOutFile",
+			args:           []string{FrameworkID, "--dry-run", "--out", "config.yml"},
+			expectedOutput: "", // No output, so we don't check it.
+			expectedFile:   "config.yml",
+		},
+		{
+			name:           "ScopeConfig",
+			args:           []string{FrameworkID, "--scope-config", configPath, "--workspace", "config_dir"},
+			expectedOutput: "INFO Assessment plan written to config_dir/assessment-plan.json",
+			expectedFile:   "config_dir/assessment-plan.json",
+		},
+	}
+
+	// Loop through all defined test cases and run them as sub-tests.
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			// Construct the full command arguments.
+			args := append([]string{"plan"}, tc.args...)
+			cmd := exec.Command("complyctl", args...)
+
+			// Execute the command.
+			output, err := cmd.CombinedOutput()
+			outputStr := string(output)
+
+			// Assert that the command's success or failure matches our expectation.
+			if tc.expectError {
+				require.Error(t, err, "Expected an error but got none. Output:\n%s", outputStr)
+			} else {
+				require.NoError(t, err, "Command failed unexpectedly. Output:\n%s", outputStr)
+			}
+
+			// If we expect specific output, check for it.
+			if tc.expectedOutput != "" {
+				assert.Contains(t, outputStr, tc.expectedOutput, "Output did not contain expected text")
+			}
+
+			// If we expect a file to be created, verify it exists.
+			if tc.expectedFile != "" {
+				assert.FileExists(t, tc.expectedFile)
+			}
+		})
+	}
+}
+
+func TestComplyctlGenerate(t *testing.T) {
+
+	cmd := exec.Command("complyctl", "generate")
+	output, err := cmd.CombinedOutput()
+
+	// Ensure there is no error when running the command
+	if err != nil {
+		t.Fatalf("Error running complyctl generate: %v\nOutput: %s", err, string(output))
+	}
+
+	// Check if the output contains expected text
+	outputStr := string(output)
+	assert.True(t, strings.Contains(outputStr, "Policy generation process completed"))
+}
+
+func TestComplyctlScan(t *testing.T) {
+	// Run the "complyctl scan" command
+	// In order to improve the performace, without md will be covered in the CustomizePlanWorkflow
+	cmd := exec.Command("complyctl", "scan", "--with-md")
+	output, err := cmd.CombinedOutput()
+
+	// Ensure there is no error when running the command
+	if err != nil {
+		t.Fatalf("Error running complyctl scan --with-md: %v\nOutput: %s", err, string(output))
+	}
+
+	// Check if the output contains expected text
+	outputStr := string(output)
+	assert.True(t, strings.Contains(outputStr, "The assessment results in JSON were successfully written to complytime/assessment-results.json"))
+	assert.True(t, strings.Contains(outputStr, "The assessment results in markdown were successfully written to complytime/assessment-results.md"))
+
+	// Check if the assessment-results files exist
+	filePath_json := "complytime/assessment-results.json"
+	filePath_md := "complytime/assessment-results.md"
+	assert.FileExists(t, filePath_json, "Expected file exists:", filePath_json)
+	assert.FileExists(t, filePath_md, "Expected file exists:", filePath_md)
+}
+
+func TestComplyctlCustomizePlanWorkflow(t *testing.T) {
+	// The the workflow of customize the assessment plan via the config.yml
+
+	// 1. Load config.yml to customize the generated assessment plan
+	cmd := exec.Command("complyctl", "plan", FrameworkID, "--scope-config", configPath)
+	output, err := cmd.CombinedOutput()
+
+	// Ensure there is no error when running the command
+	if err != nil {
+		t.Fatalf("Error running complyctl plan: %v\nOutput: %s", err, string(output))
+	}
+	// Check if the output contains expected text
+	outputStr := string(output)
+	assert.True(t, strings.Contains(outputStr, "Assessment plan written to complytime/assessment-plan.json"))
+
+	// 2. Generate PVP policy from the assessment plan
+	cmd = exec.Command("complyctl", "generate")
+	output, err = cmd.CombinedOutput()
+
+	// Ensure there is no error when running the command
+	if err != nil {
+		t.Fatalf("Error running complyctl generate: %v\nOutput: %s", err, string(output))
+	}
+	// Check if the output contains expected text
+	outputStr = string(output)
+	assert.True(t, strings.Contains(outputStr, "Policy generation process completed"))
+
+	// 3. Scan environment with the customized assessment plan
+	cmd = exec.Command("complyctl", "scan")
+	output, err = cmd.CombinedOutput()
+
+	// Ensure there is no error when running the command
+	if err != nil {
+		t.Fatalf("Error running complyctl scan: %v\nOutput: %s", err, string(output))
+	}
+	// Check if the output contains expected text
+	outputStr = string(output)
+	assert.True(t, strings.Contains(outputStr, "The assessment results in JSON were successfully written to complytime/assessment-results.json"))
+	assert.True(t, strings.Contains(outputStr, "No assessment result in markdown will be generated"))
 }

--- a/tests/testdata/config.yml
+++ b/tests/testdata/config.yml
@@ -1,0 +1,17 @@
+frameworkId: cusp_fedora
+includeControls:
+- controlId: cusp_fedora_4-1
+  controlTitle: Account Protection
+  includeRules:
+  - "accounts_umask_etc_login_defs"
+- controlId: cusp_fedora_4-2
+  controlTitle: Sudo
+  includeRules:
+  - "sudo_custom_logfile"
+- controlId: cusp_fedora_5-2
+  controlTitle: Firewall Configuration
+  includeRules:
+  - "*"
+  excludeRules:
+  - "service_firewalld_enabled"
+  - "service_nftables_disabled"


### PR DESCRIPTION
## Summary
The e2e test cases are included in this PR, which cover all the major functions:
1. complyctl help
2. complyctl list
3. complyctl info
4. complyctl plan
5. complyctl generate
6. complyctl scan
7. The workflow of loading the updated config to customize the assessment plan

## Related Issues
[CPLYTM-942](https://issues.redhat.com/browse/CPLYTM-941)
[CPLYTM-942](https://issues.redhat.com/browse/CPLYTM-942)

- _Closes #[CPLYTM-943](https://issues.redhat.com/browse/CPLYTM-943)_

## Review Hints
Successful action run here
https://github.com/complytime/complyctl/actions/runs/17227035479/job/48873647437?pr=248

