### PR TITLE
chore: update sonarqube_ci

### DIFF
--- a/.github/workflows/ci_sonarcloud.yml
+++ b/.github/workflows/ci_sonarcloud.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
         - main
-  pull_request:
-    paths:
-        - '**.go'
 
 permissions:
   contents: none


### PR DESCRIPTION
## Summary
The sonar_token won't be allowed for the forked PRs. The workflow could be triggered only by merging to main.

## Related Issues
[CPLYTM-1370](https://redhat.atlassian.net/browse/CPLYTM-1370)


[CPLYTM-1370]: https://redhat.atlassian.net/browse/CPLYTM-1370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