### PR TITLE
chore: [CPLYTM-566] Create badge that shows pass/fail status on update-sonarcloud-github-status

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -46,3 +46,9 @@ jobs:
         with:
           args: >
             -Dsonar.go.coverage.reportPaths=coverage.out -Dsonar.projectKey=rh-psce_complyctl -Dsonar.organization=rh-psce
+      - name: SonarQube Quality Gate check
+        uses: sonarsource/sonarqube-quality-gate-action@df914238f99aa5d81f4490aeea80f205c7ed9600 # pin@f9fe214a5be5769c40619de2fff2726c36d2d5eb
+        # Force to fail step after specific time
+        timeout-minutes: 5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -47,7 +47,7 @@ jobs:
           args: >
             -Dsonar.go.coverage.reportPaths=coverage.out -Dsonar.projectKey=rh-psce_complyctl -Dsonar.organization=rh-psce
       - name: SonarQube Quality Gate check
-        uses: sonarsource/sonarqube-quality-gate-action@df914238f99aa5d81f4490aeea80f205c7ed9600 # pin@f9fe214a5be5769c40619de2fff2726c36d2d5eb
+        uses: sonarsource/sonarqube-quality-gate-action@cf038b0e0cdecfa9e56c198bbb7d21d751d62c3b #v1.2.0
         # Force to fail step after specific time
         timeout-minutes: 5
         env:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![OpenSSF Best Practices status](https://www.bestpractices.dev/projects/9761/badge)](https://www.bestpractices.dev/projects/9761)
 [![GoDoc](https://img.shields.io/static/v1?label=godoc&message=reference&color=blue)](https://pkg.go.dev/github.com/complytime/complyctl)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/complytime/complyctl/badge)](https://scorecard.dev/viewer/?uri=github.com/complyctl/complyctl)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=rh-psce_complyctl&metric=coverage)](https://sonarcloud.io/summary/new_code?id=rh-psce_complyctl)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=rh-psce_complyctl&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=rh-psce_complyctl)
 
 ComplyCTL leverages [OSCAL](https://github.com/usnistgov/OSCAL/) to perform compliance assessment activities, using plugins for each stage of the lifecycle.
 


### PR DESCRIPTION
## Summary
Added the SonarCloud badges and Quality Gate workflow to the complyctl repo. This change is replicated from complyscribe README.md and codecov.yml.

## Related Issues
- Closes CPLYTM-566