### PR TITLE
fix(cli): Fix typo in scan command help text

### DIFF
--- a/cmd/complyctl/cli/scan.go
+++ b/cmd/complyctl/cli/scan.go
@@ -51,7 +51,7 @@ func scanCmd(common *option.Common) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&scanOpts.withPluginConfig, "plugin-config", "c", "", "Directory where user customized plugin manifests are located")
-	cmd.Flags().BoolP("with-md", "m", false, "If true, assessement-result markdown will be generated")
+	cmd.Flags().BoolP("with-md", "m", false, "If true, assessment-result markdown will be generated")
 	scanOpts.complyTimeOpts.BindFlags(cmd.Flags())
 	return cmd
 }


### PR DESCRIPTION
## Summary

Fix spelling error in CLI help text for the scan command.

## Motivation

The `--with-md` flag description contained a typo: "assessement-result" instead of "assessment-result". This is visible to users when running `complyctl scan --help`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)