### PR TITLE
chore: exclude vendor directory from lint checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,7 @@
 version: "2"
+run:
+  skip-dirs:
+    - vendor
 linters:
   default: standard   # https://golangci-lint.run/usage/linters/#enabled-by-default
   enable:

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -1,5 +1,7 @@
 
 # https://megalinter.io/latest/supported-linters/
+ADDITIONAL_EXCLUDED_DIRECTORIES:
+  - vendor
 ENABLE_LINTERS:
   - ACTION_ACTIONLINT
   - ANSIBLE_ANSIBLE_LINT


### PR DESCRIPTION
## Summary

Exclude vendor directory from lint checks since we don't have full control on this and wouldn't like to create noise for unrelated PRs.

## Related Issues

- Noticed from https://github.com/complytime/complyctl/pull/381

## Review Hints

Checking the CI `CI / Standardized CI / Run linters (pull_request)` should be enough. 