### PR TITLE
chore: split branch protection policy for different spec types

### DIFF
--- a/cmd/mock-oci-registry/main.go
+++ b/cmd/mock-oci-registry/main.go
@@ -630,6 +630,16 @@ guidelines:
 		{mediaType: gemaraPolicyType, data: ampelPolicy},
 	})
 
+	// policies/ampel-approval-requirements — AMPEL approval requirements controls
+	ampelApprovalPolicy, err := seedData.ReadFile("testdata/ampel-approval-requirements-policy.yaml")
+	if err != nil {
+		log.Fatalf("failed to load AMPEL approval requirements policy seed data: %v", err)
+	}
+	s.addArtifact("policies/ampel-approval-requirements", []string{"v1.0.0", "latest"}, []layerDef{
+		{mediaType: gemaraCatalogType, data: ampelCatalog},
+		{mediaType: gemaraPolicyType, data: ampelApprovalPolicy},
+	})
+
 	// Enrichment mappings
 	s.enrichments["OPA:deny-root-user"] = &enrichmentMapping{
 		control: enrichmentControl{

--- a/cmd/mock-oci-registry/testdata/ampel-approval-requirements-policy.yaml
+++ b/cmd/mock-oci-registry/testdata/ampel-approval-requirements-policy.yaml
@@ -1,7 +1,7 @@
-title: AMPEL Branch Protection Policy
+title: AMPEL Approval Requirements Policy
 metadata:
-    id: ampel-branch-protection-policy
-    description: Automated evaluation policy for branch protection controls using AMPEL
+    id: ampel-approval-requirements-policy
+    description: Automated evaluation policy for approval requirements controls using AMPEL
     author:
         id: complytime
         name: ComplyTime
@@ -29,35 +29,14 @@ imports:
 adherence:
     evaluation-methods:
         - type: automated
-          description: AMPEL automated branch protection evaluation
+          description: AMPEL automated approval requirements evaluation
           executor:
               id: ampel
               name: AMPEL
               type: Software
     assessment-plans:
-        - id: BP-1.01
-          requirement-id: BP-1.01
-          frequency: on-demand
-          evaluation-methods:
-              - type: automated
-                executor:
-                    id: ampel
-        - id: BP-3.01
-          requirement-id: BP-3.01
-          frequency: on-demand
-          evaluation-methods:
-              - type: automated
-                executor:
-                    id: ampel
-        - id: BP-4.01
-          requirement-id: BP-4.01
-          frequency: on-demand
-          evaluation-methods:
-              - type: automated
-                executor:
-                    id: ampel
-        - id: BP-5.01
-          requirement-id: BP-5.01
+        - id: BP-2.01
+          requirement-id: BP-2.01
           frequency: on-demand
           evaluation-methods:
               - type: automated


### PR DESCRIPTION
## Summary
_This PR splits the branch protection rules._

## Related Issues
- _Closes CPLYTM-1374_

## Review Hints
With splited policies, complytime.yaml needs an update. e.g.,:
```
policies:
  - url: http://localhost:8765/policies/ampel-branch-protection
    id: ampel-bp
  - url: http://localhost:8765/policies/ampel-approval-requirements
    id: ampel-approvals
targets:
  - id: agcontent-branch-protection
    policies:
      - ampel-bp
    variables:
      url: https://gitlab.cee.redhat.com/group/project
      specs: builtin:gitlab/branch-protection.yaml
      branches: main
      access_token:  ${GITLAB_TOKEN}
      platform: gitlab
  - id: agcontent-approvals
    policies:
      - ampel-approvals
    variables:
      url: https://gitlab.cee.redhat.com/group/project
      specs: gitlab/project-approvals.yaml
      branches: main
      access_token: ${GITLAB_TOKEN}
      platform: gitlab
```

