### PR TITLE
test: expand test scenario for EnsureUserWorkspace function

### DIFF
--- a/internal/complytime/configuration_test.go
+++ b/internal/complytime/configuration_test.go
@@ -54,7 +54,6 @@ func TestFindComponentDefinitions(t *testing.T) {
 func TestEnsureUserWorkspace(t *testing.T) {
 	tmpDir := t.TempDir()
 	testPlanPath := filepath.Join(tmpDir, "test_workspace")
-	defer os.RemoveAll(tmpDir) // Clean up after test
 
 	err := EnsureUserWorkspace(testPlanPath)
 	require.NoError(t, err)

--- a/internal/complytime/configuration_test.go
+++ b/internal/complytime/configuration_test.go
@@ -70,7 +70,6 @@ func TestEnsureUserWorkspace(t *testing.T) {
 
 	err = os.Chmod(tmpDir, 0500) // read + execute only, no write
 	require.NoError(t, err, "failed to chmod parent dir")
-	defer os.Chmod(tmpDir, 0755) // restore permissions so TempDir cleanup works
 
 	// Try to create the user workspace again but now it should fail
 	err = EnsureUserWorkspace(testPlanPath)

--- a/internal/complytime/configuration_test.go
+++ b/internal/complytime/configuration_test.go
@@ -55,11 +55,24 @@ func TestEnsureUserWorkspace(t *testing.T) {
 	tmpDir := t.TempDir()
 	testPlanPath := filepath.Join(tmpDir, "test_workspace")
 
+	// Ensure user workspace directory is properly created
 	err := EnsureUserWorkspace(testPlanPath)
 	require.NoError(t, err)
 
 	info, err := os.Stat(testPlanPath)
 	require.NoError(t, err)
 	require.NotNil(t, info)
-	require.True(t, info.IsDir(), "Expected a directory, got something else")
+	require.True(t, info.IsDir(), "expected a directory, got something else")
+
+	// Now lets remove the created directory and set the parent dir as read-only
+	err = os.RemoveAll(testPlanPath)
+	require.NoError(t, err, "failed to remove test_workspace directory")
+
+	err = os.Chmod(tmpDir, 0500) // read + execute only, no write
+	require.NoError(t, err, "failed to chmod parent dir")
+	defer os.Chmod(tmpDir, 0755) // restore permissions so TempDir cleanup works
+
+	// Try to create the user workspace again but now it should fail
+	err = EnsureUserWorkspace(testPlanPath)
+	require.Error(t, err, "expected error when trying to create dir in read-only parent")
 }


### PR DESCRIPTION
## Summary

Expanded the test to also include a situation where the function is expected to fail.
It depends on https://github.com/complytime/complyctl/pull/287

## Related Issues

It is good to test both expected and unexpected situations in our unit tests to ensure the function is properly treating these cases and other changes does not unintentionally impact this behavior.

## Review Hints

There are two commits with more context on their descriptions.
`make test-unit` should be enough for technical tests.