### PR TITLE
fix: mark oras-go MIGRATION_GUIDE.md as binary to fix Packit SRPM build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 * text eol=lf
 # Tells Git to treat the file as a binary file, which prevents any line ending conversions.
 vendor/github.com/go-logfmt/logfmt/README.md -text
+vendor/oras.land/oras-go/v2/MIGRATION_GUIDE.md -text


### PR DESCRIPTION
## Summary

The vendored MIGRATION_GUIDE.md has CRLF line endings which conflict with the `* text eol=lf` gitattributes rule, causing Packit to fail when switching branches during SRPM builds.

## Related Issues

- https://download.copr.fedorainfracloud.org/results/packit/complytime-complyctl-426/srpm-builds/10260263/builder-live.log.gz
- 

## Review Hints

- It is making tests in this PR to fail: https://github.com/complytime/complyctl/pull/426
