### PR TITLE
chore: [CPLYTM-1102] [CPLYTM-1103] add vulnerability check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: '1.24.6'
+          go-version-file: 'go.mod'
 
       - name: Install cosign for signatures
         uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0

--- a/.github/workflows/vuln_check_fix.yml
+++ b/.github/workflows/vuln_check_fix.yml
@@ -1,0 +1,129 @@
+# This workflow is for vulnerability checking and fix for go version in gomod.
+# It could be triggered daily. If this workflow finds any CVEs,
+# it will create a PR for go version upgrade to try to fix the CVEs.
+# Also, you can triggered this workflow with workflow_dispatch.
+
+name: Vulnerability-check-fix
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch: 
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  Vulnerability-check-fix:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the code from the repository
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Setup Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      - name: Install osv-scanner
+        run: |
+          cat go.mod
+          go install github.com/google/osv-scanner/v2/cmd/osv-scanner@a66ef4bd60622d94e536ee3ee5592ea1e3e9a382 # v2.2.3
+      - name: Check vulnerability
+        id: osv-scanner
+        run: |
+          # Show the found vulnaribilities
+          osv-scanner . || true
+          # Get the CVEs fixed version from the results.sarif
+          osv-scanner  -r --format=sarif . > results.sarif || true
+          if [ -f "results.sarif" ] && [ -s "results.sarif" ]; then
+            FIXED_VERSION=$(jq -r '.runs[0].tool.driver.rules[] | .help.markdown | capture("### Fixed Versions\\s*\\|.+\\n\\|.+\\n\\|\\s*[^|]+?\\s*\\|\\s*[^|]+?\\s*\\|\\s*(?<version>[^|]+?)\\s*\\|") | .version' results.sarif | tr ',' '\n' | sed 's/ //g' | sort -V | tail -n 1)
+            echo "The FIXED_VERSION is $FIXED_VERSION."
+            echo "FIXED_VERSION=$FIXED_VERSION" >> $GITHUB_ENV
+            echo "${{ env.FIXED_VERSION }}"
+            rm -rf results.sarif
+          else
+            echo "No vulnaribility"
+          fi
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      # Upgrade the go version to the fixed version
+      - name: Get GitHub app token
+        if: env.FIXED_VERSION != ''
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            complyctl
+      - name: Set the branches
+        if: env.FIXED_VERSION != ''
+        run: |
+          PR_BRANCH=$(gh pr list --state open --json headRefName --jq '.[] | select(.headRefName | contains("update-go-version")) | .headRefName' | head -n 1)
+          if [[ -n "$PR_BRANCH" ]]; then
+            echo "Found matching PR branch: $PR_BRANCH"
+            # Set the branch name as the PR_BRANCH.
+            echo "BRANCH_NAME=$PR_BRANCH" >> $GITHUB_ENV
+          else
+            echo "No open PR found with 'update-go-version' in the branch name."
+            BRANCH_NAME="update-go-version-$(date +%Y-%m-%d)"
+            echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          fi
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      - name: Upgrade go to fixed version
+        if: env.FIXED_VERSION != ''
+        run: |
+          git fetch --all
+          if git show-ref --verify --quiet refs/remotes/origin/"${{ env.BRANCH_NAME }}"; then
+            echo "Branch $BRANCH_NAME exists, checkout the branch."
+            git checkout -b "${{ env.BRANCH_NAME }}" origin/${{ env.BRANCH_NAME }}
+          else
+            echo "Branch $BRANCH_NAME doesn't exist, set the branch $BRANCH_NAME"
+            git checkout -b "${{ env.BRANCH_NAME }}"
+          fi
+          go mod edit -go=${{ env.FIXED_VERSION }}
+          go mod tidy
+          if [[ -z $(git status --porcelain) ]]; then
+            echo "No changes to the go.mod file. Nothing to commit."
+          else
+            git config user.name "complytime-ci"
+            git config user.email "complytime-ci@gmail.com"
+            git add go.mod go.sum
+            git commit -m "Update the gomod version to ${{ env.FIXED_VERSION }}"
+            git push origin ${{ env.BRANCH_NAME }} -f
+          fi
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      - name: Create PR or update the existing PR
+        if: env.FIXED_VERSION != ''
+        run: |
+          OWNER="complytime" 
+          REPO="complyctl"
+          action_run="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          PR_BODY="Bump golang version to ${{ env.FIXED_VERSION }} to fix the findings from job $action_run"
+          if [[ "$(git branch --show-current)" == "${{ env.BRANCH_NAME }}" ]]; then
+            # Check if the PR exists
+            PR_EXISTS=$(gh pr list --repo $OWNER/$REPO \
+              --head $BRANCH_NAME --state open --json id \
+              | jq length)
+            if [ "$PR_EXISTS" -gt 0 ]; then
+              echo "PR ${{ env.BRANCH_NAME }} already exists. Skipping PR creation."
+              echo "Add a comment for the go version update."
+              gh pr comment ${{ env.BRANCH_NAME }} --body "${PR_BODY}"
+            else
+              echo "Creating PR for new branch: ${{ env.BRANCH_NAME }}"
+              gh pr create --repo $OWNER/$REPO \
+                --title "chore: bump go version to ${{ env.FIXED_VERSION }} in gomod" \
+                --head "${{ env.BRANCH_NAME }}" \
+                --base "main" \
+                --reviewer "complytime-dev" \
+                --body "${PR_BODY}"
+            fi
+          else
+            echo "No branch ${{ env.BRANCH_NAME }}. Skipping PR creation."
+          fi
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      - name: Rescan complyctl
+        run: |
+          osv-scanner .


### PR DESCRIPTION
## Summary
Add workflow for vulnerability check via [osv-scanner](https://github.com/google/osv-scanner/), which is recommended by PSIRT.
The workflow steps:
1. Install osv-scanner
2. Scan the source of `complyctl` and show the report
3. Get the `fixed version` of the CVEs
4. Upgrade the `Go version` in the gomod file.
5. Create a PR for the upgrade if there's no existing PR
  The title and the comments of the PR are similar in the example [PR](https://github.com/auto-manage-org/complyctl/pull/22
), which is created by the [run](https://github.com/auto-manage-org/complyctl/actions/runs/18517250489/job/52770087855)



## Related Issues


- _Closes #[CPLYTM-1061](https://issues.redhat.com/browse/CPLYTM-1061)


## Review Hints

