### PR TITLE
feat(registry): resolve policy definitions by tag or digest

### DIFF
--- a/cmd/complyctl/cli/doctor.go
+++ b/cmd/complyctl/cli/doctor.go
@@ -46,7 +46,7 @@ func (r *registryVersionResolver) ResolveLatestVersion(registryURL, repository s
 	client := registry.NewClient(registryURL, credFunc)
 	ctx, cancel := context.WithTimeout(context.Background(), r.timeout)
 	defer cancel()
-	_, version, err := client.DefinitionVersion(ctx, repository)
+	_, version, err := client.DefinitionVersion(ctx, repository, "")
 	if err != nil {
 		return "", err
 	}

--- a/cmd/complyctl/cli/get.go
+++ b/cmd/complyctl/cli/get.go
@@ -132,7 +132,7 @@ func syncSinglePolicy(ctx context.Context, cacheMgr *cache.Cache, state *cache.S
 
 func resolveLatestVersion(ctx context.Context, client *registry.Client, repository, policyID string) string {
 	logger.Info("Resolving latest version", "policy", policyID)
-	_, resolvedVersion, resolveErr := client.DefinitionVersion(ctx, repository)
+	_, resolvedVersion, resolveErr := client.DefinitionVersion(ctx, repository, "")
 	if resolveErr != nil {
 		logger.Warn("Version resolution failed, falling back to 'latest'",
 			"policy", policyID, "error", resolveErr)

--- a/internal/cache/cachetest/mock_source.go
+++ b/internal/cache/cachetest/mock_source.go
@@ -46,8 +46,9 @@ func (m *MockPolicySource) SeedPolicy(policyID, version, digestStr string) {
 	}
 }
 
-// DefinitionVersion returns digest and version for a mock policy
-func (m *MockPolicySource) DefinitionVersion(_ context.Context, policyID string) (string, string, error) {
+// DefinitionVersion returns digest and version for a mock policy.
+// ref is ignored; test data is keyed by policyID only.
+func (m *MockPolicySource) DefinitionVersion(_ context.Context, policyID, _ string) (string, string, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	p, ok := m.policies[policyID]

--- a/internal/cache/source.go
+++ b/internal/cache/source.go
@@ -14,8 +14,9 @@ import (
 )
 
 // PolicySource abstracts remote policy access for sync operations.
+// ref is empty or "latest" to resolve the latest tag; otherwise a specific tag or sha256:... digest.
 type PolicySource interface {
-	DefinitionVersion(ctx context.Context, policyID string) (digest string, version string, err error)
+	DefinitionVersion(ctx context.Context, policyID, ref string) (digest string, version string, err error)
 	CopyPolicy(ctx context.Context, policyID, tag string, dst *ocistore.Store) (ocispec.Descriptor, error)
 }
 
@@ -29,8 +30,8 @@ func NewRegistrySource(client *registry.Client) *RegistrySource {
 	return &RegistrySource{client: client}
 }
 
-func (s *RegistrySource) DefinitionVersion(ctx context.Context, policyID string) (string, string, error) {
-	return s.client.DefinitionVersion(ctx, policyID)
+func (s *RegistrySource) DefinitionVersion(ctx context.Context, policyID, ref string) (string, string, error) {
+	return s.client.DefinitionVersion(ctx, policyID, ref)
 }
 
 func (s *RegistrySource) CopyPolicy(ctx context.Context, policyID, tag string, dst *ocistore.Store) (ocispec.Descriptor, error) {

--- a/internal/cache/sync.go
+++ b/internal/cache/sync.go
@@ -30,7 +30,12 @@ func (s *Sync) SyncPolicy(ctx context.Context, policyID, version string) error {
 		return fmt.Errorf("policy ID cannot be empty")
 	}
 
-	remoteDigest, remoteVersion, err := s.source.DefinitionVersion(ctx, policyID)
+	// Resolve the requested ref (tag/digest) or "latest" when version is empty.
+	resolveRef := version
+	if resolveRef == "" {
+		resolveRef = "latest"
+	}
+	remoteDigest, remoteVersion, err := s.source.DefinitionVersion(ctx, policyID, resolveRef)
 	if err != nil {
 		return fmt.Errorf(
 			"policy %s: registry unreachable: %w (cached data may still be available)",

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -14,8 +14,10 @@ import (
 )
 
 // Fetcher abstracts registry access for testing without a live OCI registry.
+// ref is empty or "latest" to resolve the latest tag; otherwise a tag (e.g. v1) or
+// a manifest digest (sha256:...).
 type Fetcher interface {
-	DefinitionVersion(ctx context.Context, modulePath string) (string, string, error)
+	DefinitionVersion(ctx context.Context, modulePath, ref string) (string, string, error)
 }
 
 // Client provides OCI registry access with credential-based auth via oras-go.
@@ -44,22 +46,36 @@ func NewClientWithFetcher(registryURL string, credFunc auth.CredentialFunc, fetc
 	}
 }
 
-func (c *Client) DefinitionVersion(ctx context.Context, modulePath string) (string, string, error) {
+func (c *Client) DefinitionVersion(ctx context.Context, modulePath, ref string) (string, string, error) {
 	if modulePath == "" {
 		return "", "", fmt.Errorf("module path cannot be empty")
 	}
 
 	if c.fetcher != nil {
-		return c.fetcher.DefinitionVersion(ctx, modulePath)
+		return c.fetcher.DefinitionVersion(ctx, modulePath, ref)
 	}
 
-	ref := fmt.Sprintf("%s/%s:latest", c.registryHost(), modulePath)
-	digest, version, err := c.fetchVersion(ctx, ref)
+	ociRef := c.buildModuleOCIReference(modulePath, ref)
+	digest, resolved, err := c.fetchVersion(ctx, ociRef)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to fetch version for %s: %w", modulePath, err)
 	}
 
-	return digest, version, nil
+	return digest, resolved, nil
+}
+
+// buildModuleOCIReference returns a full OCI reference (host/path:tag or host/path@digest).
+// ref is empty, "latest", a tag, or a sha256:... manifest digest.
+func (c *Client) buildModuleOCIReference(modulePath, ref string) string {
+	host := c.registryHost()
+	if ref != "" && strings.HasPrefix(ref, "sha256:") {
+		return fmt.Sprintf("%s/%s@%s", host, modulePath, ref)
+	}
+	tag := "latest"
+	if ref != "" && ref != "latest" {
+		tag = ref
+	}
+	return fmt.Sprintf("%s/%s:%s", host, modulePath, tag)
 }
 
 // NewRemoteRepository creates an authenticated oras-go remote.Repository

--- a/internal/registry/client_test.go
+++ b/internal/registry/client_test.go
@@ -18,7 +18,7 @@ func TestClient_DefinitionVersion_WithMockFetcher(t *testing.T) {
 
 	client := registry.NewClientWithFetcher("mock-registry", nil, mock)
 
-	digest, version, err := client.DefinitionVersion(context.Background(), "test-policy")
+	digest, version, err := client.DefinitionVersion(context.Background(), "test-policy", "")
 	require.NoError(t, err)
 	assert.NotEmpty(t, digest)
 	assert.NotEmpty(t, version)
@@ -27,7 +27,7 @@ func TestClient_DefinitionVersion_WithMockFetcher(t *testing.T) {
 func TestClient_DefinitionVersion_EmptyPath(t *testing.T) {
 	client := registry.NewClientWithFetcher("mock-registry", nil, registry.NewMockFetcher())
 
-	_, _, err := client.DefinitionVersion(context.Background(), "")
+	_, _, err := client.DefinitionVersion(context.Background(), "", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "module path cannot be empty")
 }
@@ -36,7 +36,18 @@ func TestClient_DefinitionVersion_NotFound(t *testing.T) {
 	mock := registry.NewMockFetcher()
 	client := registry.NewClientWithFetcher("mock-registry", nil, mock)
 
-	_, _, err := client.DefinitionVersion(context.Background(), "nonexistent")
+	_, _, err := client.DefinitionVersion(context.Background(), "nonexistent", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestClient_DefinitionVersion_ExplicitRef(t *testing.T) {
+	mock := registry.NewMockFetcher()
+	mock.SeedTestPolicy("test-policy")
+	client := registry.NewClientWithFetcher("mock-registry", nil, mock)
+
+	digest, version, err := client.DefinitionVersion(context.Background(), "test-policy", "v1.0.0")
+	require.NoError(t, err)
+	assert.Equal(t, "v1.0.0", version)
+	assert.Equal(t, "sha256:abc123", digest)
 }

--- a/internal/registry/mock_fetcher_test.go
+++ b/internal/registry/mock_fetcher_test.go
@@ -48,9 +48,9 @@ func (m *MockFetcher) AddPolicy(modulePath, version, digest string, manifest []b
 	}
 }
 
-// DefinitionVersion returns digest and version for modulePath
-func (m *MockFetcher) DefinitionVersion(ctx context.Context, modulePath string) (string, string, error) {
-	_ = ctx
+// DefinitionVersion returns digest and version for modulePath.
+// ref is empty or "latest" to use the "latest" entry; otherwise a specific version key.
+func (m *MockFetcher) DefinitionVersion(_ context.Context, modulePath, ref string) (string, string, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -58,9 +58,16 @@ func (m *MockFetcher) DefinitionVersion(ctx context.Context, modulePath string) 
 	if !ok {
 		return "", "", fmt.Errorf("policy %s not found", modulePath)
 	}
-	p := versions["latest"]
+	key := "latest"
+	if ref != "" && ref != "latest" {
+		key = ref
+	}
+	p := versions[key]
+	if p == nil && (ref == "" || ref == "latest") {
+		p = versions["latest"]
+	}
 	if p == nil {
-		return "", "", fmt.Errorf("policy %s has no latest version", modulePath)
+		return "", "", fmt.Errorf("policy %s not found for ref %q", modulePath, ref)
 	}
 	return p.Digest, p.Version, nil
 }


### PR DESCRIPTION
## Summary

- Extend `DefinitionVersion` (registry client, `PolicySource`, mocks) with a `ref` argument so policies can be resolved by **tag** or **`sha256:...` manifest digest**, not only `:latest`.
- `SyncPolicy` passes the configured version, defaulting the empty case to `latest` for resolution.
- CLI `doctor` / `get` call sites pass an empty ref for existing “resolve latest” behavior.
- Tests: updated mocks, `TestClient_DefinitionVersion_ExplicitRef` for a specific tag.

## Notes

- `complytime.yaml` local OCI test edits were **not** included; the sample file remains the upstream default.

**Branch:** `sonupreetam:feat/registry-definition-version-ref` → `complytime/complyctl:main` (draft)

Made with [Cursor](https://cursor.com)