### PR TITLE
feat: add target ID into scan result summary

### DIFF
--- a/cmd/complyctl/cli/scan.go
+++ b/cmd/complyctl/cli/scan.go
@@ -230,6 +230,7 @@ func (o *scanOptions) run(ctx context.Context) error {
 	scanSpin.Start()
 
 	var allAssessments []plugin.AssessmentLog
+	var assessmentTargets []string
 
 	for _, target := range targets {
 		if !slices.Contains(target.Policies, eid) {
@@ -254,6 +255,9 @@ func (o *scanOptions) run(ctx context.Context) error {
 
 		eval.AddTarget(assessments)
 		allAssessments = append(allAssessments, assessments...)
+		for range assessments {
+			assessmentTargets = append(assessmentTargets, target.ID)
+		}
 	}
 
 	scanSpin.Stop()
@@ -289,7 +293,7 @@ func (o *scanOptions) run(ctx context.Context) error {
 		fmt.Printf("OSCAL report written: %s\n\n", oscalPath)
 	}
 
-	fmt.Println(output.FormatScanSummary(allAssessments, reqToControl, eid, targetIDs))
+	fmt.Println(output.FormatScanSummary(allAssessments, assessmentTargets, reqToControl, eid, targetIDs))
 	return nil
 }
 

--- a/internal/output/scan_summary.go
+++ b/internal/output/scan_summary.go
@@ -15,6 +15,7 @@ import (
 )
 
 type nonPassingEntry struct {
+	targetID      string
 	requirementID string
 	controlID     string
 	result        gemara.Result
@@ -55,7 +56,7 @@ func matchingStepMessage(steps []plugin.Step, target gemara.Result) string {
 // FormatScanSummary builds a report-style post-scan output per FR-037.
 // Intro text, plain aligned text table of non-passing results, compact totals.
 // See spec.md Session 2026-02-26e.
-func FormatScanSummary(assessments []plugin.AssessmentLog, reqToControl map[string]string, policyID string, targetIDs []string) string {
+func FormatScanSummary(assessments []plugin.AssessmentLog, assessmentTargets []string, reqToControl map[string]string, policyID string, targetIDs []string) string {
 	var passCount, failCount, skipCount, errCount int
 	var entries []nonPassingEntry
 
@@ -68,12 +69,18 @@ func FormatScanSummary(assessments []plugin.AssessmentLog, reqToControl map[stri
 			ctrlID = "-"
 		}
 
+		targetID := "-"
+		if i < len(assessmentTargets) {
+			targetID = assessmentTargets[i]
+		}
+
 		switch result {
 		case gemara.Passed:
 			passCount++
 		case gemara.Failed:
 			failCount++
 			entries = append(entries, nonPassingEntry{
+				targetID:      targetID,
 				requirementID: a.RequirementID,
 				controlID:     ctrlID,
 				result:        result,
@@ -83,6 +90,7 @@ func FormatScanSummary(assessments []plugin.AssessmentLog, reqToControl map[stri
 		case gemara.NotApplicable, gemara.NotRun:
 			skipCount++
 			entries = append(entries, nonPassingEntry{
+				targetID:      targetID,
 				requirementID: a.RequirementID,
 				controlID:     ctrlID,
 				result:        result,
@@ -92,6 +100,7 @@ func FormatScanSummary(assessments []plugin.AssessmentLog, reqToControl map[stri
 		default:
 			errCount++
 			entries = append(entries, nonPassingEntry{
+				targetID:      targetID,
 				requirementID: a.RequirementID,
 				controlID:     ctrlID,
 				result:        result,
@@ -109,10 +118,10 @@ func FormatScanSummary(assessments []plugin.AssessmentLog, reqToControl map[stri
 	intro := fmt.Sprintf("Scan: %s | Target: %s | %d requirements",
 		policyID, strings.Join(targetIDs, ", "), total)
 
-	headers := []string{"REQUIREMENT ID", "CONTROL ID", "STATUS", "MESSAGE"}
+	headers := []string{"TARGET ID", "REQUIREMENT ID", "CONTROL ID", "STATUS", "MESSAGE"}
 	var rows [][]string
 	for _, e := range entries {
-		rows = append(rows, []string{e.requirementID, e.controlID, e.emoji, e.message})
+		rows = append(rows, []string{e.targetID, e.requirementID, e.controlID, e.emoji, e.message})
 	}
 
 	conclusion := fmt.Sprintf("%d requirements: %d passed, %d failed, %d skipped, %d error",

--- a/internal/output/scan_summary_test.go
+++ b/internal/output/scan_summary_test.go
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package output
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/complytime/complyctl/pkg/plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatScanSummary_SingleTarget(t *testing.T) {
+	assessments := []plugin.AssessmentLog{
+		{
+			RequirementID: "REQ-1",
+			Steps: []plugin.Step{
+				{Result: plugin.ResultPassed, Message: "Test passed"},
+			},
+		},
+		{
+			RequirementID: "REQ-2",
+			Steps: []plugin.Step{
+				{Result: plugin.ResultFailed, Message: "Test failed"},
+			},
+		},
+	}
+	assessmentTargets := []string{"target1", "target1"}
+	reqToControl := map[string]string{
+		"REQ-1": "CTRL-1",
+		"REQ-2": "CTRL-2",
+	}
+	policyID := "test-policy"
+	targetIDs := []string{"target1"}
+
+	output := FormatScanSummary(assessments, assessmentTargets, reqToControl, policyID, targetIDs)
+
+	assert.Contains(t, output, "Scan: test-policy")
+	assert.Contains(t, output, "Target: target1")
+	assert.Contains(t, output, "2 requirements")
+	assert.Contains(t, output, "TARGET ID")
+	assert.Contains(t, output, "REQUIREMENT ID")
+	assert.Contains(t, output, "target1")
+	assert.Contains(t, output, "REQ-2")
+	assert.Contains(t, output, "1 passed, 1 failed")
+}
+
+func TestFormatScanSummary_MultipleTargets(t *testing.T) {
+	assessments := []plugin.AssessmentLog{
+		{
+			RequirementID: "REQ-1",
+			Steps: []plugin.Step{
+				{Result: plugin.ResultFailed, Message: "Target A failed"},
+			},
+		},
+		{
+			RequirementID: "REQ-1",
+			Steps: []plugin.Step{
+				{Result: plugin.ResultFailed, Message: "Target B failed"},
+			},
+		},
+	}
+	assessmentTargets := []string{"targetA", "targetB"}
+	reqToControl := map[string]string{"REQ-1": "CTRL-1"}
+	policyID := "multi-target-policy"
+	targetIDs := []string{"targetA", "targetB"}
+
+	output := FormatScanSummary(assessments, assessmentTargets, reqToControl, policyID, targetIDs)
+
+	assert.Contains(t, output, "Target: targetA, targetB")
+	assert.Contains(t, output, "2 requirements")
+	lines := strings.Split(output, "\n")
+	var targetAFound, targetBFound bool
+	for _, line := range lines {
+		if strings.Contains(line, "targetA") && strings.Contains(line, "REQ-1") {
+			targetAFound = true
+		}
+		if strings.Contains(line, "targetB") && strings.Contains(line, "REQ-1") {
+			targetBFound = true
+		}
+	}
+	assert.True(t, targetAFound, "targetA should appear in output")
+	assert.True(t, targetBFound, "targetB should appear in output")
+}
+
+func TestFormatScanSummary_AllPassed(t *testing.T) {
+	assessments := []plugin.AssessmentLog{
+		{
+			RequirementID: "REQ-1",
+			Steps:         []plugin.Step{{Result: plugin.ResultPassed, Message: "OK"}},
+		},
+		{
+			RequirementID: "REQ-2",
+			Steps:         []plugin.Step{{Result: plugin.ResultPassed, Message: "OK"}},
+		},
+	}
+	assessmentTargets := []string{"target1", "target1"}
+	reqToControl := map[string]string{}
+	policyID := "passing-policy"
+	targetIDs := []string{"target1"}
+
+	output := FormatScanSummary(assessments, assessmentTargets, reqToControl, policyID, targetIDs)
+
+	assert.Contains(t, output, "2 requirements: 2 passed, 0 failed, 0 skipped, 0 error")
+	assert.NotContains(t, output, "TARGET ID")
+}
+
+func TestFormatScanSummary_MissingTargetID(t *testing.T) {
+	assessments := []plugin.AssessmentLog{
+		{
+			RequirementID: "REQ-1",
+			Steps:         []plugin.Step{{Result: plugin.ResultFailed, Message: "Failed"}},
+		},
+	}
+	assessmentTargets := []string{}
+	reqToControl := map[string]string{"REQ-1": "CTRL-1"}
+	policyID := "test"
+	targetIDs := []string{"target1"}
+
+	output := FormatScanSummary(assessments, assessmentTargets, reqToControl, policyID, targetIDs)
+
+	require.Contains(t, output, "1 requirements")
+	assert.Contains(t, output, "-")
+}
+
+func TestFormatScanSummary_ControlIDMissing(t *testing.T) {
+	assessments := []plugin.AssessmentLog{
+		{
+			RequirementID: "REQ-UNKNOWN",
+			Steps:         []plugin.Step{{Result: plugin.ResultFailed, Message: "No control"}},
+		},
+	}
+	assessmentTargets := []string{"target1"}
+	reqToControl := map[string]string{}
+	policyID := "test"
+	targetIDs := []string{"target1"}
+
+	output := FormatScanSummary(assessments, assessmentTargets, reqToControl, policyID, targetIDs)
+
+	lines := strings.Split(output, "\n")
+	var foundDash bool
+	for _, line := range lines {
+		if strings.Contains(line, "REQ-UNKNOWN") && strings.Contains(line, "target1") {
+			parts := strings.Fields(line)
+			for i, part := range parts {
+				if part == "REQ-UNKNOWN" && i+1 < len(parts) && parts[i+1] == "-" {
+					foundDash = true
+					break
+				}
+			}
+		}
+	}
+	assert.True(t, foundDash, "Should show '-' for missing control ID")
+}


### PR DESCRIPTION
## Summary
_This PR adds the scan target ID into the scan result summary, to clarify the target when requirement verrifation failed._

## Review Hints
Scan: ampel-bp | Target: complyctl, agcontent, psc-governance | 12 requirements
Before:
```
REQUIREMENT ID  CONTROL ID  STATUS  MESSAGE
BP-1.01         BP-1        ❌       Direct pushes are enabled so Pull/Merge requests are not required.
BP-1.01         BP-1        ❌       Direct pushes are enabled so Pull/Merge requests are not required.
BP-4.01         BP-4        ❌       Admins can bypass branch protection by pushing directly or force-pushing
```

After:
```
TARGET ID       REQUIREMENT ID  CONTROL ID  STATUS  MESSAGE
complyctl       BP-1.01         BP-1        ❌       Direct pushes are enabled so Pull/Merge requests are not required.
psc-governance  BP-1.01         BP-1        ❌       Direct pushes are enabled so Pull/Merge requests are not required.
psc-governance  BP-4.01         BP-4        ❌       Admins can bypass branch protection by pushing directly or force-pushing

```