### PR TITLE
docs: Update broken component definition URL in QUICK_START

### DIFF
--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -1,6 +1,6 @@
 # Quick Start
 
-To get started with the `complyctl` CLI, at least one plugin must be installed with a corresponding OSCAL [Component Definition](https://pages.nist.gov/OSCAL/resources/concepts/layer/implementation/component-definition/).
+To get started with the `complyctl` CLI, at least one plugin must be installed with a corresponding OSCAL [Component Definition](https://pages.nist.gov/OSCAL/learn/concepts/layer/implementation/component-definition/).
 
 > Note: Some of these steps are manual. The [quick_start.sh](../scripts/quick_start/quick_start.sh) automates the process below.
 


### PR DESCRIPTION
## Summary

The link to the sample component definition in the quick start guide was resulting in a 404 error. This has been updated to the correct URL.
