### PR TITLE
chore: [CPLYTM-1013] Ensure user workspace exists

### DIFF
--- a/cmd/complyctl/cli/generate.go
+++ b/cmd/complyctl/cli/generate.go
@@ -33,6 +33,10 @@ func generateCmd(common *option.Common) *cobra.Command {
 		Short:   "Generate PVP policy from an assessment plan",
 		Example: "complyctl generate",
 		Args:    cobra.NoArgs,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			// Ensure user workspace exists before proceeding
+			return complytime.EnsureUserWorkspace(generateOpts.complyTimeOpts.UserWorkspace)
+		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runGenerate(cmd, generateOpts)
 		},

--- a/cmd/complyctl/cli/plan.go
+++ b/cmd/complyctl/cli/plan.go
@@ -61,8 +61,10 @@ func planCmd(common *option.Common) *cobra.Command {
 		Short:   "Generate a new assessment plan for a given compliance framework id.",
 		Example: planExample,
 		Args:    cobra.ExactArgs(1),
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRunE: func(cmd *cobra.Command, args []string) error {
 			completePlan(planOpts, args)
+			// Ensure user workspace exists before proceeding
+			return complytime.EnsureUserWorkspace(planOpts.complyTimeOpts.UserWorkspace)
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := validatePlan(planOpts); err != nil {

--- a/cmd/complyctl/cli/scan.go
+++ b/cmd/complyctl/cli/scan.go
@@ -41,6 +41,10 @@ func scanCmd(common *option.Common) *cobra.Command {
 		Example:      "complyctl scan",
 		SilenceUsage: true,
 		Args:         cobra.NoArgs,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			// Ensure user workspace exists before proceeding
+			return complytime.EnsureUserWorkspace(scanOpts.complyTimeOpts.UserWorkspace)
+		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runScan(cmd, scanOpts)
 		},

--- a/internal/complytime/configuration.go
+++ b/internal/complytime/configuration.go
@@ -139,6 +139,16 @@ func (a ApplicationDirectory) Dirs() []string {
 	}
 }
 
+// EnsureUserWorkspace creates the user workspace directory if it doesn't exist.
+// This function should be called early in command execution to ensure the workspace
+// is available before any operations that depend on it.
+func EnsureUserWorkspace(userWorkspace string) error {
+	if err := os.MkdirAll(userWorkspace, 0700); err != nil {
+		return fmt.Errorf("failed to create user workspace directory %s: %w", userWorkspace, err)
+	}
+	return nil
+}
+
 // FindComponentDefinitions locates all the OSCAL Component Definitions in the
 // given `bundles` directory that meet the defined naming scheme.
 //

--- a/internal/complytime/configuration_test.go
+++ b/internal/complytime/configuration_test.go
@@ -50,3 +50,17 @@ func TestFindComponentDefinitions(t *testing.T) {
 	require.ErrorIs(t, err, ErrNoComponentDefinitionsFound)
 
 }
+
+func TestEnsureUserWorkspace(t *testing.T) {
+	tmpDir := t.TempDir()
+	testPlanPath := filepath.Join(tmpDir, "test_workspace")
+	defer os.RemoveAll(tmpDir) // Clean up after test
+
+	err := EnsureUserWorkspace(testPlanPath)
+	require.NoError(t, err)
+
+	info, err := os.Stat(testPlanPath)
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	require.True(t, info.IsDir(), "Expected a directory, got something else")
+}

--- a/internal/complytime/plan.go
+++ b/internal/complytime/plan.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	oscalTypes "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-3"
 	"github.com/oscal-compass/oscal-sdk-go/extensions"
@@ -18,12 +17,6 @@ import (
 
 // WritePlan writes an AssessmentPlan to a given path location with consistency.
 func WritePlan(plan *oscalTypes.AssessmentPlan, frameworkId string, planLocation string) error {
-	// Ensure UserWorkspace exists before writing the plan
-	userWorkspace := filepath.Dir(planLocation)
-	if err := os.MkdirAll(userWorkspace, 0700); err != nil {
-		return err
-	}
-
 	// Add the framework property needed for ComplyTime
 	if plan.Metadata.Props == nil {
 		plan.Metadata.Props = &[]oscalTypes.Property{}
@@ -34,10 +27,8 @@ func WritePlan(plan *oscalTypes.AssessmentPlan, frameworkId string, planLocation
 		Ns:    extensions.TrestleNameSpace,
 	}
 	*plan.Metadata.Props = append(*plan.Metadata.Props, frameworkProperty)
-
 	// Handle the placeholders before writing plan
 	replacePlaceholdersInPlan(plan, frameworkId)
-
 	// To ensure we can easily read the plan once written, include under
 	// OSCAL Model type to include the top-level "assessment-plan" key.
 	oscalModels := oscalTypes.OscalModels{


### PR DESCRIPTION
## Summary
- Ensure user workspace exists before generate and scan
- Add PreRunE to verify user workspace via complytime.EnsureUserWorkspace
- Fails early with a clear error if missing
- Check for valid permissions

## Related Issues
- Refs CPLYTM-1013

## Changes
```go
// filepath:cli/generate.go
PreRunE: func(cmd *cobra.Command, args []string) error {
    // Ensure user workspace exists before proceeding
    if err := complytime.EnsureUserWorkspace(generateOpts.complyTimeOpts.UserWorkspace); err != nil {
        return err
    }
    return nil
}
// filepath:cli/scan.go
PreRunE: func(cmd *cobra.Command, args []string) error {
    // Ensure user workspace exists before proceeding
    if err := complytime.EnsureUserWorkspace(scanOpts.complyTimeOpts.UserWorkspace); err != nil {
        return err
    }
    return nil
},

// filepath:internal/plan.go
func EnsureUserWorkspace(userWorkspace string) error {
    if err := os.MkdirAll(userWorkspace, 0700); err != nil {
        return fmt.Errorf("failed to create user workspace directory %s: %w", userWorkspace, err)
    }
    return nil
}
// filepath:internal/plan_test.go
func TestEnsureUserWorkspace(t *testing.T) {
    tmpDir := filepath.Join(os.TempDir(), "test_workspace")
    defer os.RemoveAll(tmpDir) // Clean up after test

    err := EnsureUserWorkspace(tmpDir)
    if err != nil {
        t.Fatalf("Expected no error, got %v", err)
    }

    // Check if directory was created
    info, err := os.Stat(tmpDir)
    if err != nil {
        t.Fatalf("Expected directory to exist, got error: %v", err)
    }
    if !info.IsDir() {
        t.Fatalf("Expected a directory, got something else")
    }
}
```