### PR TITLE
chore: bump oscal-sdk-go version to 0.0.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.7.0
 	github.com/oscal-compass/compliance-to-policy-go/v2 v2.0.0-alpha.3
-	github.com/oscal-compass/oscal-sdk-go v0.0.6
+	github.com/oscal-compass/oscal-sdk-go v0.0.7
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -244,8 +244,8 @@ github.com/openshift/machine-config-operator v0.0.1-0.20250401081735-9026ff2d802
 github.com/openshift/machine-config-operator v0.0.1-0.20250401081735-9026ff2d802e/go.mod h1:wmBAHvqHXXSFa0yz3scg0RZLxcs5B51ZTeaVlCSPaDk=
 github.com/oscal-compass/compliance-to-policy-go/v2 v2.0.0-alpha.3 h1:cwuJ9w7l2YOE92YzpRi32ebMK0rqojgaFwLzDVaDC7A=
 github.com/oscal-compass/compliance-to-policy-go/v2 v2.0.0-alpha.3/go.mod h1:XWJflt7dFbJRW6oCWA7GAm/VqmdCR2hEablZNjXSuI4=
-github.com/oscal-compass/oscal-sdk-go v0.0.6 h1:vhs23WgVtdvZoWgw8Yl4IVa5MfnIlrvmxXYmll0pcO4=
-github.com/oscal-compass/oscal-sdk-go v0.0.6/go.mod h1:+8uyfcY5YkpB2CUXEeVZnWmSwi8Po5MV5yflLPDjRKE=
+github.com/oscal-compass/oscal-sdk-go v0.0.7 h1:O6xdLRM5qv+NlGaypWjLOELZsbEk0YSWBIKLttWPgvE=
+github.com/oscal-compass/oscal-sdk-go v0.0.7/go.mod h1:+8uyfcY5YkpB2CUXEeVZnWmSwi8Po5MV5yflLPDjRKE=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=
 github.com/pjbgf/sha1cd v0.3.2/go.mod h1:zQWigSxVmsHEZow5qaLtPYxpcKMMQpa09ixqBxuCS6A=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/internal/complytime/scope.go
+++ b/internal/complytime/scope.go
@@ -280,7 +280,7 @@ func (a AssessmentScope) applyControlScope(assessmentPlan *oscalTypes.Assessment
 						filterControlSelection(controlSelection, includedControls)
 						if controlSelection.IncludeControls == nil {
 							activity.RelatedControls = nil
-							a.addActivityProperty(activity, "skipped", "true")
+							a.addActivityProperty(activity, extensions.SkippedRulesProperty, "true")
 						}
 					}
 				}
@@ -360,12 +360,12 @@ func (a AssessmentScope) applyRuleScope(assessmentPlan *oscalTypes.AssessmentPla
 						a.filterControlSelectionByRule(controlSelection, activity.Title, controlRuleConfig, globalExcludeRules, logger, activity.Title)
 						if controlSelection.IncludeControls == nil {
 							activity.RelatedControls = nil
-							a.addActivityProperty(activity, "skipped", "true")
+							a.addActivityProperty(activity, extensions.SkippedRulesProperty, "true")
 						} else {
 							// If the rule is waived in one control, add a waivedActivity prop to activity
 							shouldWaive := a.checkWaive(controlSelection, activity.Title, controlRuleConfig, globalWaiveRules)
 							if shouldWaive {
-								a.addActivityProperty(activity, "waived", "true")
+								a.addActivityProperty(activity, extensions.WaivedRulesProperty, "true")
 							}
 						}
 					}
@@ -387,11 +387,11 @@ func (a AssessmentScope) applyRuleScope(assessmentPlan *oscalTypes.AssessmentPla
 							if controlSelection.IncludeControls == nil {
 								activity.RelatedControls.ControlSelections = nil
 								step.ReviewedControls = nil
-								a.addStepProperty(step, "skipped", "true")
+								a.addStepProperty(step, extensions.SkippedRulesProperty, "true")
 							} else {
 								shouldWaive := a.checkWaive(controlSelection, activity.Title, controlRuleConfig, globalWaiveRules)
 								if shouldWaive {
-									a.addStepProperty(step, "waived", "true")
+									a.addStepProperty(step, extensions.WaivedRulesProperty, "true")
 								}
 							}
 						}

--- a/internal/complytime/scope_test.go
+++ b/internal/complytime/scope_test.go
@@ -1202,7 +1202,7 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 					Title: "rule-1",
 					Props: &[]oscalTypes.Property{
 						{
-							Name:  "skipped",
+							Name:  extensions.SkippedRulesProperty,
 							Value: "true",
 							Ns:    extensions.TrestleNameSpace,
 						},
@@ -1272,7 +1272,7 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 					Title: "rule-1",
 					Props: &[]oscalTypes.Property{
 						{
-							Name:  "skipped",
+							Name:  extensions.SkippedRulesProperty,
 							Value: "true",
 							Ns:    extensions.TrestleNameSpace,
 						},
@@ -1342,7 +1342,7 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 					Title: "rule-1",
 					Props: &[]oscalTypes.Property{
 						{
-							Name:  "skipped",
+							Name:  extensions.SkippedRulesProperty,
 							Value: "true",
 							Ns:    extensions.TrestleNameSpace,
 						},
@@ -1353,7 +1353,7 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 					Title: "rule-2",
 					Props: &[]oscalTypes.Property{
 						{
-							Name:  "skipped",
+							Name:  extensions.SkippedRulesProperty,
 							Value: "true",
 							Ns:    extensions.TrestleNameSpace,
 						},
@@ -1410,7 +1410,7 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 					Title: "rule-1",
 					Props: &[]oscalTypes.Property{
 						{
-							Name:  "skipped",
+							Name:  extensions.SkippedRulesProperty,
 							Value: "true",
 							Ns:    extensions.TrestleNameSpace,
 						},
@@ -1484,7 +1484,7 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 					Title: "rule-1",
 					Props: &[]oscalTypes.Property{
 						{
-							Name:  "waived",
+							Name:  extensions.WaivedRulesProperty,
 							Value: "true",
 							Ns:    extensions.TrestleNameSpace,
 						},
@@ -1572,7 +1572,7 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 					Title: "rule-1",
 					Props: &[]oscalTypes.Property{
 						{
-							Name:  "skipped",
+							Name:  extensions.SkippedRulesProperty,
 							Value: "true",
 							Ns:    extensions.TrestleNameSpace,
 						},
@@ -1583,7 +1583,7 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 					Title: "rule-2",
 					Props: &[]oscalTypes.Property{
 						{
-							Name:  "waived",
+							Name:  extensions.WaivedRulesProperty,
 							Value: "true",
 							Ns:    extensions.TrestleNameSpace,
 						},
@@ -1654,7 +1654,7 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 					Title: "rule-1",
 					Props: &[]oscalTypes.Property{
 						{
-							Name:  "waived",
+							Name:  extensions.WaivedRulesProperty,
 							Value: "true",
 							Ns:    extensions.TrestleNameSpace,
 						},
@@ -1742,7 +1742,7 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 					Title: "rule-1",
 					Props: &[]oscalTypes.Property{
 						{
-							Name:  "waived",
+							Name:  extensions.WaivedRulesProperty,
 							Value: "true",
 							Ns:    extensions.TrestleNameSpace,
 						},
@@ -1766,7 +1766,7 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 					Title: "rule-2",
 					Props: &[]oscalTypes.Property{
 						{
-							Name:  "waived",
+							Name:  extensions.WaivedRulesProperty,
 							Value: "true",
 							Ns:    extensions.TrestleNameSpace,
 						},
@@ -1838,7 +1838,7 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 					Title: "rule-1",
 					Props: &[]oscalTypes.Property{
 						{
-							Name:  "skipped",
+							Name:  extensions.SkippedRulesProperty,
 							Value: "true",
 							Ns:    extensions.TrestleNameSpace,
 						},
@@ -1849,7 +1849,7 @@ func TestAssessmentScope_ApplyRuleScope(t *testing.T) {
 					Title: "rule-2",
 					Props: &[]oscalTypes.Property{
 						{
-							Name:  "skipped",
+							Name:  extensions.SkippedRulesProperty,
 							Value: "true",
 							Ns:    extensions.TrestleNameSpace,
 						},

--- a/vendor/github.com/oscal-compass/oscal-sdk-go/extensions/props.go
+++ b/vendor/github.com/oscal-compass/oscal-sdk-go/extensions/props.go
@@ -41,6 +41,8 @@ const (
 	// AssessmentCheckIdProp represents the property name for a check associated to an OSCAL
 	// Observation.
 	AssessmentCheckIdProp = "assessment-check-id"
+	// SkippedRulesProperty represents the property name for Skipped Rules.
+	SkippedRulesProperty = "skipped"
 	// WaivedRulesProperty represents the property name for Waived Rules.
 	WaivedRulesProperty = "waived"
 )

--- a/vendor/github.com/oscal-compass/oscal-sdk-go/settings/factory.go
+++ b/vendor/github.com/oscal-compass/oscal-sdk-go/settings/factory.go
@@ -55,6 +55,11 @@ func NewAssessmentActivitiesSettings(assessmentActivities []oscalTypes.Activity)
 		if activity.Props == nil {
 			continue
 		}
+		// Skipped activity has a property named 'skipped'
+		skipped, found := extensions.GetTrestleProp(extensions.SkippedRulesProperty, *activity.Props)
+		if found && skipped.Value == "true" {
+			continue
+		}
 
 		paramProps := extensions.FindAllProps(*activity.Props, extensions.WithClass(extensions.TestParameterClass))
 		for _, param := range paramProps {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -358,7 +358,7 @@ github.com/oscal-compass/compliance-to-policy-go/v2/internal/utils
 github.com/oscal-compass/compliance-to-policy-go/v2/logging
 github.com/oscal-compass/compliance-to-policy-go/v2/plugin
 github.com/oscal-compass/compliance-to-policy-go/v2/policy
-# github.com/oscal-compass/oscal-sdk-go v0.0.6
+# github.com/oscal-compass/oscal-sdk-go v0.0.7
 ## explicit; go 1.24
 github.com/oscal-compass/oscal-sdk-go/extensions
 github.com/oscal-compass/oscal-sdk-go/internal/plans


### PR DESCRIPTION
## Summary
This PR bumps the oscal-sdk-go version to v0.0.7 to support excluding skipped rules in plugin policy generation.

## Related Issues
- _Closes CPLYTM-961_