### PR TITLE
chore: CPLYTM-577 add message for creating application directory

### DIFF
--- a/cmd/complyctl/cli/generate.go
+++ b/cmd/complyctl/cli/generate.go
@@ -37,7 +37,7 @@ func generateCmd(common *option.Common) *cobra.Command {
 			return runGenerate(cmd, generateOpts)
 		},
 	}
-	cmd.Flags().StringVarP(&generateOpts.withPluginConfig, "plugin-config", "c", "", "Directory where user customized plugin manifests located")
+	cmd.Flags().StringVarP(&generateOpts.withPluginConfig, "plugin-config", "c", "", "Directory where user customized plugin manifests are located")
 	generateOpts.complyTimeOpts.BindFlags(cmd.Flags())
 	return cmd
 }

--- a/cmd/complyctl/cli/generate.go
+++ b/cmd/complyctl/cli/generate.go
@@ -37,7 +37,7 @@ func generateCmd(common *option.Common) *cobra.Command {
 			return runGenerate(cmd, generateOpts)
 		},
 	}
-	cmd.Flags().StringVarP(&generateOpts.withPluginConfig, "plugin-config", "c", "", "Directory where user customized plugin manifests located.")
+	cmd.Flags().StringVarP(&generateOpts.withPluginConfig, "plugin-config", "c", "", "Directory where user customized plugin manifests located")
 	generateOpts.complyTimeOpts.BindFlags(cmd.Flags())
 	return cmd
 }
@@ -55,7 +55,7 @@ func runGenerate(cmd *cobra.Command, opts *generateOptions) error {
 	}
 
 	// Create the application directory if it does not exist
-	appDir, err := complytime.NewApplicationDirectory(true)
+	appDir, err := complytime.NewApplicationDirectory(true, logger)
 	if err != nil {
 		return err
 	}

