### PR TITLE
feat: CPLYTM-1385 - include workflow for branch protection checks

### DIFF
--- a/.github/workflows/ci_compliance.yml
+++ b/.github/workflows/ci_compliance.yml
@@ -1,0 +1,32 @@
+name: Compliance Checks
+
+on:
+  workflow_dispatch:
+    inputs:
+      complytime_config_path:
+        description: 'Relative path of the complytime.yaml file in this repository'
+        required: false
+        type: string
+        default: 'complytime.yaml'
+      policy_id:
+        description: 'Policy ID to use for complyctl generate and scan commands'
+        required: false
+        type: string
+        default: 'ampel-bp'
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  contents: none
+
+jobs:
+  call_reusable_compliance:
+    name: Compliance Evaluation
+    permissions:
+      contents: read
+    uses: complytime/org-infra/.github/workflows/reusable_compliance.yml@main
+    with:
+      complytime_config_path: ${{ inputs.complytime_config_path || 'complytime.yaml' }}
+      policy_id: ${{ inputs.policy_id || 'ampel-bp' }}
+    secrets:
+      source_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The same workflow was already [implemented in org-infra](https://github.com/complytime/org-infra/blob/main/.github/workflows/ci_compliance.yml) by https://github.com/complytime/org-infra/pull/159

The approach here is to consume the reusable workflow to scan its own branch protection rules.


## Related Issues

- https://redhat.atlassian.net/browse/CPLYTM-1385

## Review Hints

If you note the org-infra implementation, it is also scanning `complyctl`.
This duplication is intentional and temporary.
We can see both types of implementation and decide one to use as the standard for all repositories.

Here are some examples of this workflow implemented in org-infra:
- https://github.com/complytime/org-infra/actions/workflows/ci_compliance.yml