### PR TITLE
feat: CPLYTM-983 add support for waived rules

### DIFF
--- a/internal/complytime/scope_test.go
+++ b/internal/complytime/scope_test.go
@@ -1433,6 +1433,431 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Success/WaiveRulesForControl",
+			basePlan: &oscalTypes.AssessmentPlan{
+				LocalDefinitions: &oscalTypes.LocalDefinitions{
+					Activities: &[]oscalTypes.Activity{
+						{
+							Title: "rule-1",
+							RelatedControls: &oscalTypes.ReviewedControls{
+								ControlSelections: []oscalTypes.AssessedControls{
+									{
+										IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+											{
+												ControlId: "control-1",
+											},
+											{
+												ControlId: "control-2",
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Title: "rule-2",
+							RelatedControls: &oscalTypes.ReviewedControls{
+								ControlSelections: []oscalTypes.AssessedControls{
+									{
+										IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+											{
+												ControlId: "control-1",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			scope: AssessmentScope{
+				FrameworkID: "test",
+				IncludeControls: []ControlEntry{
+					{ControlID: "control-1", IncludeRules: []string{"*"}, WaiveRules: []string{"rule-1"}},
+					{ControlID: "control-2", IncludeRules: []string{"*"}},
+				},
+			},
+			wantActivities: &[]oscalTypes.Activity{
+				{
+					Title: "rule-1",
+					Props: &[]oscalTypes.Property{
+						{
+							Name:  "waived",
+							Value: "true",
+							Ns:    extensions.TrestleNameSpace,
+						},
+					},
+					RelatedControls: &oscalTypes.ReviewedControls{
+						ControlSelections: []oscalTypes.AssessedControls{
+							{
+								IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+									{
+										ControlId: "control-1",
+									},
+									{
+										ControlId: "control-2",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Title: "rule-2",
+					RelatedControls: &oscalTypes.ReviewedControls{
+						ControlSelections: []oscalTypes.AssessedControls{
+							{
+								IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+									{
+										ControlId: "control-1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Success/WaiveRulesForControlWithGlobalExclude",
+			basePlan: &oscalTypes.AssessmentPlan{
+				LocalDefinitions: &oscalTypes.LocalDefinitions{
+					Activities: &[]oscalTypes.Activity{
+						{
+							Title: "rule-1",
+							RelatedControls: &oscalTypes.ReviewedControls{
+								ControlSelections: []oscalTypes.AssessedControls{
+									{
+										IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+											{
+												ControlId: "control-1",
+											},
+											{
+												ControlId: "control-2",
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Title: "rule-2",
+							RelatedControls: &oscalTypes.ReviewedControls{
+								ControlSelections: []oscalTypes.AssessedControls{
+									{
+										IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+											{
+												ControlId: "control-1",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			scope: AssessmentScope{
+				FrameworkID:        "test",
+				GlobalExcludeRules: []string{"rule-1"},
+				IncludeControls: []ControlEntry{
+					{ControlID: "control-1", IncludeRules: []string{"*"}, WaiveRules: []string{"rule-2"}},
+					{ControlID: "control-2", IncludeRules: []string{"*"}},
+				},
+			},
+			wantActivities: &[]oscalTypes.Activity{
+				{
+					Title: "rule-1",
+					Props: &[]oscalTypes.Property{
+						{
+							Name:  "skipped",
+							Value: "true",
+							Ns:    extensions.TrestleNameSpace,
+						},
+					},
+					RelatedControls: nil,
+				},
+				{
+					Title: "rule-2",
+					Props: &[]oscalTypes.Property{
+						{
+							Name:  "waived",
+							Value: "true",
+							Ns:    extensions.TrestleNameSpace,
+						},
+					},
+					RelatedControls: &oscalTypes.ReviewedControls{
+						ControlSelections: []oscalTypes.AssessedControls{
+							{
+								IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+									{
+										ControlId: "control-1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Success/GlobalWaiveSpecificRules",
+			basePlan: &oscalTypes.AssessmentPlan{
+				LocalDefinitions: &oscalTypes.LocalDefinitions{
+					Activities: &[]oscalTypes.Activity{
+						{
+							Title: "rule-1",
+							RelatedControls: &oscalTypes.ReviewedControls{
+								ControlSelections: []oscalTypes.AssessedControls{
+									{
+										IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+											{
+												ControlId: "control-1",
+											},
+											{
+												ControlId: "control-2",
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Title: "rule-2",
+							RelatedControls: &oscalTypes.ReviewedControls{
+								ControlSelections: []oscalTypes.AssessedControls{
+									{
+										IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+											{
+												ControlId: "control-1",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			scope: AssessmentScope{
+				FrameworkID:      "test",
+				GlobalWaiveRules: []string{"rule-1"},
+				IncludeControls: []ControlEntry{
+					{ControlID: "control-1", IncludeRules: []string{"*"}},
+					{ControlID: "control-2", IncludeRules: []string{"*"}},
+				},
+			},
+			wantActivities: &[]oscalTypes.Activity{
+				{
+					Title: "rule-1",
+					Props: &[]oscalTypes.Property{
+						{
+							Name:  "waived",
+							Value: "true",
+							Ns:    extensions.TrestleNameSpace,
+						},
+					},
+					RelatedControls: &oscalTypes.ReviewedControls{
+						ControlSelections: []oscalTypes.AssessedControls{
+							{
+								IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+									{
+										ControlId: "control-1",
+									},
+									{
+										ControlId: "control-2",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Title: "rule-2",
+					RelatedControls: &oscalTypes.ReviewedControls{
+						ControlSelections: []oscalTypes.AssessedControls{
+							{
+								IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+									{
+										ControlId: "control-1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Success/GlobalWaiveAllRules",
+			basePlan: &oscalTypes.AssessmentPlan{
+				LocalDefinitions: &oscalTypes.LocalDefinitions{
+					Activities: &[]oscalTypes.Activity{
+						{
+							Title: "rule-1",
+							RelatedControls: &oscalTypes.ReviewedControls{
+								ControlSelections: []oscalTypes.AssessedControls{
+									{
+										IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+											{
+												ControlId: "control-1",
+											},
+											{
+												ControlId: "control-2",
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Title: "rule-2",
+							RelatedControls: &oscalTypes.ReviewedControls{
+								ControlSelections: []oscalTypes.AssessedControls{
+									{
+										IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+											{
+												ControlId: "control-1",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			scope: AssessmentScope{
+				FrameworkID:      "test",
+				GlobalWaiveRules: []string{"*"},
+				IncludeControls: []ControlEntry{
+					{ControlID: "control-1", IncludeRules: []string{"*"}},
+					{ControlID: "control-2", IncludeRules: []string{"*"}},
+				},
+			},
+			wantActivities: &[]oscalTypes.Activity{
+				{
+					Title: "rule-1",
+					Props: &[]oscalTypes.Property{
+						{
+							Name:  "waived",
+							Value: "true",
+							Ns:    extensions.TrestleNameSpace,
+						},
+					},
+					RelatedControls: &oscalTypes.ReviewedControls{
+						ControlSelections: []oscalTypes.AssessedControls{
+							{
+								IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+									{
+										ControlId: "control-1",
+									},
+									{
+										ControlId: "control-2",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Title: "rule-2",
+					Props: &[]oscalTypes.Property{
+						{
+							Name:  "waived",
+							Value: "true",
+							Ns:    extensions.TrestleNameSpace,
+						},
+					},
+					RelatedControls: &oscalTypes.ReviewedControls{
+						ControlSelections: []oscalTypes.AssessedControls{
+							{
+								IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+									{
+										ControlId: "control-1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Success/GlobalExcludeOverridesWaive",
+			basePlan: &oscalTypes.AssessmentPlan{
+				LocalDefinitions: &oscalTypes.LocalDefinitions{
+					Activities: &[]oscalTypes.Activity{
+						{
+							Title: "rule-1",
+							RelatedControls: &oscalTypes.ReviewedControls{
+								ControlSelections: []oscalTypes.AssessedControls{
+									{
+										IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+											{
+												ControlId: "control-1",
+											},
+											{
+												ControlId: "control-2",
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Title: "rule-2",
+							RelatedControls: &oscalTypes.ReviewedControls{
+								ControlSelections: []oscalTypes.AssessedControls{
+									{
+										IncludeControls: &[]oscalTypes.AssessedControlsSelectControlById{
+											{
+												ControlId: "control-1",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			scope: AssessmentScope{
+				FrameworkID:        "test",
+				GlobalExcludeRules: []string{"*"},
+				GlobalWaiveRules:   []string{"rule-1"},
+				IncludeControls: []ControlEntry{
+					{ControlID: "control-1", IncludeRules: []string{"*"}},
+					{ControlID: "control-2", IncludeRules: []string{"*"}},
+				},
+			},
+			wantActivities: &[]oscalTypes.Activity{
+				{
+					Title: "rule-1",
+					Props: &[]oscalTypes.Property{
+						{
+							Name:  "skipped",
+							Value: "true",
+							Ns:    extensions.TrestleNameSpace,
+						},
+					},
+					RelatedControls: nil,
+				},
+				{
+					Title: "rule-2",
+					Props: &[]oscalTypes.Property{
+						{
+							Name:  "skipped",
+							Value: "true",
+							Ns:    extensions.TrestleNameSpace,
+						},
+					},
+					RelatedControls: nil,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
Provide user the ability to set waived rules, so that when they failed, they could be showed as waived instead of failed in the report. 

## Related Issues

- _Closes CPLYTM-983_
- https://github.com/oscal-compass/compliance-to-policy-go/issues/230

## Review Hints
Two yaml keys could be used in the scope configuration file, 'globalWaiveRules' for global waive rules and 'waiveRules' for control specific waive rules. The priority is global > control specific, exclude > waive > include.
