### PR TITLE
chore: update goreleaser settings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,16 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'The tag to release (e.g., v1.2.3)'
+        required: true
+        type: string
 
-permissions: {}
+
+permissions:
+  contents: none
+  id-token: none
 
 jobs:
   release:
@@ -50,5 +58,5 @@ jobs:
           args: --verbose release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GORELEASER_CURRENT_TAG: ${{ github.event.inputs.tag }}
+          GORELEASER_CURRENT_TAG: ${{ inputs.tag }}
         continue-on-error: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
-          version: '~> v2.4.8'
+          version: '~> v2'
           args: --verbose release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,10 +45,13 @@ archives:
 
 changelog:
   sort: asc
+  use: github
+  format: "{{ .SHA }}: {{ .Message }}{{ with .AuthorUsername }} (@{{ . }}){{ end }}"
   filters:
     exclude:
       - "^docs:"
       - "^test:"
+      - Merge pull request
   groups:
     - title: "New Features"
       regexp: '^.*?feat(\(.+\))??!?:.+$'
@@ -82,4 +85,3 @@ signs:
       - "--yes" # needed on cosign 2.0.0+
     artifacts: checksum # only need to sign checksums
     output: true
-    bundle: false   # REQUIRED for cosign v2

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -76,12 +76,11 @@ sboms:
 
 signs:
   - cmd: cosign
-    certificate: "${artifact}.pem"
+    signature: "${artifact}.sigstore.json"
     args:
       - "sign-blob"
-      - "--output-certificate=${certificate}"
-      - "--output-signature=${signature}"
+      - "--bundle=${signature}"
       - "${artifact}"
-      - "--yes" # needed on cosign 2.0.0+
-    artifacts: checksum # only need to sign checksums
+      - "--yes"
+    artifacts: checksum
     output: true


### PR DESCRIPTION
## Summary

First this PR removes the pinned version [2.4.8](https://github.com/goreleaser/goreleaser/releases/tag/v2.4.8) and stick only to the v2 major version, so updates, fixes and new features are automatically adopted.

Regarding GoReleaser configuration, the changelog was polished so we can have more informative description in our changelogs.

Finally, it updates the cosign part to be aligned with [v3](https://github.com/sigstore/cosign/releases).

## Related Issues

- This should fix the issue reported here: https://github.com/complytime/complyctl/actions/runs/19433611450/job/55598532998

## Review Hints

- https://github.com/goreleaser/goreleaser/blob/main/www/docs/blog/posts/2025-11-05-cosign-v3.md
- https://github.com/goreleaser/goreleaser/releases
- https://github.com/goreleaser/goreleaser/blob/main/.goreleaser.yaml