### PR TITLE
chore: CPLYTM-1303 - ignore agent specific files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ governance/reports/*
 # Go workspaces
 go.work*
 
+megalinter-reports/
+
 # Speckit
 .specify/extensions/.cache/
 .specify/extensions/.backup/
@@ -54,5 +56,11 @@ go.work*
 
 # Agent dirs
 .cursor
+.claude
 
-megalinter-reports/
+# Agents specific files
+CLAUDE.md
+
+# Ignore generated credentials from google-github-actions/auth
+# See: https://github.com/google-github-actions/auth
+gha-creds-*.json


### PR DESCRIPTION
## Summary

When using speckit locally, it creates commands for specific agents but we don't want agent specific configuration in the repository while users should be free to use any combination they want locally.

This PR ensures some already known files are removed while also creates the section to include more on-demand.

## Related Issues

- https://issues.redhat.com/browse/CPLYTM-1303

## Review Hints

The changes are straightforward, but a way to test is confirming your agent specific files are ignored locally.