### PR TITLE
feat: add progress spinner for scan operation

### DIFF
--- a/.github/workflows/vuln_check_fix.yml
+++ b/.github/workflows/vuln_check_fix.yml
@@ -7,7 +7,7 @@ name: Vulnerability-check-fix
 on:
   schedule:
     - cron: "0 0 * * *"
-  workflow_dispatch: 
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -97,7 +97,7 @@ jobs:
       - name: Create PR or update the existing PR
         if: env.FIXED_VERSION != ''
         run: |
-          OWNER="complytime" 
+          OWNER="complytime"
           REPO="complyctl"
           action_run="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           PR_BODY="Bump golang version to ${{ env.FIXED_VERSION }} to fix the findings from job $action_run"

--- a/cmd/complyctl/cli/scan.go
+++ b/cmd/complyctl/cli/scan.go
@@ -109,7 +109,7 @@ func runScan(cmd *cobra.Command, opts *scanOptions) error {
 	}
 	logger.Info(fmt.Sprintf("Successfully loaded %v plugin(s).", len(plugins)))
 
-	logger.Info("Scanning environment (this may take several minutes)...")
+	logger.Info("Scanning (this may take some time depending on the system and controls)...")
 	stopSpinner := make(chan int)
 	go terminal.ShowSpinner(stopSpinner)
 

--- a/cmd/complyctl/cli/scan.go
+++ b/cmd/complyctl/cli/scan.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/complytime/complyctl/cmd/complyctl/option"
 	"github.com/complytime/complyctl/internal/complytime"
+	"github.com/complytime/complyctl/internal/terminal"
 )
 
 const assessmentResultsLocationJson = "assessment-results.json"
@@ -108,10 +109,17 @@ func runScan(cmd *cobra.Command, opts *scanOptions) error {
 	}
 	logger.Info(fmt.Sprintf("Successfully loaded %v plugin(s).", len(plugins)))
 
+	logger.Info("Scanning environment (this may take several minutes)...")
+	stopSpinner := make(chan int)
+	go terminal.ShowSpinner(stopSpinner)
+
 	allResults, err := actions.AggregateResults(cmd.Context(), inputContext, plugins)
+	stopSpinner <- 1
+
 	if err != nil {
 		return err
 	}
+	logger.Info("Scan completed successfully.")
 
 	// Collect results in a single report
 	planHref := fmt.Sprintf("file://%s", apCleanedPath)


### PR DESCRIPTION
## Summary

Add visual feedback during environment scanning with:
- Animated spinner to show the scan is actively running
- Message to inform users that scanning may take several minutes and to notify them when the scan is complete

This improves user experience by providing clear feedback during potentially long-running scan operations.

## Related Issues
- Related issue: #293