### PR TITLE
chore: minor lint issues

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -33,9 +33,9 @@ jobs:
         uses: ./.github/actions/setup-complyctl
         # This is the test data for a specific product, and it may be updated in the future if necessary.
         with:
-          product: $PRODUCT
-          catalog: $CATALOG
-          profile: $PROFILE
+          product: "$PRODUCT"
+          catalog: "$CATALOG"
+          profile: "$PROFILE"
 
       - name: Test complyctl list
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,6 @@ jobs:
           version: '~> v2'
           args: --verbose release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GORELEASER_CURRENT_TAG: ${{ inputs.tag }}
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GORELEASER_CURRENT_TAG: "${{ inputs.tag }}"
         continue-on-error: false

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -41,8 +41,8 @@ jobs:
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}" # Needed to get PR information, if any
+          SONAR_TOKEN: "${{ secrets.SONAR_TOKEN }}"
         with:
           args: >
             "-Dsonar.go.coverage.reportPaths=coverage.out"
@@ -53,4 +53,4 @@ jobs:
         # Force to fail step after specific time
         timeout-minutes: 5
         env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: "${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -30,4 +30,4 @@ jobs:
 
       # Step 4: Run Go tests
       - name: Run unit tests
-        run: go test -v $(go list ./... | grep -v /tests)
+        run: go list ./... | grep -v /tests | xargs go test -v


### PR DESCRIPTION
## Summary

Quote variables as recommended by `shellcheck`.
Slightly updated the go test command to keep the same behavior without quotes.

## Related Issues

- https://github.com/complytime/complyctl/actions/runs/20015887697/job/57393294265?pr=351

## Review Hints

- https://www.shellcheck.net/wiki/SC2046

Locally this command could be tested:
```bash
go list ./... | grep -v /tests | xargs go test -v
``` 
