### PR TITLE
fix(scripts): Add missing hyphen to curl -X POST flag

### DIFF
--- a/scripts/setup-github-workflows.py
+++ b/scripts/setup-github-workflows.py
@@ -118,7 +118,7 @@ def create_pull_request(workflow, owner, repo, workflow_branch):
             "base": "main",
             "head": f"{owner}:{workflow_branch}"
     }
-    cmd = f'curl -L -s X POST {cmd_header} {pulls_api} -d \'{json.dumps(data)}\''
+    cmd = f'curl -L -s -X POST {cmd_header} {pulls_api} -d \'{json.dumps(data)}\''
 
     print(f"Creating a pull request for {workflow} workflow update")
     try:


### PR DESCRIPTION
## Summary

Fix curl syntax error in workflow setup script by adding missing hyphen to the `-X POST` flag.

## Motivation

The `create_pull_request()` function had a curl command with `X POST` instead of `-X POST`. Without the hyphen, curl interprets `X` and `POST` as URLs/hostnames to fetch, which would cause curl to attempt resolving these invalid hosts before processing the actual API call.

While the final API request might still succeed (since `-d` causes curl to default to POST method), the command would produce errors about being unable to resolve hosts "X" and "POST", making the script unreliable.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)