### PR TITLE
fix: set goreleaser dir for openscap-plugin separate Go module

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,7 +26,8 @@ builds:
           - "-X github.com/complytime/complyctl/internal/version.buildDate={{ .Date }}"
     - id: openscap-plugin
       binary: openscap-plugin
-      main: ./cmd/openscap-plugin/
+      dir: ./cmd/openscap-plugin
+      main: .
       goos:
           - linux
 


### PR DESCRIPTION
## Summary
The openscap-plugin has its own go.mod and must be built from its directory.
Without `dir`, goreleaser tries to resolve the package from the root module which fails.

## Related Issues

- https://github.com/complytime/complyctl/actions/runs/23552180643/job/68568952419

## Review Hints

A lot changed with the redesign and this minor update is necessary to release.