### PR TITLE
fix: exclude vendored files from scan

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,9 +5,10 @@ sonar.organization=rh-psce
 sonar.projectName=complyctl
 #sonar.projectVersion=1.0
 
+# Exclude vendored dependencies from analysis
+sonar.exclusions=vendor/**
 
-# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
-#sonar.sources=.
-
-# Encoding of the source code. Default is default system encoding
-#sonar.sourceEncoding=UTF-8
+# Disable C/C++/Objective-C sensors (pure Go project)
+sonar.c.file.suffixes=-
+sonar.cpp.file.suffixes=-
+sonar.objc.file.suffixes=-


### PR DESCRIPTION
## Summary
- Exclude `vendor/**` from SonarCloud analysis to avoid scanning third-party code
- Disable C/C++/Objective-C sensors (complyctl is a pure Go project)

This fixes the SonarCloud scan failure caused by the CFamily sensor crashing on vendored C files (e.g. from go-git). The scan has been broken since June 2025.

## Test plan
- [ ] Verify SonarCloud check passes on this PR

## Review Hints
- Check scan failures for the PR https://github.com/complytime/complyctl/pull/378