### PR TITLE
chore: fix the conflict of go version

### DIFF
--- a/.github/workflows/vuln_check_fix.yml
+++ b/.github/workflows/vuln_check_fix.yml
@@ -34,13 +34,13 @@ jobs:
           # Get the CVEs fixed version from the results.sarif
           osv-scanner  -r --format=sarif . > results.sarif || true
           if [ -f "results.sarif" ] && [ -s "results.sarif" ]; then
-            FIXED_VERSION=$(jq -r '.runs[0].tool.driver.rules[] | .help.markdown | capture("### Fixed Versions\\s*\\|.+\\n\\|.+\\n\\|\\s*[^|]+?\\s*\\|\\s*[^|]+?\\s*\\|\\s*(?<version>[^|]+?)\\s*\\|") | .version' results.sarif | tr ',' '\n' | sed 's/ //g' | sort -V | tail -n 1)
+            FIXED_VERSION=$(jq -r '.runs[0].tool.driver.rules[]| .help.markdown| capture("### Fixed Versions\\s*\\|.+\\n\\|.+\\n\\|\\s*[^|]+?\\s*\\|\\s*[^|]+?\\s*\\|\\s*(?<version>[^|]+?)\\s*\\|")| .version| gsub(" "; "") | split(",")| map(split(".") | map(tonumber))| min| map(tostring)| join(".")' results.sarif | sort -V | tail -n 1)
             echo "The FIXED_VERSION is $FIXED_VERSION."
             echo "FIXED_VERSION=$FIXED_VERSION" >> $GITHUB_ENV
             echo "${{ env.FIXED_VERSION }}"
             rm -rf results.sarif
           else
-            echo "No vulnaribility"
+            echo "No vulnerability"
           fi
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -82,13 +82,12 @@ jobs:
             git checkout -b "${{ env.BRANCH_NAME }}"
           fi
           go mod edit -go=${{ env.FIXED_VERSION }}
-          go mod tidy
           if [[ -z $(git status --porcelain) ]]; then
             echo "No changes to the go.mod file. Nothing to commit."
           else
             git config user.name "complytime-ci"
             git config user.email "complytime-ci@gmail.com"
-            git add go.mod go.sum
+            git add go.mod
             git commit -m "Update the gomod version to ${{ env.FIXED_VERSION }}"
             git push origin ${{ env.BRANCH_NAME }} -f
           fi


### PR DESCRIPTION
## Summary
This PR tries to fix the [error](https://github.com/complytime/complyctl/actions/runs/18925551386/job/54147038065) about the go running version and the upgrade version in go.mod.
And it also improved to get `FIXED_VERSION` when it found vulnerabilities. 


