### PR TITLE
chore: bump go version to 1.24.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: '1.22'
+          go-version: '1.24.6'
 
       - name: Install cosign for signatures
         uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/complytime/complyctl
 
-go 1.24.0
+go 1.24.6
 
 require (
 	github.com/ComplianceAsCode/compliance-operator v1.7.0


### PR DESCRIPTION
## Summary
The PR bumps the project's go version to 1.24.6 to address https://pkg.go.dev/vuln/GO-2025-3956

## Related Issues

https://bugzilla.redhat.com/show_bug.cgi?id=2399329

