### PR TITLE
fix: filter verbose scan finding logs to debug level

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -68,14 +68,18 @@ func defaultStyles() *charmlog.Styles {
 // NewLogger initializes a new wrapped logger with default styles
 func NewLogger(o io.Writer) hclog.Logger {
 	c := charmlog.NewWithOptions(o, *defaultOptions())
-	l := &CharmHclog{c}
+	l := &CharmHclog{
+		logger:   c,
+		logLevel: hclog.Info, // Default to Info level
+	}
 	l.logger.SetStyles(defaultStyles())
 	return l
 }
 
 // CharmHclog adapts the charm logger to the hashicorp logger.
 type CharmHclog struct {
-	logger *charmlog.Logger
+	logger   *charmlog.Logger
+	logLevel hclog.Level
 }
 
 // CharmHclog will implement the hclog.Logger.
@@ -111,6 +115,14 @@ func (c *CharmHclog) Debug(msg string, args ...interface{}) {
 	c.logger.Debug(msg, args...)
 }
 func (c *CharmHclog) Info(msg string, args ...interface{}) {
+	// Filter verbose messages from C2P unless in debug mode
+	if strings.Contains(msg, "generated finding for rule") {
+		if c.logLevel > hclog.Debug {
+			return
+		}
+		c.logger.Debug(msg, args...)
+		return
+	}
 	c.logger.Info(msg, args...)
 }
 func (c *CharmHclog) Warn(msg string, args ...interface{}) {
@@ -134,7 +146,10 @@ func (c *CharmHclog) IsError() bool { return false }
 func (c *CharmHclog) ImpliedArgs() []interface{} { return nil }
 
 func (c *CharmHclog) With(args ...interface{}) hclog.Logger {
-	return &CharmHclog{c.logger.With(args...)}
+	return &CharmHclog{
+		logger:   c.logger.With(args...),
+		logLevel: c.logLevel,
+	}
 }
 
 // The GetPrefix() method will return the prefix of the logger.
@@ -142,22 +157,29 @@ func (c *CharmHclog) Name() string { return c.logger.GetPrefix() }
 
 // The Named() method appends to the current logger prefix.
 func (c *CharmHclog) Named(name string) hclog.Logger {
-	return &CharmHclog{c.logger.WithPrefix(name)}
+	return &CharmHclog{
+		logger:   c.logger.WithPrefix(name),
+		logLevel: c.logLevel,
+	}
 }
 
 // The ResetNamed() method creates the logger with only the prefix passed.
 func (c *CharmHclog) ResetNamed(name string) hclog.Logger {
-	return &CharmHclog{c.logger.WithPrefix(name)}
+	return &CharmHclog{
+		logger:   c.logger.WithPrefix(name),
+		logLevel: c.logLevel,
+	}
 }
 
 // The SetLevel() method enables setting logger level.
 func (c *CharmHclog) SetLevel(level hclog.Level) {
+	c.logLevel = level
 	c.logger.SetLevel(hclogCharmLevels[level])
 }
 
 // The GetLevel() method returns the current level.
 func (c *CharmHclog) GetLevel() hclog.Level {
-	return charmHclogLevels[c.logger.GetLevel()]
+	return c.logLevel
 }
 
 // The StandardLog() of CharmHclog is returned, wrapping go-hclog.


### PR DESCRIPTION
## Summary

* Move verbose "generated finding for rule" messages from INFO to DEBUG level
* Reduces log noise during scan operations while preserving important messages
* Messages only appear when --debug flag is used

## Motivation

During scan operations, the reporter generates verbose INFO messages for each finding. On systems with many findings, this creates hundreds of log lines that obscure important messages.

## Overview of changes

Enhanced CharmHclog adapter to filter specific messages based on log level state. Messages containing "generated finding for rule" are suppressed in normal mode or shown at DEBUG level with --debug flag.

## Testing

Tested in Vagrant environment with scan command:

**Normal mode (clean output):**
```
$ complyctl scan
INFO Searching for plugins in /usr/libexec/complytime/plugins
INFO openscap: configuring client automatic mTLS
INFO openscap-plugin: Starting OpenSCAP plugin @module=openscap-plugin timestamp=2025-11-20T11:31:30.021Z
INFO openscap-plugin: configuring server automatic mTLS @module=openscap-plugin timestamp=2025-11-20T11:31:30.021Z
INFO Successfully loaded 1 plugin(s).
INFO Scanning (this may take some time depending on the system and controls)...
\WARN openscap-plugin: at least one rule resulted in fail or unknown err="exit status 2" @module=openscap-plugin timestamp=2025-11-20T11:31:50.374Z
INFO Scan completed successfully.
INFO reporter: generating assessments results for plan file://complytime/assessment-plan.json
INFO The assessment results in JSON were successfully written to complytime/assessment-results.json.
INFO No assessment result in markdown will be generated.
INFO openscap: plugin process exited plugin=/usr/libexec/complytime/plugins/openscap-plugin id=1137
```

**Debug mode (verbose messages visible):**
```
$ complyctl scan --debug
[... additional log messages ...]
DEBUG reporter: generated finding for rule accounts_umask_etc_profile
DEBUG reporter: generated finding for rule sysctl_net_ipv4_conf_all_accept_source_route
DEBUG reporter: generated finding for rule audit_rules_time_watch_localtime
[... additional finding messages ...]
```

The filtering successfully suppresses verbose finding logs in normal mode while keeping them available for debugging.

Fixes https://github.com/complytime/complyctl/issues/293

---

This description was generated with AI assistance from Claude Code.