--- a/cmd/complyctl/cli/info.go
+++ b/cmd/complyctl/cli/info.go
@@ -140,7 +140,7 @@ func infoCmd(common *option.Common) *cobra.Command {
 // runInfo executes the info command using the provided options.
 func runInfo(opts *infoOptions) error {
 
-	appDir, err := complytime.NewApplicationDirectory(true)
+	appDir, err := complytime.NewApplicationDirectory(true, logger)
 	if err != nil {
 		return fmt.Errorf("failed to initialize application directory: %w", err)
 	}

--- a/cmd/complyctl/cli/list.go
+++ b/cmd/complyctl/cli/list.go
@@ -44,7 +44,7 @@ func listCmd(common *option.Common) *cobra.Command {
 }
 
 func runList(opts *listOptions) error {
-	appDir, err := complytime.NewApplicationDirectory(true)
+	appDir, err := complytime.NewApplicationDirectory(true, logger)
 	if err != nil {
 		return err
 	}

--- a/cmd/complyctl/cli/plan.go
+++ b/cmd/complyctl/cli/plan.go
@@ -158,7 +158,6 @@ func loadPlan(opts *option.ComplyTime, validator validation.Validator) (*oscalTy
 
 // planDryRun leverages the AssessmentScope structure to populate tailoring config.
 // The config is written to stdout.
-// func planDryRun(frameworkId string, cds []oscalTypes.ComponentDefinition, output string, logger) error {
 func planDryRun(frameworkId string, cds []oscalTypes.ComponentDefinition, output string, logger hclog.Logger) error {
 	// Create application directory and validator to get control titles
 	appDir, err := complytime.NewApplicationDirectory(true, logger)

--- a/cmd/complyctl/cli/plan.go
+++ b/cmd/complyctl/cli/plan.go
@@ -10,6 +10,7 @@ import (
 
 	oscalTypes "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-3"
 	"github.com/goccy/go-yaml"
+	"github.com/hashicorp/go-hclog"
 	"github.com/oscal-compass/oscal-sdk-go/transformers"
 	"github.com/oscal-compass/oscal-sdk-go/validation"
 	"github.com/spf13/cobra"
@@ -92,7 +93,7 @@ func validatePlan(opts *planOptions) error {
 
 func runPlan(cmd *cobra.Command, opts *planOptions) error {
 	// Create the application directory if it does not exist
-	appDir, err := complytime.NewApplicationDirectory(true)
+	appDir, err := complytime.NewApplicationDirectory(true, logger)
 	if err != nil {
 		return err
 	}
@@ -106,7 +107,7 @@ func runPlan(cmd *cobra.Command, opts *planOptions) error {
 
 	if opts.dryRun {
 		// Write the plan configuration to stdout
-		return planDryRun(opts.complyTimeOpts.FrameworkID, componentDefs, opts.output)
+		return planDryRun(opts.complyTimeOpts.FrameworkID, componentDefs, opts.output, logger)
 	}
 
 	logger.Debug(fmt.Sprintf("Using bundle directory: %s for component definitions.", appDir.BundleDir()))
@@ -157,9 +158,10 @@ func loadPlan(opts *option.ComplyTime, validator validation.Validator) (*oscalTy
 
 // planDryRun leverages the AssessmentScope structure to populate tailoring config.
 // The config is written to stdout.
-func planDryRun(frameworkId string, cds []oscalTypes.ComponentDefinition, output string) error {
+// func planDryRun(frameworkId string, cds []oscalTypes.ComponentDefinition, output string, logger) error {
+func planDryRun(frameworkId string, cds []oscalTypes.ComponentDefinition, output string, logger hclog.Logger) error {
 	// Create application directory and validator to get control titles
-	appDir, err := complytime.NewApplicationDirectory(true)
+	appDir, err := complytime.NewApplicationDirectory(true, logger)
 	if err != nil {
 		return fmt.Errorf("failed to initialize application directory: %w", err)
 	}

--- a/cmd/complyctl/cli/scan.go
+++ b/cmd/complyctl/cli/scan.go
@@ -45,7 +45,7 @@ func scanCmd(common *option.Common) *cobra.Command {
 			return runScan(cmd, scanOpts)
 		},
 	}
-	cmd.Flags().StringVarP(&scanOpts.withPluginConfig, "plugin-config", "c", "", "Directory where user customized plugin manifests located.")
+	cmd.Flags().StringVarP(&scanOpts.withPluginConfig, "plugin-config", "c", "", "Directory where user customized plugin manifests located")
 	cmd.Flags().BoolP("with-md", "m", false, "If true, assessement-result markdown will be generated")
 	scanOpts.complyTimeOpts.BindFlags(cmd.Flags())
 	return cmd
@@ -65,7 +65,7 @@ func runScan(cmd *cobra.Command, opts *scanOptions) error {
 	}
 
 	// Create the application directory if it does not exist
-	appDir, err := complytime.NewApplicationDirectory(true)
+	appDir, err := complytime.NewApplicationDirectory(true, logger)
 	if err != nil {
 		return err
 	}

--- a/cmd/complyctl/cli/scan.go
+++ b/cmd/complyctl/cli/scan.go
@@ -45,7 +45,7 @@ func scanCmd(common *option.Common) *cobra.Command {
 			return runScan(cmd, scanOpts)
 		},
 	}
-	cmd.Flags().StringVarP(&scanOpts.withPluginConfig, "plugin-config", "c", "", "Directory where user customized plugin manifests located")
+	cmd.Flags().StringVarP(&scanOpts.withPluginConfig, "plugin-config", "c", "", "Directory where user customized plugin manifests are located")
 	cmd.Flags().BoolP("with-md", "m", false, "If true, assessement-result markdown will be generated")
 	scanOpts.complyTimeOpts.BindFlags(cmd.Flags())
 	return cmd

--- a/internal/complytime/configuration.go
+++ b/internal/complytime/configuration.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/adrg/xdg"
 	oscalTypes "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-3"
+	"github.com/hashicorp/go-hclog"
 	"github.com/oscal-compass/compliance-to-policy-go/v2/framework"
 	"github.com/oscal-compass/compliance-to-policy-go/v2/framework/actions"
 	"github.com/oscal-compass/oscal-sdk-go/models"
@@ -54,9 +55,15 @@ type ApplicationDirectory struct {
 // Creation of the directories is optional using the `create` input.
 // If the application directories exist, this will not overwrite what is
 // existing.
-func NewApplicationDirectory(create bool) (ApplicationDirectory, error) {
+func NewApplicationDirectory(create bool, logger hclog.Logger) (ApplicationDirectory, error) {
 	// When running local built complytime for development
 	if os.Getenv("COMPLYTIME_DEV_MODE") == "1" {
+		applicationDirectory := filepath.Join(xdg.DataHome, ApplicationDir)
+		if _, err := os.Stat(applicationDirectory); err != nil {
+			if os.IsNotExist(err) {
+				logger.Info(fmt.Sprintf("Application directory not found, creating directory: %s", applicationDirectory))
+			}
+		}
 		return newApplicationDirectory(xdg.DataHome, create)
 	} else {
 		return newApplicationDirectory(DataRootDir, false)


### PR DESCRIPTION
## Summary
An information message is added to indicate that if the application directory does not exist while running complyctl commands, it will be created automatically. 

## Related Issues
- _Closes CPLYTM-577_