### PR TITLE
chore: update codeql and respective version comment

### DIFF
--- a/.github/workflows/behavioral_assessment.yml
+++ b/.github/workflows/behavioral_assessment.yml
@@ -31,7 +31,7 @@ jobs:
               run: make test-behavioral
 
             - name: Upload SARIF to Code Scanning
-              uses: github/codeql-action/upload-sarif@45580472a5bb82c4681c4ac726cfdb60060c2ee1 # v3
+              uses: github/codeql-action/upload-sarif@c793b717bc78562f491db7b0e93a3a178b099162 # v4.32.5
               if: always()
               with:
                   sarif_file: governance/reports/behavioral-report.sarif.json


### PR DESCRIPTION
## Summary

Replaces the https://github.com/complytime/complyctl/pull/398 in order to keep the commented version aligned.

## Related Issues

- https://github.com/complytime/complyctl/pull/398

## Review Hints

- https://github.com/complytime/complyctl/pull/398#issuecomment-4010073222