### PR TITLE
chore(spec): mark all 004-providers-repository-split tasks complete

### DIFF
--- a/specs/004-providers-repository-split/tasks.md
+++ b/specs/004-providers-repository-split/tasks.md
@@ -101,7 +101,7 @@ directive.
 **Purpose**: Vendor dependencies in `complytime-providers` and prepare CI for publishing release artifacts.
 
 - [x] T037 [US2] Run `go mod vendor` in `complytime-providers/` to create the `vendor/` tree
-- [ ] T038 [US2] Remove `replace` directive from `complytime-providers/go.mod`; update `require github.com/complytime/complyctl` to the tagged release version from Phase 1 checkpoint; re-run `go mod vendor`
+- [x] T038 [US2] Remove `replace` directive from `complytime-providers/go.mod`; update `require github.com/complytime/complyctl` to the tagged release version from Phase 1 checkpoint; re-run `go mod vendor`
 - [x] T039 [US2] Create `.github/workflows/ci.yml` in `complytime-providers/` with jobs: build both providers, run tests, and publish release artifacts (`complyctl-provider-openscap` and `complyctl-provider-ampel`) on tag push
 - [x] T040 [US1][US3] Verify `make build` in `complytime-providers/` produces both `complyctl-provider-openscap` and `complyctl-provider-ampel` binaries with no local complyctl source tree present
 
@@ -129,10 +129,10 @@ to download provider binary from `complytime-providers` release artifact.
 - [x] T048 [US4] Confirm `SC-002`: full-text search of complyctl for "plugin" (case-insensitive) in Go sources, Makefile, CI workflows, and docs returns zero provider-concept matches (library name `hashicorp/go-plugin` and proto package `complyctl.plugin.v1` are exempt)
 - [x] T049 [US2] Confirm `SC-003`: both providers build from `complytime-providers` without a local complyctl source tree
 - [x] T050 [US1] Confirm `SC-004`: all complyctl unit tests pass (`go test ./...`)
-- [ ] T051 [US3] Confirm `SC-005`: complyctl E2E tests pass using a provider binary built from `complytime-providers`
-- [ ] T052 [US3] Confirm `SC-006`: a binary built from `complytime-providers` is discovered and invoked by `complyctl scan` correctly (binary name and discovery paths unchanged)
+- [x] T051 [US3] Confirm `SC-005`: complyctl E2E tests pass using a provider binary built from `complytime-providers`
+- [x] T052 [US3] Confirm `SC-006`: a binary built from `complytime-providers` is discovered and invoked by `complyctl scan` correctly (binary name and discovery paths unchanged)
 - [x] T053 [US1] Confirm `SC-007`: `make build` in complyctl produces only the `complyctl` CLI binary
-- [ ] T054 [US1] Confirm `SC-008`: complyctl CI pipeline passes without modification to any step that previously built or tested provider source directories
+- [x] T054 [US1] Confirm `SC-008`: complyctl CI pipeline passes without modification to any step that previously built or tested provider source directories
 
 ---
 


### PR DESCRIPTION
## Summary

Marks all 54 tasks in \`specs/004-providers-repository-split/tasks.md\` as complete now that the full migration has landed:

- **T038**: \`replace\` directive removed from \`complytime-providers/go.mod\`; complyctl pinned to pseudo-version \`v1.0.0-alpha.0.0.20260423124442-eafccc5f4f2b\` (complytime-providers PR #4).
- **T051**: \`SC-005\` confirmed — complyctl e2e-test passes on main post-merge.
- **T052**: \`SC-006\` confirmed — provider binary discovery works correctly (e2e CI validates end-to-end invocation).
- **T054**: \`SC-008\` confirmed — complyctl CI pipeline passes cleanly on main with no provider source directories present.

Also closes issues resolved by the migration:
- Closes #483 (OpenSCAP and Ampel plugins removed from complyctl)
- Closes #457 (both complyctl and complytime-providers working properly)

## Related Issues

- Closes #483
- Closes #457
- https://github.com/complytime/complyctl/issues/447

## Review Hints

- This PR is a single-file documentation change — only \`specs/004-providers-repository-split/tasks.md\` is modified (four checkboxes flipped from `[ ]` to `[x]`).
- All substantive implementation changes landed in PR #474 (complyctl) and complytime-providers PRs #2 and #4.