### PR TITLE
chore: update ampel granular policy BP-02 and write spec

### DIFF
--- a/cmd/ampel-plugin/convert/testdata/ampel-bundle-expected-full.json
+++ b/cmd/ampel-plugin/convert/testdata/ampel-bundle-expected-full.json
@@ -50,7 +50,7 @@
       "tenets": [
         {
           "id": "01",
-          "code": "(has(predicates[0].data.values) && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.required_approving_review_count >= 1)) || (has(predicates[0].data.approvals_before_merge) && predicates[0].data.approvals_before_merge >= 1)",
+          "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.required_approving_review_count >= 1)) || (has(predicates[0].data.values.approvals_before_merge) && predicates[0].data.values.approvals_before_merge >= 1)",
           "predicates": {
             "types": [
               "http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml",
@@ -67,7 +67,7 @@
         },
         {
           "id": "02",
-          "code": "(has(predicates[0].data.values) && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.dismiss_stale_reviews_on_push == true)) || (has(predicates[0].data.reset_approvals_on_push) && predicates[0].data.reset_approvals_on_push == true)",
+          "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.dismiss_stale_reviews_on_push == true)) || (has(predicates[0].data.values.reset_approvals_on_push) && predicates[0].data.values.reset_approvals_on_push == true)",
           "predicates": {
             "types": [
               "http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml",
@@ -84,7 +84,7 @@
         },
         {
           "id": "03",
-          "code": "(has(predicates[0].data.values) && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.require_last_push_approval == true)) || (has(predicates[0].data.merge_requests_disable_committers_approval) && predicates[0].data.merge_requests_disable_committers_approval == true)",
+          "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.require_last_push_approval == true)) || (has(predicates[0].data.values.merge_requests_disable_committers_approval) && predicates[0].data.values.merge_requests_disable_committers_approval == true)",
           "predicates": {
             "types": [
               "http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml",

--- a/cmd/ampel-plugin/convert/testdata/policies/BP-02.01-minimum-approvals.json
+++ b/cmd/ampel-plugin/convert/testdata/policies/BP-02.01-minimum-approvals.json
@@ -10,7 +10,7 @@
   "tenets": [
     {
       "id": "01",
-      "code": "(has(predicates[0].data.values) && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.required_approving_review_count >= 1)) || (has(predicates[0].data.approvals_before_merge) && predicates[0].data.approvals_before_merge >= 1)",
+      "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.required_approving_review_count >= 1)) || (has(predicates[0].data.values.approvals_before_merge) && predicates[0].data.values.approvals_before_merge >= 1)",
       "predicates": {
         "types": [
           "http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml",
@@ -27,7 +27,7 @@
     },
     {
       "id": "02",
-      "code": "(has(predicates[0].data.values) && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.dismiss_stale_reviews_on_push == true)) || (has(predicates[0].data.reset_approvals_on_push) && predicates[0].data.reset_approvals_on_push == true)",
+      "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.dismiss_stale_reviews_on_push == true)) || (has(predicates[0].data.values.reset_approvals_on_push) && predicates[0].data.values.reset_approvals_on_push == true)",
       "predicates": {
         "types": [
           "http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml",
@@ -44,7 +44,7 @@
     },
     {
       "id": "03",
-      "code": "(has(predicates[0].data.values) && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.require_last_push_approval == true)) || (has(predicates[0].data.merge_requests_disable_committers_approval) && predicates[0].data.merge_requests_disable_committers_approval == true)",
+      "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.require_last_push_approval == true)) || (has(predicates[0].data.values.merge_requests_disable_committers_approval) && predicates[0].data.values.merge_requests_disable_committers_approval == true)",
       "predicates": {
         "types": [
           "http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml",

--- a/cmd/ampel-plugin/scan/scan.go
+++ b/cmd/ampel-plugin/scan/scan.go
@@ -1,10 +1,11 @@
 package scan
 
 import (
-	_ "embed"
+	"embed"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net/url"
 	"os"
 	"os/exec"
@@ -24,17 +25,8 @@ type RepoTarget struct {
 	Platform    string // "github" or "gitlab"
 }
 
-//go:embed specs/github/branch-rules.yaml
-var githubBranchRulesSpec []byte
-
-//go:embed specs/gitlab/branch-protection.yaml
-var gitlabBranchProtectionSpec []byte
-
-// GitHubSpecFile is the filename for the GitHub branch rules spec.
-const GitHubSpecFile = "branch-rules.yaml"
-
-// GitLabSpecFile is the filename for the GitLab branch protection spec.
-const GitLabSpecFile = "branch-protection.yaml"
+//go:embed specs
+var embeddedSpecs embed.FS
 
 // ScanConfig holds configuration for scanning a repository.
 type ScanConfig struct {
@@ -91,31 +83,45 @@ func buildTokenEnv(repo RepoTarget) []string {
 	return filtered
 }
 
-// WriteSpecFiles writes the embedded spec files to the given directory.
+// WriteSpecFiles writes all embedded spec files to the given directory.
+// It automatically discovers and writes all spec files from the embedded FS,
+// preserving the directory structure (e.g., specs/github/*.yaml, specs/gitlab/*.yaml).
 func WriteSpecFiles(specDir string) error {
-	// Create GitHub spec directory and write spec file
-	githubDir := filepath.Join(specDir, "github")
-	if err := os.MkdirAll(githubDir, 0750); err != nil {
-		return fmt.Errorf("creating github spec directory %s: %w", githubDir, err)
-	}
+	return fs.WalkDir(embeddedSpecs, "specs", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
 
-	githubSpecPath := filepath.Join(githubDir, GitHubSpecFile)
-	if err := os.WriteFile(githubSpecPath, githubBranchRulesSpec, 0600); err != nil {
-		return fmt.Errorf("writing github spec file %s: %w", githubSpecPath, err)
-	}
+		// Skip the root "specs" directory itself
+		if path == "specs" {
+			return nil
+		}
 
-	// Create GitLab spec directory and write spec file
-	gitlabDir := filepath.Join(specDir, "gitlab")
-	if err := os.MkdirAll(gitlabDir, 0750); err != nil {
-		return fmt.Errorf("creating gitlab spec directory %s: %w", gitlabDir, err)
-	}
+		// Get relative path from "specs/" (e.g., "github/branch-rules.yaml")
+		relPath := strings.TrimPrefix(path, "specs/")
+		targetPath := filepath.Join(specDir, relPath)
 
-	gitlabSpecPath := filepath.Join(gitlabDir, GitLabSpecFile)
-	if err := os.WriteFile(gitlabSpecPath, gitlabBranchProtectionSpec, 0600); err != nil {
-		return fmt.Errorf("writing gitlab spec file %s: %w", gitlabSpecPath, err)
-	}
+		if d.IsDir() {
+			// Create directory
+			if err := os.MkdirAll(targetPath, 0750); err != nil {
+				return fmt.Errorf("creating spec directory %s: %w", targetPath, err)
+			}
+			return nil
+		}
 
-	return nil
+		// Read embedded file content
+		content, err := embeddedSpecs.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("reading embedded spec %s: %w", path, err)
+		}
+
+		// Write to target location
+		if err := os.WriteFile(targetPath, content, 0600); err != nil {
+			return fmt.Errorf("writing spec file %s: %w", targetPath, err)
+		}
+
+		return nil
+	})
 }
 
 // ResolveSpecPath resolves a spec reference to an absolute path.

--- a/cmd/ampel-plugin/scan/scan_test.go
+++ b/cmd/ampel-plugin/scan/scan_test.go
@@ -98,7 +98,7 @@ func (m *mockRunner) run(name string, args ...string) ([]byte, error) {
 }
 
 func TestConstructSnappyCommand(t *testing.T) {
-	// Test GitHub spec
+	// Test GitHub branch-rules spec
 	args := constructSnappyCommand("github", "github.com", "myorg", "myrepo", "main", "/specs/github/branch-rules.yaml")
 	require.Equal(t, []string{
 		"snappy", "snap",
@@ -109,7 +109,7 @@ func TestConstructSnappyCommand(t *testing.T) {
 		"--attest",
 	}, args)
 
-	// Test GitLab spec
+	// Test GitLab branch-protection spec
 	argsGitLab := constructSnappyCommand("gitlab", "gitlab.com", "mygroup", "myproject", "main", "builtin:gitlab/branch-protection.yaml")
 	require.Equal(t, []string{
 		"snappy", "snap",
@@ -186,21 +186,27 @@ func TestWriteSpecFiles(t *testing.T) {
 	err := WriteSpecFiles(dir)
 	require.NoError(t, err)
 
-	// Test GitHub spec file
-	githubSpecPath := filepath.Join(dir, "github", GitHubSpecFile)
+	// Test GitHub branch-rules spec file
+	githubSpecPath := filepath.Join(dir, "github", "branch-rules.yaml")
 	githubData, err := os.ReadFile(githubSpecPath)
 	require.NoError(t, err)
 	require.Contains(t, string(githubData), "branch-rules.yaml")
 	require.Contains(t, string(githubData), "${ORG}")
 
-	// Test GitLab spec file
-	gitlabSpecPath := filepath.Join(dir, "gitlab", GitLabSpecFile)
-	gitlabData, err := os.ReadFile(gitlabSpecPath)
+	// Test GitLab branch-protection spec files
+	gitlabBranchPath := filepath.Join(dir, "gitlab", "branch-protection.yaml")
+	gitlabBranchData, err := os.ReadFile(gitlabBranchPath)
 	require.NoError(t, err)
-	require.Contains(t, string(gitlabData), "branch-protection.yaml")
-	require.Contains(t, string(gitlabData), "${HOST}")
-	require.Contains(t, string(gitlabData), "${GROUP}")
-	require.Contains(t, string(gitlabData), "${PROJECT}")
+	require.Contains(t, string(gitlabBranchData), "branch-protection.yaml")
+	require.Contains(t, string(gitlabBranchData), "${HOST}")
+	require.Contains(t, string(gitlabBranchData), "${GROUP}")
+	require.Contains(t, string(gitlabBranchData), "${PROJECT}")
+
+	// Test GitLab project-approvals spec file
+	gitlabApprovalsPath := filepath.Join(dir, "gitlab", "project-approvals.yaml")
+	gitlabApprovalsData, err := os.ReadFile(gitlabApprovalsPath)
+	require.NoError(t, err)
+	require.Contains(t, string(gitlabApprovalsData), "project-approvals.yaml")
 }
 
 func TestResolveSpecPath(t *testing.T) {


### PR DESCRIPTION
This PR updated the Ampel granular policy file BP-02 to align to changes here: https://github.com/complytime/org-infra/pull/169 

Also, with more specs involved, updated the way to write spec files to avoid hard-coded filenames. 