### PR TITLE
chore: [CPLYTM-1018] remove placeholders

### DIFF
--- a/internal/complytime/configuration.go
+++ b/internal/complytime/configuration.go
@@ -27,6 +27,7 @@ const (
 	DataRootDir            = "/usr/share"
 	PluginBinaryRootDir    = "/usr/libexec/"
 	DefaultPluginConfigDir = "/etc/complytime/config.d/"
+	Placeholder            = "REPLACE_ME"
 )
 
 // ErrNoComponentDefinitionsFound returns an error indicated the supplied directory
@@ -196,4 +197,51 @@ func ActionsContextFromPlan(assessmentPlan *oscalTypes.AssessmentPlan) (*actions
 	}
 	inputContext.Settings = apSettings
 	return inputContext, nil
+}
+
+// Config default value if it is a placeholder
+func replaceString(current_value string, default_value string) string {
+	if current_value == Placeholder {
+		return default_value
+	}
+	return current_value
+}
+
+// Replace the placeholders for assessment plan
+func replacePlaceholdersInPlan(plan *oscalTypes.AssessmentPlan, frameworkId string) {
+	if plan == nil {
+		return
+	}
+
+	// 1. Handle assessment-plan.metadata.title assessment-plan.assessment-assets.assessment-platforms.title
+	plan.Metadata.Title = replaceString(
+		plan.Metadata.Title,
+		fmt.Sprintf("Assessment plan for '%s'", frameworkId),
+	)
+	// 2. Handle assessment-plan.assessment-assets.import-ssp.href
+	plan.ImportSsp.Href = replaceString(
+		plan.ImportSsp.Href,
+		"ImportSsp Href has not been set.",
+	)
+
+	// 3. Handle assessment-plan.assessment-assets.assessment-platforms.title
+	if plan.AssessmentAssets != nil && plan.AssessmentAssets.AssessmentPlatforms != nil {
+		for i := range plan.AssessmentAssets.AssessmentPlatforms {
+			platforms := plan.AssessmentAssets.AssessmentPlatforms
+			platforms[i].Title = replaceString(
+				platforms[i].Title,
+				"The AssessmentPlatforms title has not been set.",
+			)
+		}
+	}
+	// 4. Handle assessment-plan.assessment-assets.back-matter.resources.description
+	if plan.BackMatter != nil && plan.BackMatter.Resources != nil {
+		resources := *plan.BackMatter.Resources
+		for i := range resources {
+			resources[i].Description = replaceString(
+				resources[i].Description,
+				"The description of BackMatter Resource has not been set.",
+			)
+		}
+	}
 }

--- a/internal/complytime/plan.go
+++ b/internal/complytime/plan.go
@@ -35,6 +35,9 @@ func WritePlan(plan *oscalTypes.AssessmentPlan, frameworkId string, planLocation
 	}
 	*plan.Metadata.Props = append(*plan.Metadata.Props, frameworkProperty)
 
+	// Handle the placeholders before writing plan
+	replacePlaceholdersInPlan(plan, frameworkId)
+
 	// To ensure we can easily read the plan once written, include under
 	// OSCAL Model type to include the top-level "assessment-plan" key.
 	oscalModels := oscalTypes.OscalModels{

--- a/internal/complytime/scan.go
+++ b/internal/complytime/scan.go
@@ -16,6 +16,8 @@ func WriteAssessmentResults(assessmentResults *oscalTypes.AssessmentResults, ass
 		AssessmentResults: assessmentResults,
 	}
 
+	assessmentResults.Metadata.Title = replaceString(assessmentResults.Metadata.Title, "Assessment result")
+
 	assessmentResultsJson, err := json.MarshalIndent(oscalModels, "", " ")
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
The placeholders, "`REPLACE_ME`", in `assessment-plan` and `assessment-result` will be replaced with a meaningful string.
## Related Issues
[CPLYTM-1019](https://issues.redhat.com/browse/CPLYTM-1019)

- _Closes #[CPLYTM-1018](https://issues.redhat.com/browse/CPLYTM-1018)_

## Review Hints
- In the assessment-plan.json, there are 4 placeholders:
```
 assessment-plan.assessment-assets.assessment-platforms.title
 assessment-plan.assessment-assets.import-ssp.href
 assessment-plan.assessment-assets.back-matter.resources.description
 assessment-plan.metadata.title
```
- In the assessment-result.json, there is one placeholder:
`assessment-results.metadata.title.`
- The assessment-plan.json and assessment-result.json has no `REPLACE_ME` after the PR.
