### PR TITLE
fix: replace gopkg.in/yaml.v3 with goccy/go-yaml

### DIFF
--- a/cmd/behavioral-report/main.go
+++ b/cmd/behavioral-report/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/complytime/complyctl/tests/behavioral"
 	"github.com/gemaraproj/go-gemara"
 	"github.com/gemaraproj/go-gemara/gemaraconv"
-	"gopkg.in/yaml.v3"
+	"github.com/goccy/go-yaml"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/grpc v1.79.3
 	google.golang.org/protobuf v1.36.11
-	gopkg.in/yaml.v3 v3.0.1
 	oras.land/oras-go/v2 v2.6.0
 )
 
@@ -62,4 +61,5 @@ require (
 	golang.org/x/text v0.32.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
## Summary

- Replace direct `gopkg.in/yaml.v3` import in `cmd/behavioral-report/main.go` with `github.com/goccy/go-yaml`, which is already a direct dependency used throughout the rest of the codebase
- `gopkg.in/yaml.v3` is now `// indirect` only, pulled in transitively by `testify` and `go-oscal`
- No behavioral change — the only usage is `yaml.Marshal`, which is API-compatible between both libraries
- This was flagged during review by @jpower432 on the `complytime/website PR https://github.com/complytime/website/pull/4

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes