### PR TITLE
chore: align to update for gitlab nested groups in snappy

### DIFF
--- a/cmd/ampel-plugin/scan/specs/gitlab/branch-protection.yaml
+++ b/cmd/ampel-plugin/scan/specs/gitlab/branch-protection.yaml
@@ -5,7 +5,7 @@ id: ${HOST}/${GROUP}/${PROJECT}@${BRANCH}
 name: ${HOST}/${GROUP}/${PROJECT}@${BRANCH}
 url: git+https://${HOST}/${GROUP}/${PROJECT}/@${BRANCH}
 type: http://github.com/carabiner-dev/snappy/specs/gitlab/branch-protection.yaml
-endpoint: projects/${GROUP}%2F${PROJECT}/protected_branches/${BRANCH}
+endpoint: projects/${GROUP}/${PROJECT}/protected_branches/${BRANCH}
 method: GET
 mask:
   - id

--- a/cmd/ampel-plugin/targets/targets.go
+++ b/cmd/ampel-plugin/targets/targets.go
@@ -41,7 +41,17 @@ func ParseRepoURL(repoURL, platformHint string) (platform, org, repo string, err
 		}
 	}
 
-	return platform, parts[0], parts[1], nil
+	// For GitLab, support nested groups: all segments except the last form the group path.
+	// For GitHub, use the first two segments (org/repo).
+	if platform == "gitlab" && len(parts) > 2 {
+		org = strings.Join(parts[:len(parts)-1], "/")
+		repo = parts[len(parts)-1]
+	} else {
+		org = parts[0]
+		repo = parts[1]
+	}
+
+	return platform, org, repo, nil
 }
 
 // SanitizeRepoURL converts a repository URL into a filesystem-safe name

--- a/cmd/ampel-plugin/targets/targets_test.go
+++ b/cmd/ampel-plugin/targets/targets_test.go
@@ -22,6 +22,22 @@ func TestParseRepoURL_GitLab(t *testing.T) {
 	require.Equal(t, "myrepo", repo)
 }
 
+func TestParseRepoURL_GitLabNestedGroups(t *testing.T) {
+	platform, group, repo, err := ParseRepoURL("https://gitlab.com/mygroup/subgroup/myproject", "")
+	require.NoError(t, err)
+	require.Equal(t, "gitlab", platform)
+	require.Equal(t, "mygroup/subgroup", group)
+	require.Equal(t, "myproject", repo)
+}
+
+func TestParseRepoURL_GitLabDeeplyNestedGroups(t *testing.T) {
+	platform, group, repo, err := ParseRepoURL("https://gitlab.com/a/b/c/d/project", "")
+	require.NoError(t, err)
+	require.Equal(t, "gitlab", platform)
+	require.Equal(t, "a/b/c/d", group)
+	require.Equal(t, "project", repo)
+}
+
 func TestParseRepoURL_UnsupportedHost(t *testing.T) {
 	_, _, _, err := ParseRepoURL("https://bitbucket.org/myorg/myrepo", "")
 	require.Error(t, err)


### PR DESCRIPTION
## Summary
This PR aligns to [update](https://github.com/carabiner-dev/snappy/pull/43) in snappy for gitlab nested groups.