### PR TITLE
chore: improve tenets code in BP-02

### DIFF
--- a/cmd/ampel-plugin/convert/testdata/ampel-bundle-expected-full.json
+++ b/cmd/ampel-plugin/convert/testdata/ampel-bundle-expected-full.json
@@ -14,8 +14,16 @@
       "meta": {
         "description": "Validate branch protection settings require pull/merge requests via GitHub or GitLab API",
         "controls": [
-          { "framework": "repo-branch-protection", "class": "source-code", "id": "BP-1" },
-          { "framework": "OSPS", "class": "OSPS-QA", "id": "07" }
+          {
+            "framework": "repo-branch-protection",
+            "class": "source-code",
+            "id": "BP-1"
+          },
+          {
+            "framework": "OSPS",
+            "class": "OSPS-QA",
+            "id": "07"
+          }
         ]
       },
       "tenets": [
@@ -43,14 +51,22 @@
       "meta": {
         "description": "Validate minimum approval count and prevent self-approval via GitHub or GitLab API",
         "controls": [
-          { "framework": "repo-branch-protection", "class": "source-code", "id": "BP-2" },
-          { "framework": "OSPS", "class": "OSPS-QA", "id": "07" }
+          {
+            "framework": "repo-branch-protection",
+            "class": "source-code",
+            "id": "BP-2"
+          },
+          {
+            "framework": "OSPS",
+            "class": "OSPS-QA",
+            "id": "07"
+          }
         ]
       },
       "tenets": [
         {
           "id": "01",
-          "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.required_approving_review_count >= 1)) || (has(predicates[0].data.values.approvals_before_merge) && predicates[0].data.values.approvals_before_merge >= 1)",
+          "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.required_approving_review_count >= 1)) || (has(predicates[0].data.values) && type(predicates[0].data.values) != list && has(predicates[0].data.values.approvals_before_merge) && predicates[0].data.values.approvals_before_merge >= 1)",
           "predicates": {
             "types": [
               "http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml",
@@ -67,7 +83,7 @@
         },
         {
           "id": "02",
-          "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.dismiss_stale_reviews_on_push == true)) || (has(predicates[0].data.values.reset_approvals_on_push) && predicates[0].data.values.reset_approvals_on_push == true)",
+          "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.dismiss_stale_reviews_on_push == true)) || (has(predicates[0].data.values) && type(predicates[0].data.values) != list && has(predicates[0].data.values.reset_approvals_on_push) && predicates[0].data.values.reset_approvals_on_push == true)",
           "predicates": {
             "types": [
               "http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml",
@@ -84,7 +100,7 @@
         },
         {
           "id": "03",
-          "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.require_last_push_approval == true)) || (has(predicates[0].data.values.merge_requests_disable_committers_approval) && predicates[0].data.values.merge_requests_disable_committers_approval == true)",
+          "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.require_last_push_approval == true)) || (has(predicates[0].data.values) && type(predicates[0].data.values) != list && has(predicates[0].data.values.merge_requests_disable_committers_approval) && predicates[0].data.values.merge_requests_disable_committers_approval == true)",
           "predicates": {
             "types": [
               "http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml",
@@ -106,8 +122,16 @@
       "meta": {
         "description": "Validate force push blocking is enabled on protected branches via GitHub or GitLab API",
         "controls": [
-          { "framework": "repo-branch-protection", "class": "source-code", "id": "BP-3" },
-          { "framework": "OSPS", "class": "OSPS-QA", "id": "07" }
+          {
+            "framework": "repo-branch-protection",
+            "class": "source-code",
+            "id": "BP-3"
+          },
+          {
+            "framework": "OSPS",
+            "class": "OSPS-QA",
+            "id": "07"
+          }
         ]
       },
       "tenets": [
@@ -135,8 +159,16 @@
       "meta": {
         "description": "Validate admin bypass prevention is enabled via GitHub or GitLab API",
         "controls": [
-          { "framework": "repo-branch-protection", "class": "source-code", "id": "BP-4" },
-          { "framework": "OSPS", "class": "OSPS-QA", "id": "07" }
+          {
+            "framework": "repo-branch-protection",
+            "class": "source-code",
+            "id": "BP-4"
+          },
+          {
+            "framework": "OSPS",
+            "class": "OSPS-QA",
+            "id": "07"
+          }
         ]
       },
       "tenets": [
@@ -164,7 +196,11 @@
       "meta": {
         "description": "Validate code owner review requirements are enabled when CODEOWNERS file exists via GitHub or GitLab API",
         "controls": [
-          { "framework": "repo-branch-protection", "class": "source-code", "id": "BP-5" }
+          {
+            "framework": "repo-branch-protection",
+            "class": "source-code",
+            "id": "BP-5"
+          }
         ]
       },
       "tenets": [

--- a/cmd/ampel-plugin/convert/testdata/policies/BP-02.01-minimum-approvals.json
+++ b/cmd/ampel-plugin/convert/testdata/policies/BP-02.01-minimum-approvals.json
@@ -10,7 +10,7 @@
   "tenets": [
     {
       "id": "01",
-      "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.required_approving_review_count >= 1)) || (has(predicates[0].data.values.approvals_before_merge) && predicates[0].data.values.approvals_before_merge >= 1)",
+      "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.required_approving_review_count >= 1)) || (has(predicates[0].data.values) && type(predicates[0].data.values) != list && has(predicates[0].data.values.approvals_before_merge) && predicates[0].data.values.approvals_before_merge >= 1)",
       "predicates": {
         "types": [
           "http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml",
@@ -27,7 +27,7 @@
     },
     {
       "id": "02",
-      "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.dismiss_stale_reviews_on_push == true)) || (has(predicates[0].data.values.reset_approvals_on_push) && predicates[0].data.values.reset_approvals_on_push == true)",
+      "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.dismiss_stale_reviews_on_push == true)) || (has(predicates[0].data.values) && type(predicates[0].data.values) != list && has(predicates[0].data.values.reset_approvals_on_push) && predicates[0].data.values.reset_approvals_on_push == true)",
       "predicates": {
         "types": [
           "http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml",
@@ -44,7 +44,7 @@
     },
     {
       "id": "03",
-      "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.require_last_push_approval == true)) || (has(predicates[0].data.values.merge_requests_disable_committers_approval) && predicates[0].data.values.merge_requests_disable_committers_approval == true)",
+      "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"pull_request\" && rule.parameters.require_last_push_approval == true)) || (has(predicates[0].data.values) && type(predicates[0].data.values) != list && has(predicates[0].data.values.merge_requests_disable_committers_approval) && predicates[0].data.values.merge_requests_disable_committers_approval == true)",
       "predicates": {
         "types": [
           "http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml",


### PR DESCRIPTION
## Summary
There is an error in running scan on github repos with speicified settings, error from BP-02 assessment, 
Evaluating policy code: CEL evaluation error 
Guidance: unsupported index type 'string' in list

This is because when the tenets code checking for GitHub is failed in BP-02, it will continue the checking for GitLab, which should be not and this will raise such an error, thus here adds more restrictions on code checking for GitLab to avoid this corner case.