### PR TITLE
ci: minor improvements in release changelog

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,9 +12,9 @@ before:
     #- go generate ./...
 
 builds:
-  - #
-    id: complyctl
+  - id: complyctl
     binary: complyctl
+    main: ./cmd/complyctl/
     env:
       - CGO_ENABLED=0
     goos:
@@ -24,13 +24,11 @@ builds:
       - "-X github.com/complytime/complyctl/internal/version.gitTreeState={{ .GitTreeState }}"
       - "-X github.com/complytime/complyctl/internal/version.commit={{ .Commit }}"
       - "-X github.com/complytime/complyctl/internal/version.buildDate={{ .Date }}"
-    main: ./cmd/complyctl/
-  - #
-    id: openscap-plugin
+  - id: openscap-plugin
     binary: openscap-plugin
+    main: ./cmd/openscap-plugin/
     goos:
       - linux
-    main: ./cmd/openscap-plugin/
 
 archives:
   - format: tar.gz

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -54,16 +54,22 @@ changelog:
     - title: "New Features"
       regexp: '^.*?feat(\(.+\))??!?:.+$'
       order: 100
-    - title: "Security updates"
+    - title: "Security Updates"
       regexp: '^.*?sec(\(.+\))??!?:.+$'
       order: 150
-    - title: "Bug fixes"
+    - title: "Bug Fixes"
       regexp: '^.*?(fix|refactor)(\(.+\))??!?:.+$'
       order: 200
-    - title: "Documentation updates"
-      regexp: ^.*?docs?(\(.+\))??!?:.+$
+    - title: "Dependency Updates"
+      regexp: '^.*chore\(deps\):.*$'
+      order: 250
+    - title: "Infrastructure Updates"
+      regexp: '^.*ci(\(.*\))?:.*$'
+      order: 300
+    - title: "Documentation Updates"
+      regexp: '^.*?docs?(\(.+\))??!?:.+$'
       order: 400
-    - title: Other work
+    - title: "Other Work"
       order: 9999
 
 sboms:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -44,7 +44,7 @@ archives:
 changelog:
   sort: asc
   use: github
-  format: "{{ .SHA }}: {{ .Message }}{{ with .AuthorUsername }} (@{{ . }}){{ end }}"
+  format: "{{ .SHA }}: {{ .Message }} ({{ with .AuthorUsername }}@{{ . }}{{ else }}{{ .AuthorName }}{{ end }})"
   filters:
     exclude:
       - "^docs:"


### PR DESCRIPTION
## Summary

There are three commits, the first is just a minor improvement on syntax to be more aligned with the documentation in cases of multiple binaries.

Second commit creates two new sections to group dependencies and infrastructure updates that are now mixed in "Other Work".

Finally a third commit includes a conditional for the changelog lines format to show the author also for custom PR created by automation.

## Related Issues

- Not real problems, but some improvements based on last release:
  - https://github.com/complytime/complyctl/releases/tag/v0.1.1

## Review Hints

- https://goreleaser.com/customization/builds/go/
- https://goreleaser.com/customization/changelog/
- https://regex101.com/r/Z7PV2S/1