### PR TITLE
chore: add dependabot support for setup-complyctl directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/setup-complyctl"
     schedule:
       interval: "daily"
     commit-message:


### PR DESCRIPTION
## Summary
Configure dependabot to check GitHub Actions dependencies in the `.github/actions/setup-complyctl` directory

**Note**: Dependabot doesn't seem to support recursive directory scanning, so each directory containing dependencies should be explicitly listed,

Closes #292
