### PR TITLE
feat: replace --format otel with COMPLYTIME_EXPORT_ENABLED env var

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,3 +273,5 @@ packages organized by domain responsibility.
 - 005-rpm-packaging-ci: Added Go 1.25 + go-rpm-macros, Packit, Testing Farm (TMT/FMF)
 
 - 004-providers-repository-split: Providers (openscap, ampel) migrated to `complytime-providers`; `pkg/plugin/` renamed to `pkg/provider/`; all "plugin" terminology updated to "provider"
+
+- envvar-otel-export: **BREAKING** — `--format otel` removed; export now triggered via `COMPLYTIME_EXPORT_ENABLED=true` env var. Export works alongside any `--format` flag.

--- a/README.md
+++ b/README.md
@@ -134,12 +134,19 @@ complyctl scan --policy-id nist-800-53-r5 --format pretty
 
 # SARIF for security tooling
 complyctl scan --policy-id nist-800-53-r5 --format sarif
+
+# Export evidence to Beacon collector (with optional format report)
+COMPLYTIME_EXPORT_ENABLED=true complyctl scan --policy-id nist-800-53-r5 --format sarif
 ```
 
 | Flag | Short | Description |
 |:---|:---|:---|
 | `--policy-id` | `-p` | Policy ID to scan (required) |
 | `--format` | `-f` | Output format: `oscal`, `pretty`, `sarif` |
+
+| Environment Variable | Description |
+|:---|:---|
+| `COMPLYTIME_EXPORT_ENABLED` | Set to `true` to export evidence to a Beacon collector after scan. Requires a `collector` section in `complytime.yaml`. |
 
 Output written to `./.complytime/scan/`.
 
@@ -177,6 +184,12 @@ targets:
     variables:
       kubeconfig: /path/to/kubeconfig
       api_token: ${MY_API_TOKEN}
+# collector:                                      # Optional — needed when COMPLYTIME_EXPORT_ENABLED is set
+#   endpoint: "collector.example.com:4317"
+#   auth:
+#     client-id: "${BEACON_CLIENT_ID}"
+#     client-secret: "${BEACON_CLIENT_SECRET}"
+#     token-endpoint: "https://sso.example.com/realms/comply/protocol/openid-connect/token"
 ```
 
 | Field | Description |
@@ -187,6 +200,8 @@ targets:
 | `targets[].id` | Scan target identifier |
 | `targets[].policies` | List of effective policy IDs to evaluate against this target |
 | `targets[].variables` | Provider-specific key-value pairs; supports `${VAR}` env substitution |
+| `collector.endpoint` | Beacon collector OTLP endpoint (host:port) |
+| `collector.auth` | Optional OIDC client credentials for collector authentication |
 
 ## Contributing
 

--- a/api/plugin/plugin.proto
+++ b/api/plugin/plugin.proto
@@ -25,7 +25,7 @@ service Plugin {
   rpc Describe(DescribeRequest) returns (DescribeResponse);
 
   // Export ships scan evidence to a Beacon collector via ProofWatch.
-  // Called during `complyctl scan --format otel` after scan completes.
+  // Called during `complyctl scan` when COMPLYTIME_EXPORT_ENABLED is set, after scan completes.
   // Only plugins that declare supports_export=true in DescribeResponse
   // will receive this call.
   rpc Export(ExportRequest) returns (ExportResponse);

--- a/api/plugin/plugin_grpc.pb.go
+++ b/api/plugin/plugin_grpc.pb.go
@@ -47,7 +47,7 @@ type PluginClient interface {
 	// requirements. Called during plugin discovery and doctor diagnostics.
 	Describe(ctx context.Context, in *DescribeRequest, opts ...grpc.CallOption) (*DescribeResponse, error)
 	// Export ships scan evidence to a Beacon collector via ProofWatch.
-	// Called during `complyctl scan --format otel` after scan completes.
+	// Called during `complyctl scan` when COMPLYTIME_EXPORT_ENABLED is set, after scan completes.
 	// Only plugins that declare supports_export=true in DescribeResponse
 	// will receive this call.
 	Export(ctx context.Context, in *ExportRequest, opts ...grpc.CallOption) (*ExportResponse, error)
@@ -118,7 +118,7 @@ type PluginServer interface {
 	// requirements. Called during plugin discovery and doctor diagnostics.
 	Describe(context.Context, *DescribeRequest) (*DescribeResponse, error)
 	// Export ships scan evidence to a Beacon collector via ProofWatch.
-	// Called during `complyctl scan --format otel` after scan completes.
+	// Called during `complyctl scan` when COMPLYTIME_EXPORT_ENABLED is set, after scan completes.
 	// Only plugins that declare supports_export=true in DescribeResponse
 	// will receive this call.
 	Export(context.Context, *ExportRequest) (*ExportResponse, error)

--- a/cmd/complyctl/cli/cli_test.go
+++ b/cmd/complyctl/cli/cli_test.go
@@ -94,23 +94,92 @@ func TestScanOptions_Validate_InvalidFormat(t *testing.T) {
 }
 
 func TestScanOptions_Validate_ValidFormats(t *testing.T) {
-	for _, f := range []string{"", "oscal", "pretty", "sarif", "otel"} {
+	for _, f := range []string{"", "oscal", "pretty", "sarif"} {
 		o := &scanOptions{format: f}
 		assert.NoError(t, o.validate(), "format %q should be valid", f)
 	}
 }
 
-func TestScanOptions_Run_OtelWithoutCollector(t *testing.T) {
+func TestScanOptions_Run_ExportEnabledWithoutCollector(t *testing.T) {
 	chdirTemp(t)
+	t.Setenv(complytime.ExportEnabledEnvVar, "true")
 	writeWorkspaceConfig(t, minimalConfig)
 	o := &scanOptions{
-		Common:  &Common{},
-		format:  complytime.OutputFormatOTEL,
-		timeout: 5 * time.Second,
+		Common:   &Common{},
+		policyID: "test-policy",
+		timeout:  5 * time.Second,
+		cacheDir: t.TempDir(),
 	}
+	// The scan will fail before reaching export (no cache/providers),
+	// but we verify the export trigger does not cause an early collector error.
+	// The collector validation now happens in runExport(), not in run().
 	err := o.run(context.Background())
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "collector")
+	// Should fail on cache/provider resolution, not on collector config.
+	assert.NotContains(t, err.Error(), "collector")
+}
+
+// --- maybeExport env var parsing ---
+
+func TestMaybeExport_EnvVarParsing(t *testing.T) {
+	tests := []struct {
+		name        string
+		envValue    string
+		setEnv      bool
+		wantExport  bool
+		wantWarning bool
+	}{
+		{name: "unset", setEnv: false, wantExport: false},
+		{name: "empty", envValue: "", setEnv: true, wantExport: false},
+		{name: "true", envValue: "true", setEnv: true, wantExport: true},
+		{name: "TRUE", envValue: "TRUE", setEnv: true, wantExport: true},
+		{name: "True", envValue: "True", setEnv: true, wantExport: true},
+		{name: "1", envValue: "1", setEnv: true, wantExport: true},
+		{name: "t", envValue: "t", setEnv: true, wantExport: true},
+		{name: "T", envValue: "T", setEnv: true, wantExport: true},
+		{name: "false", envValue: "false", setEnv: true, wantExport: false},
+		{name: "FALSE", envValue: "FALSE", setEnv: true, wantExport: false},
+		{name: "0", envValue: "0", setEnv: true, wantExport: false},
+		{name: "f", envValue: "f", setEnv: true, wantExport: false},
+		{name: "yes", envValue: "yes", setEnv: true, wantExport: false, wantWarning: true},
+		{name: "on", envValue: "on", setEnv: true, wantExport: false, wantWarning: true},
+		{name: "enabled", envValue: "enabled", setEnv: true, wantExport: false, wantWarning: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setEnv {
+				t.Setenv(complytime.ExportEnabledEnvVar, tt.envValue)
+			}
+
+			// Capture stderr to check for warnings.
+			// NOTE: os.Stderr swap is safe here because subtests run sequentially,
+			// but this pattern should not be used in parallel tests.
+			oldStderr := os.Stderr
+			r, w, _ := os.Pipe()
+			os.Stderr = w
+
+			o := &scanOptions{Common: &Common{}}
+			err := o.maybeExport(context.Background(), &complytime.WorkspaceConfig{}, nil, nil)
+
+			w.Close()
+			var stderrBuf bytes.Buffer
+			_, _ = stderrBuf.ReadFrom(r)
+			os.Stderr = oldStderr
+
+			if tt.wantExport {
+				// When export is triggered with no collector config, we expect an error
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "collector")
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if tt.wantWarning {
+				assert.Contains(t, stderrBuf.String(), "not a recognized boolean value")
+			}
+		})
+	}
 }
 
 // --- export helpers ---
@@ -220,6 +289,13 @@ func TestFormatExportSummary_MixedResults(t *testing.T) {
 	assert.Contains(t, out, "plugin-c")
 	assert.Contains(t, out, "plugin-d")
 	assert.Contains(t, out, "partial failure")
+}
+
+// --- scan help text ---
+
+func TestScanCmd_HelpContainsExportEnvVar(t *testing.T) {
+	cmd := scanCmd(&Common{})
+	assert.Contains(t, cmd.Long, complytime.ExportEnabledEnvVar)
 }
 
 // --- generateOptions tests ---

--- a/cmd/complyctl/cli/scan.go
+++ b/cmd/complyctl/cli/scan.go
@@ -38,11 +38,17 @@ func scanCmd(common *Common) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "scan [flags]",
 		Short: "Scan targets and produce compliance reports",
+		Long: `Scan targets and produce compliance reports.
+
+Set COMPLYTIME_EXPORT_ENABLED=true to export evidence to a Beacon collector
+after the scan completes. Requires a collector section in complytime.yaml.
+Export works alongside any --format flag. The variable must be set in the
+same shell session or CI job step that invokes complyctl scan.`,
 		Example: `complyctl scan --policy-id nist-800-53-r5
   complyctl scan --policy-id nist-800-53-r5 --format pretty
   complyctl scan --policy-id nist-800-53-r5 --format oscal
   complyctl scan --policy-id nist-800-53-r5 --format sarif
-  complyctl scan --policy-id nist-800-53-r5 --format otel`,
+  COMPLYTIME_EXPORT_ENABLED=true complyctl scan --policy-id nist-800-53-r5 --format sarif`,
 		SilenceUsage:      true,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
@@ -57,13 +63,13 @@ func scanCmd(common *Common) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&o.policyID, "policy-id", "p", "", "Policy ID to scan (see complyctl list)")
-	cmd.Flags().StringVarP(&o.format, "format", "f", "", "Output format: oscal, pretty, sarif, otel")
+	cmd.Flags().StringVarP(&o.format, "format", "f", "", "Output format: oscal, pretty, sarif")
 	cmd.Flags().DurationVarP(&o.timeout, "timeout", "t", complytime.DefaultCommandTimeout, "Maximum time for the scan operation (e.g. 5m, 10m, 1h)")
 	if err := cmd.MarkFlagRequired("policy-id"); err != nil {
 		logger.Error("Failed to mark policy-id as required", "error", err)
 	}
 	if err := cmd.RegisterFlagCompletionFunc("format", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-		return []string{complytime.OutputFormatOSCAL, complytime.OutputFormatPretty, complytime.OutputFormatSARIF, complytime.OutputFormatOTEL}, cobra.ShellCompDirectiveNoFileComp
+		return []string{complytime.OutputFormatOSCAL, complytime.OutputFormatPretty, complytime.OutputFormatSARIF}, cobra.ShellCompDirectiveNoFileComp
 	}); err != nil {
 		logger.Error("Failed to register format completion", "error", err)
 	}
@@ -78,10 +84,10 @@ func scanCmd(common *Common) *cobra.Command {
 func (o *scanOptions) validate() error {
 	if o.format != "" {
 		switch o.format {
-		case complytime.OutputFormatOSCAL, complytime.OutputFormatPretty, complytime.OutputFormatSARIF, complytime.OutputFormatOTEL:
+		case complytime.OutputFormatOSCAL, complytime.OutputFormatPretty, complytime.OutputFormatSARIF:
 		default:
-			return fmt.Errorf("invalid format %q: must be one of %s, %s, %s, %s",
-				o.format, complytime.OutputFormatOSCAL, complytime.OutputFormatPretty, complytime.OutputFormatSARIF, complytime.OutputFormatOTEL)
+			return fmt.Errorf("invalid format %q: must be one of %s, %s, %s",
+				o.format, complytime.OutputFormatOSCAL, complytime.OutputFormatPretty, complytime.OutputFormatSARIF)
 		}
 	}
 	return nil
@@ -107,12 +113,6 @@ func (o *scanOptions) run(ctx context.Context) error {
 	cfg, err := loadWorkspaceConfig()
 	if err != nil {
 		return err
-	}
-
-	if o.format == complytime.OutputFormatOTEL {
-		if cfg.Collector == nil || cfg.Collector.Endpoint == "" {
-			return fmt.Errorf("--format otel requires a collector section in complytime.yaml (see docs for configuration)")
-		}
 	}
 
 	if len(cfg.Targets) == 0 {
@@ -175,7 +175,13 @@ func (o *scanOptions) executeScanPhase(ctx context.Context, cfg *complytime.Work
 }
 
 func (o *scanOptions) maybeExport(ctx context.Context, cfg *complytime.WorkspaceConfig, mgr *provider.Manager, groups map[string]policy.EvaluatorGroup) error {
-	if o.format != complytime.OutputFormatOTEL {
+	enabled, raw, err := complytime.ExportEnabled()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: %s=%q is not a recognized boolean value; export disabled (accepted: true, false, 1, 0, t, f)\n",
+			complytime.ExportEnabledEnvVar, raw)
+		return nil
+	}
+	if !enabled {
 		return nil
 	}
 	return o.runExport(ctx, cfg, mgr, groups)
@@ -433,8 +439,11 @@ func writeOSCALReport(eval *output.Evaluator, reportDir string) error {
 }
 
 // runExport orchestrates evidence export to the configured Beacon collector.
-// Called when --format otel is used, after the scan phase completes.
+// Called when COMPLYTIME_EXPORT_ENABLED is set to a truthy value, after the scan phase completes.
 func (o *scanOptions) runExport(ctx context.Context, cfg *complytime.WorkspaceConfig, mgr *provider.Manager, groups map[string]policy.EvaluatorGroup) error {
+	if cfg.Collector == nil || cfg.Collector.Endpoint == "" {
+		return fmt.Errorf("export requires a collector section in complytime.yaml (see docs for configuration)")
+	}
 	collector := cfg.Collector
 
 	authToken, err := resolveCollectorAuth(ctx, collector.Auth)
@@ -589,7 +598,7 @@ type exportResult struct {
 
 // countExportFailures returns the number of export results that represent
 // a failure: a transport error or a response where Success is false or
-// FailedCount is non-zero. Skipped plugins are not counted as failures.
+// FailedCount is non-zero. Skipped providers are not counted as failures.
 func countExportFailures(results []exportResult) int {
 	count := 0
 	for _, r := range results {

--- a/cmd/test-provider/main.go
+++ b/cmd/test-provider/main.go
@@ -21,8 +21,11 @@ import (
 	"github.com/complytime/complyctl/pkg/provider"
 )
 
-// Compile-time check
-var _ provider.Provider = (*testEvaluator)(nil)
+// Compile-time checks
+var (
+	_ provider.Provider = (*testEvaluator)(nil)
+	_ provider.Exporter = (*testEvaluator)(nil)
+)
 
 // testEvaluator returns predefined responses for all RPCs.
 type testEvaluator struct {
@@ -34,6 +37,7 @@ func (t *testEvaluator) Describe(_ context.Context, _ *provider.DescribeRequest)
 		Healthy:                 true,
 		Version:                 "test-v0.1.0",
 		RequiredGlobalVariables: []string{"workspace"},
+		SupportsExport:          true,
 	}, nil
 }
 
@@ -62,6 +66,18 @@ func (t *testEvaluator) Scan(_ context.Context, req *provider.ScanRequest) (*pro
 		})
 	}
 	return &provider.ScanResponse{Assessments: assessments}, nil
+}
+
+func (t *testEvaluator) Export(_ context.Context, _ *provider.ExportRequest) (*provider.ExportResponse, error) {
+	n := len(t.requirementIDs)
+	if n == 0 {
+		n = 1 // always report at least one exported record
+	}
+	return &provider.ExportResponse{
+		Success:       true,
+		ExportedCount: int32(n), //nolint:gosec // test provider; requirementIDs count is always small
+		FailedCount:   0,
+	}, nil
 }
 
 func main() {

--- a/internal/complytime/consts.go
+++ b/internal/complytime/consts.go
@@ -5,6 +5,7 @@ package complytime
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -26,8 +27,27 @@ const (
 	OutputFormatOSCAL  = "oscal"
 	OutputFormatPretty = "pretty"
 	OutputFormatSARIF  = "sarif"
-	OutputFormatOTEL   = "otel"
 )
+
+// ExportEnabledEnvVar is the environment variable that controls whether
+// the scan command triggers evidence export to a Beacon collector.
+// Parsed via strconv.ParseBool — accepts "true", "TRUE", "1", etc.
+const ExportEnabledEnvVar = "COMPLYTIME_EXPORT_ENABLED"
+
+// ExportEnabled checks whether COMPLYTIME_EXPORT_ENABLED is set to a truthy
+// value. Returns (true, "", nil) when enabled, (false, "", nil) when unset or
+// falsy, and (false, rawValue, err) when set to an unrecognized value.
+func ExportEnabled() (enabled bool, raw string, err error) {
+	raw = os.Getenv(ExportEnabledEnvVar)
+	if raw == "" {
+		return false, "", nil
+	}
+	enabled, err = strconv.ParseBool(raw)
+	if err != nil {
+		return false, raw, err
+	}
+	return enabled, raw, nil
+}
 
 const ScanOutputDir = "scan"
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -648,7 +648,7 @@ func CheckCollector(cfg *complytime.WorkspaceConfig) []CheckResult {
 		return []CheckResult{{
 			Name:    "collector",
 			Status:  StatusPass,
-			Message: "no collector configured (optional — needed for --format otel)",
+			Message: "no collector configured (optional — needed when " + complytime.ExportEnabledEnvVar + " is set)",
 		}}
 	}
 	if cfg.Collector.Endpoint == "" {
@@ -666,7 +666,39 @@ func CheckCollector(cfg *complytime.WorkspaceConfig) []CheckResult {
 	if cfg.Collector.Auth != nil {
 		results = append(results, checkCollectorAuth(cfg.Collector.Auth))
 	}
+	if result, ok := checkExportEnabled(); ok {
+		results = append(results, result)
+	}
 	return results
+}
+
+// checkExportEnabled checks whether the export env var is set when a collector
+// is configured. Returns a warning result and true if the env var is not
+// enabled. Returns zero value and false when export is enabled (no warning needed).
+func checkExportEnabled() (CheckResult, bool) {
+	enabled, raw, err := complytime.ExportEnabled()
+	if err != nil {
+		return CheckResult{
+			Name:    "collector-export",
+			Status:  StatusWarn,
+			Message: fmt.Sprintf("%s=%q is not a recognized boolean value — export will not trigger", complytime.ExportEnabledEnvVar, raw),
+		}, true
+	}
+	if raw == "" {
+		return CheckResult{
+			Name:    "collector-export",
+			Status:  StatusWarn,
+			Message: fmt.Sprintf("collector configured but %s is not set — export will not trigger", complytime.ExportEnabledEnvVar),
+		}, true
+	}
+	if !enabled {
+		return CheckResult{
+			Name:    "collector-export",
+			Status:  StatusWarn,
+			Message: fmt.Sprintf("collector configured but %s=%s — export will not trigger", complytime.ExportEnabledEnvVar, raw),
+		}, true
+	}
+	return CheckResult{}, false
 }
 
 func checkCollectorAuth(auth *complytime.AuthConfig) CheckResult {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -834,12 +834,14 @@ func TestCheckCollector_EmptyEndpoint(t *testing.T) {
 }
 
 func TestCheckCollector_ValidEndpointNoAuth(t *testing.T) {
+	t.Setenv(complytime.ExportEnabledEnvVar, "")
 	cfg := &complytime.WorkspaceConfig{
 		Collector: &complytime.CollectorConfig{Endpoint: "collector.example.com:4317"},
 	}
 	results := CheckCollector(cfg)
-	if len(results) != 1 {
-		t.Fatalf("expected 1 result, got %d", len(results))
+	// endpoint pass + export-not-enabled warning
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
 	}
 	if results[0].Status != StatusPass {
 		t.Errorf("expected pass, got %s: %s", results[0].Status, results[0].Message)
@@ -850,6 +852,7 @@ func TestCheckCollector_ValidEndpointNoAuth(t *testing.T) {
 }
 
 func TestCheckCollector_ValidEndpointWithCompleteAuth(t *testing.T) {
+	t.Setenv(complytime.ExportEnabledEnvVar, "")
 	cfg := &complytime.WorkspaceConfig{
 		Collector: &complytime.CollectorConfig{
 			Endpoint: "collector.example.com:4317",
@@ -861,8 +864,9 @@ func TestCheckCollector_ValidEndpointWithCompleteAuth(t *testing.T) {
 		},
 	}
 	results := CheckCollector(cfg)
-	if len(results) != 2 {
-		t.Fatalf("expected 2 results (endpoint + auth), got %d", len(results))
+	// endpoint pass + auth pass + export-not-enabled warning
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results (endpoint + auth + export warning), got %d", len(results))
 	}
 	if results[0].Status != StatusPass {
 		t.Errorf("expected pass for endpoint, got %s: %s", results[0].Status, results[0].Message)
@@ -906,6 +910,58 @@ func TestCheckCollectorAuth_Complete(t *testing.T) {
 	}
 	if !strings.Contains(result.Message, "https://idp.example.com/token") {
 		t.Errorf("expected token-endpoint in message, got %q", result.Message)
+	}
+}
+
+// --- checkExportEnabled Tests ---
+
+func TestCheckExportEnabled_Unset(t *testing.T) {
+	t.Setenv(complytime.ExportEnabledEnvVar, "")
+	result, warn := checkExportEnabled()
+	if !warn {
+		t.Fatal("expected warning when env var is unset")
+	}
+	if result.Status != StatusWarn {
+		t.Errorf("expected warn status, got %s", result.Status)
+	}
+	if !strings.Contains(result.Message, "is not set") {
+		t.Errorf("expected 'is not set' in message, got %q", result.Message)
+	}
+}
+
+func TestCheckExportEnabled_Truthy(t *testing.T) {
+	t.Setenv(complytime.ExportEnabledEnvVar, "true")
+	_, warn := checkExportEnabled()
+	if warn {
+		t.Error("expected no warning when export is enabled")
+	}
+}
+
+func TestCheckExportEnabled_Falsy(t *testing.T) {
+	t.Setenv(complytime.ExportEnabledEnvVar, "false")
+	result, warn := checkExportEnabled()
+	if !warn {
+		t.Fatal("expected warning when env var is falsy")
+	}
+	if result.Status != StatusWarn {
+		t.Errorf("expected warn status, got %s", result.Status)
+	}
+	if !strings.Contains(result.Message, "export will not trigger") {
+		t.Errorf("expected 'export will not trigger' in message, got %q", result.Message)
+	}
+}
+
+func TestCheckExportEnabled_Unrecognized(t *testing.T) {
+	t.Setenv(complytime.ExportEnabledEnvVar, "yes")
+	result, warn := checkExportEnabled()
+	if !warn {
+		t.Fatal("expected warning for unrecognized value")
+	}
+	if result.Status != StatusWarn {
+		t.Errorf("expected warn status, got %s", result.Status)
+	}
+	if !strings.Contains(result.Message, "not a recognized boolean value") {
+		t.Errorf("expected 'not a recognized boolean value' in message, got %q", result.Message)
 	}
 }
 

--- a/openspec/changes/envvar-otel-export/.openspec.yaml
+++ b/openspec/changes/envvar-otel-export/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-06

--- a/openspec/changes/envvar-otel-export/design.md
+++ b/openspec/changes/envvar-otel-export/design.md
@@ -1,0 +1,71 @@
+## Context
+
+The `complyctl scan` command currently supports four output formats via `--format`: `oscal`, `pretty`, `sarif`, and `otel`. The first three produce local files in their respective formats. The `otel` value is architecturally different — it triggers a post-scan export phase that ships evidence to a remote Beacon collector via provider gRPC `Export` RPCs.
+
+The export logic lives in `cmd/complyctl/cli/scan.go` and is gated by `maybeExport()` checking `o.format == complytime.OutputFormatOTEL`. The underlying export orchestration (OIDC token resolution, provider routing, summary rendering) is mature and stays unchanged.
+
+The collector endpoint and auth credentials are already configured via environment variables expanded in `complytime.yaml`. Adding an env var trigger aligns with that pattern.
+
+**Supersedes**: This change supersedes the trigger mechanism defined in `specs/003-complybeacon-export/spec.md` — specifically FR-001 (`--format otel` as trigger), FR-011 (error without collector when `--format otel` used), and FR-012 (no behavior change when `--format otel` not used). The Export RPC, provider routing, and all other 003 requirements remain unchanged.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Decouple export triggering from the `--format` flag so users can export while also producing local format reports (e.g., `--format sarif` + export)
+- Replace `--format otel` with `COMPLYTIME_EXPORT_ENABLED=true` environment variable
+- Keep all existing export orchestration, OIDC auth, provider routing, and summary rendering unchanged
+- Update tests to use the new trigger mechanism
+
+**Non-Goals:**
+- Changing the export protocol, provider interface, or gRPC contract
+- Adding a `--export` CLI flag (env var only, consistent with collector credential configuration)
+- Modifying the `Export` RPC, `ExportRequest`, `ExportResponse`, or `CollectorConfig` types
+- Modifying any provider-side export logic (ProofWatch, GemaraEvidence, etc.)
+
+## Decisions
+
+### D1: Environment variable name — `COMPLYTIME_EXPORT_ENABLED`
+
+Use `COMPLYTIME_EXPORT_ENABLED` as the env var name.
+
+Rationale: Follows the `COMPLYTIME_` namespace prefix convention. The `_ENABLED` suffix is a common boolean toggle pattern. It is descriptive without being tied to the OTEL implementation detail.
+
+Alternative considered: `COMPLYTIME_OTEL_EXPORT_ENABLED` — rejected because the env var controls whether complyctl triggers the export phase, not which protocol is used. The OTEL detail belongs to the provider/ProofWatch layer.
+
+### D2: Trigger check location — in `maybeExport()` only
+
+The `maybeExport()` function in `scan.go` currently checks `o.format != complytime.OutputFormatOTEL`. Replace this with a `strconv.ParseBool(os.Getenv("COMPLYTIME_EXPORT_ENABLED"))` call. When the env var is unset or empty, `ParseBool("")` returns `false, err` — treat this as "not enabled" silently (no warning for the common unset case). When `ParseBool` returns `true`, proceed with export. When `ParseBool` returns an error on a non-empty value (e.g., `"yes"`, `"on"`), log an error to stderr with the unrecognized value and the accepted values, then skip export. This uses Go's stdlib `strconv.ParseBool` (Constitution V: Do Not Reinvent the Wheel) which accepts `1`, `t`, `T`, `TRUE`, `true`, `True`, `0`, `f`, `F`, `FALSE`, `false`, `False`.
+
+The collector config validation currently in `run()` (the `OutputFormatOTEL` guard block) moves into `runExport()` so it only runs when export is actually triggered. The nil check on `cfg.Collector` must occur before any dereference of collector fields.
+
+Rationale: Single check point, minimal diff, no structural changes to the scan flow. `strconv.ParseBool` is stdlib and handles common boolean representations that operators use in CI/CD, systemd, and Kubernetes environments.
+
+### D3: Remove `OutputFormatOTEL` constant entirely
+
+Delete the `OutputFormatOTEL = "otel"` constant from `consts.go` and remove all references. The `--format` flag accepts only `oscal`, `pretty`, `sarif`. The format validation switch in `validate()` drops the `otel` case.
+
+Rationale: Clean removal avoids dead code. If `otel` is accepted but silently ignored, users will be confused.
+
+### D4: Evaluation log still written when export is enabled
+
+When export is triggered, the scan still writes the evaluation log YAML (same as all other formats). If a `--format` is also specified, that format report is also written. Export runs after all local reports. When export is enabled but collector config is missing, the scan phase completes and writes the evaluation log before the export-phase error — the user gets partial output.
+
+Rationale: Export and local reporting are now independent. Users can get both. The scan phase should not be blocked by export configuration issues.
+
+### D5: Environment variable is env-var-only, not settable in `complytime.yaml`
+
+`COMPLYTIME_EXPORT_ENABLED` is intentionally a process-level environment variable, not a field in `complytime.yaml`.
+
+Rationale: This is a per-invocation toggle ("should this particular scan export?") rather than a workspace-level setting. The `complytime.yaml` collector section configures *where* to export; the env var controls *whether* to export for a given run. This separation is consistent with how CI/CD pipelines typically control feature gates (env vars) vs. configuration (config files).
+
+### D6: No deprecation period — clean removal
+
+The `--format otel` value is removed entirely. It is rejected with the standard invalid format error, the same as any unknown format value. No special migration error or deprecation warning.
+
+Rationale: The feature was never deployed. There are no existing users to migrate. A migration-specific error message would be dead code.
+
+## Risks / Trade-offs
+
+- **[Breaking change]** Users and CI scripts using `--format otel` will break. → Mitigation: `otel` is rejected with the standard invalid format error. Migration path documented in release notes and README.
+- **[Discoverability]** Env vars are less discoverable than CLI flags. → Mitigation: `complyctl scan --help` mentions the env var. `doctor` command references it when collector config is present but export is not enabled.
+- **[Format + export interaction]** Users might set the env var and forget `--format`, getting no local report. → Acceptable: this matches existing behavior where no `--format` produces only the evaluation log YAML.

--- a/openspec/changes/envvar-otel-export/proposal.md
+++ b/openspec/changes/envvar-otel-export/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+The `--format otel` flag on the `scan` command conflates two concerns: output format selection and export behavior. The other `--format` values (`oscal`, `pretty`, `sarif`) control the local file format of scan results. `otel` is fundamentally different — it triggers a network export to a remote Beacon collector as a side effect, not a file format choice. This creates UX confusion and prevents users from exporting to a collector while also producing a local report (e.g., `--format sarif` + export).
+
+Switching to an environment variable (`COMPLYTIME_EXPORT_ENABLED`) decouples the export trigger from format selection, aligns with how collector credentials are already configured (env vars in `complytime.yaml`), and allows export to work alongside any output format.
+
+## What Changes
+
+- **BREAKING**: Remove `otel` as a valid value for the `--format` flag on `complyctl scan`. Users currently passing `--format otel` must switch to setting `COMPLYTIME_EXPORT_ENABLED=true`.
+- Add `COMPLYTIME_EXPORT_ENABLED` environment variable. When set to `true`, the scan command triggers the existing export-to-collector flow after scan completes, regardless of which `--format` is used (or none).
+- The underlying export orchestration logic (`runExport`, `exportToProviders`, OIDC token resolution, export summary rendering) remains unchanged — only the trigger mechanism changes.
+- Update `complyctl scan` help text, examples, and shell completions to remove `otel` from the format list.
+- Update `doctor` command messaging to reference the new env var instead of `--format otel`.
+
+## Capabilities
+
+### New Capabilities
+- `envvar-export-trigger`: Environment variable-based trigger for Beacon collector export, replacing the `--format otel` flag.
+
+### Modified Capabilities
+- `scan --format`: The `otel` value is removed from the accepted format list. The `--format` flag now only controls local file output format (`oscal`, `pretty`, `sarif`).
+- `doctor`: Collector check messaging updated to reference `COMPLYTIME_EXPORT_ENABLED` instead of `--format otel`.
+
+### Removed Capabilities
+- `format-otel`: The `otel` value for the `--format` flag is removed. Export is now triggered via `COMPLYTIME_EXPORT_ENABLED=true` environment variable.
+
+## Constitution Alignment
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| I. Single Source of Truth | PASS | New `ExportEnabledEnvVar` constant centralizes the env var name. No magic strings. |
+| II. Simplicity & Isolation | PASS | Minimal change — replaces one check in `maybeExport()`. No structural changes to scan flow. |
+| III. Incremental Improvement | PASS | Single-concern change. No unrelated refactoring bundled in. |
+| IV. Readability First | PASS | `COMPLYTIME_EXPORT_ENABLED` is self-documenting. `--format otel` rejected with standard invalid format error; migration documented in release notes. |
+| V. Do Not Reinvent the Wheel | PASS | Uses `strconv.ParseBool` (stdlib) for boolean parsing. No custom env var framework. |
+| VI. Composability | PASS | Export and format are now independent — users can compose `--format sarif` + export. Improves composability. |
+| VII. Convention Over Configuration | PASS | Export defaults to off (env var not set). Consistent with existing env var pattern for collector credentials. |
+
+## Impact
+
+- **CLI surface**: `--format` flag loses the `otel` value. Breaking change for users and scripts using `--format otel`.
+- **Code**: `cmd/complyctl/cli/scan.go` (trigger logic), `internal/complytime/consts.go` (remove `OutputFormatOTEL`), `internal/doctor/doctor.go` (messaging update), shell completions.
+- **Tests**: E2E tests (`TestE2E_ScanFormatOtel`, `TestE2E_ScanFormatOtelNoCollector`), unit tests for format validation, behavioral tests.
+- **Documentation**: Any user-facing docs referencing `--format otel`. README.md scan section, AGENTS.md recent changes, release notes.
+- **Upstream specs**: `specs/003-complybeacon-export/spec.md` requirements FR-001, FR-011, FR-012 are superseded by this change and should be annotated.
+- **No dependency changes**: No new Go modules needed. `golang.org/x/oauth2` and the provider export infrastructure remain as-is.

--- a/openspec/changes/envvar-otel-export/release-notes.md
+++ b/openspec/changes/envvar-otel-export/release-notes.md
@@ -1,0 +1,16 @@
+## Breaking Changes
+
+- **`--format otel` removed from `complyctl scan`**: The `otel` value for the `--format` flag has been removed. Export to a Beacon collector is now triggered via the `COMPLYTIME_EXPORT_ENABLED` environment variable.
+
+  **Migration**: Replace `complyctl scan --format otel` with:
+  ```bash
+  COMPLYTIME_EXPORT_ENABLED=true complyctl scan [--format <format>]
+  ```
+
+  Export now works alongside any `--format` flag (e.g., `--format sarif`), allowing users to produce local reports and export evidence in a single scan invocation.
+
+## New Features
+
+- **`COMPLYTIME_EXPORT_ENABLED` environment variable**: Set to `true` (or any value accepted by Go's `strconv.ParseBool`: `1`, `t`, `T`, `TRUE`, `True`) to enable Beacon collector export after scan. Requires a `collector` section in `complytime.yaml`.
+
+- **Doctor proactive diagnostic**: When a `collector` section is configured but `COMPLYTIME_EXPORT_ENABLED` is not set, `complyctl doctor` now warns that export will not trigger.

--- a/openspec/changes/envvar-otel-export/specs/envvar-export-trigger/spec.md
+++ b/openspec/changes/envvar-otel-export/specs/envvar-export-trigger/spec.md
@@ -1,0 +1,70 @@
+## ADDED Requirements
+
+### Requirement: Export triggered by environment variable
+The `complyctl scan` command SHALL trigger evidence export to the configured Beacon collector when the environment variable `COMPLYTIME_EXPORT_ENABLED` is set to a truthy value as defined by Go's `strconv.ParseBool` (`1`, `t`, `T`, `TRUE`, `true`, `True`). Export SHALL NOT be triggered by any `--format` flag value. When the env var is set to a value that `strconv.ParseBool` cannot parse, the command SHALL log an error and disable export.
+
+#### Scenario: Export enabled via env var
+- **GIVEN** a workspace with a valid `collector` section in `complytime.yaml` and providers that support export
+- **WHEN** the user runs `complyctl scan` with `COMPLYTIME_EXPORT_ENABLED` set to a truthy value (e.g., `true`, `TRUE`, `1`)
+- **THEN** the scan command executes the scan phase, writes any requested format report, and then runs the export phase to ship evidence to the collector
+
+#### Scenario: Export enabled with format flag
+- **GIVEN** a workspace with a valid `collector` section in `complytime.yaml`
+- **WHEN** `COMPLYTIME_EXPORT_ENABLED=true` is set and `--format sarif` is also specified
+- **THEN** the scan command produces the SARIF report locally AND runs the export phase
+
+#### Scenario: Export disabled via falsy value
+- **GIVEN** a workspace with or without a `collector` section
+- **WHEN** `COMPLYTIME_EXPORT_ENABLED` is not set, set to an empty string, or set to a falsy value (`false`, `FALSE`, `0`, `f`, `F`)
+- **THEN** the scan command SHALL NOT run the export phase regardless of other flags or configuration
+
+#### Scenario: Export env var set to unrecognized value
+- **GIVEN** a workspace with or without a `collector` section
+- **WHEN** `COMPLYTIME_EXPORT_ENABLED` is set to a value that `strconv.ParseBool` cannot parse (e.g., `yes`, `on`, `enabled`)
+- **THEN** the scan command SHALL log an error to stderr indicating the value is not recognized and listing accepted values, and SHALL NOT run the export phase
+
+#### Scenario: Export enabled without collector config
+- **GIVEN** no `collector` section exists in `complytime.yaml`
+- **WHEN** the user runs `complyctl scan` with `COMPLYTIME_EXPORT_ENABLED=true` set
+- **THEN** the scan phase completes and writes the evaluation log, then the command exits with an error indicating no collector is configured
+
+### Requirement: Format flag no longer accepts otel
+The `--format` flag on the `complyctl scan` command SHALL accept only `oscal`, `pretty`, and `sarif` as valid values. The value `otel` SHALL be rejected as an invalid format.
+
+#### Scenario: User passes --format otel
+- **WHEN** a user runs `complyctl scan --format otel`
+- **THEN** the command SHALL exit with the standard invalid format error
+
+#### Scenario: Shell completion excludes otel
+- **WHEN** a user invokes shell completion for the `--format` flag
+- **THEN** only `oscal`, `pretty`, and `sarif` SHALL be offered as completions
+
+### Requirement: Scan help text documents export env var
+The `complyctl scan` command help text SHALL mention the `COMPLYTIME_EXPORT_ENABLED` environment variable and its purpose.
+
+#### Scenario: Help text includes env var reference
+- **WHEN** a user runs `complyctl scan --help`
+- **THEN** the output SHALL include a reference to `COMPLYTIME_EXPORT_ENABLED` for enabling Beacon collector export
+
+### Requirement: Doctor warns when collector configured but export not enabled
+The `complyctl doctor` command SHALL warn when a `collector` section is present in `complytime.yaml` but `COMPLYTIME_EXPORT_ENABLED` is not set or is falsy. This helps operators diagnose the common misconfiguration where the collector is configured but export never triggers.
+
+#### Scenario: Collector configured but export not enabled
+- **GIVEN** a `complytime.yaml` with a valid `collector` section
+- **WHEN** the user runs `complyctl doctor` without `COMPLYTIME_EXPORT_ENABLED` set (or set to a falsy value)
+- **THEN** the doctor output SHALL include a warning indicating that a collector is configured but export is not enabled, and suggest setting `COMPLYTIME_EXPORT_ENABLED=true`
+
+#### Scenario: Collector configured and export enabled
+- **GIVEN** a `complytime.yaml` with a valid `collector` section
+- **WHEN** the user runs `complyctl doctor` with `COMPLYTIME_EXPORT_ENABLED=true` set
+- **THEN** the doctor output SHALL NOT emit the "export not enabled" warning
+
+## MODIFIED Requirements
+
+None — all changes are additions or removals.
+
+## REMOVED Requirements
+
+### Requirement: Format flag accepts otel value
+**Reason**: The `otel` format value conflated output format selection with export behavior. Export is now triggered independently via the `COMPLYTIME_EXPORT_ENABLED` environment variable.
+**Migration**: Replace `--format otel` with `COMPLYTIME_EXPORT_ENABLED=true complyctl scan [--format <format>]`.

--- a/openspec/changes/envvar-otel-export/tasks.md
+++ b/openspec/changes/envvar-otel-export/tasks.md
@@ -1,0 +1,45 @@
+## 1. Remove otel format constant and validation
+
+- [x] 1.1 Delete `OutputFormatOTEL` constant from `internal/complytime/consts.go`
+- [x] 1.2 Remove `otel` from the format validation switch in `scan.go` `validate()` — falls through to generic invalid format error
+- [x] 1.3 [P] Remove `otel` from shell completion list in `scanCmd()` and from the `--format` flag description
+- [x] 1.4 [P] Remove `otel` from the scan command examples in `scanCmd()`
+
+## 2. Add environment variable export trigger
+
+- [x] 2.1 Add `ExportEnabledEnvVar` constant (`COMPLYTIME_EXPORT_ENABLED`) to `internal/complytime/consts.go`
+- [x] 2.2 Modify `maybeExport()` in `scan.go` to use `strconv.ParseBool(os.Getenv(complytime.ExportEnabledEnvVar))` instead of checking `o.format == complytime.OutputFormatOTEL`. When unset/empty, skip silently. When ParseBool returns true, proceed with export. When ParseBool returns error on a non-empty value, log an error to stderr with the unrecognized value and accepted values, then skip export.
+- [x] 2.3 Move the collector config validation (the `OutputFormatOTEL` guard block in `run()`) into `runExport()` so it only fires when export is actually triggered. Ensure the `cfg.Collector == nil` check occurs before any dereference of `cfg.Collector` fields.
+- [x] 2.4 Add env var reference to the scan command `Long` or help text description
+
+## 3. Update doctor command
+
+- [x] 3.1 Update `internal/doctor/doctor.go` collector check messaging (the string `"no collector configured (optional — needed for --format otel)"`) to reference `COMPLYTIME_EXPORT_ENABLED` instead of `--format otel`
+- [x] 3.2 Add proactive diagnostic to doctor: when a `collector` section exists in `complytime.yaml` but `COMPLYTIME_EXPORT_ENABLED` is not set or is falsy, emit a warning suggesting the user set `COMPLYTIME_EXPORT_ENABLED=true`. When the env var is truthy, suppress this warning.
+
+## 4. Update tests
+
+- [x] 4.1 Update format validation unit tests in `cmd/complyctl/cli/cli_test.go` — `otel` should now be rejected with migration guidance. Also update `TestScanOptions_Run_OtelWithoutCollector` to use `t.Setenv("COMPLYTIME_EXPORT_ENABLED", "true")` instead of referencing `OutputFormatOTEL`
+- [x] 4.2 Rename and update E2E test `TestE2E_ScanFormatOtel` → `TestE2E_ScanExportEnabled` to use `COMPLYTIME_EXPORT_ENABLED=true` env var instead of `--format otel`
+- [x] 4.3 Rename and update E2E test `TestE2E_ScanFormatOtelNoCollector` → `TestE2E_ScanExportEnabledNoCollector` to use env var trigger
+- [x] 4.4 [P] Removed — `--format otel` now hits the standard invalid format error (covered by existing `TestScanOptions_Validate_InvalidFormat`)
+- [x] 4.5 [P] Add test case verifying export works alongside `--format sarif` when env var is set. Assert both: (a) SARIF report file exists in output directory, AND (b) export summary table appears in stdout
+- [x] 4.6 [P] Add table-driven unit test for env var parsing via `strconv.ParseBool`: verify export triggers for truthy values (`"true"`, `"TRUE"`, `"True"`, `"1"`, `"t"`, `"T"`), does NOT trigger for falsy values (`"false"`, `"FALSE"`, `"0"`, `"f"`), does NOT trigger and logs error for unrecognized values (`"yes"`, `"on"`, `"enabled"`), and does NOT trigger silently when unset/empty. Use `t.Setenv()` for isolation
+- [x] 4.7 [P] Add test verifying `complyctl scan --help` output contains `COMPLYTIME_EXPORT_ENABLED`
+
+## 5. Update proto comments
+
+- [x] 5.1 Update the `Export` RPC comment in `api/plugin/plugin.proto` to reference `COMPLYTIME_EXPORT_ENABLED` instead of `--format otel`, and regenerate `plugin_grpc.pb.go`
+- [x] 5.2 Update the `runExport()` function comment in `scan.go` to reference the env var trigger instead of `--format otel`
+
+## 6. Update upstream spec and documentation
+
+- [x] 6.1 Add supersession notice to `specs/003-complybeacon-export/spec.md` noting that the trigger mechanism (FR-001, FR-011, FR-012) is replaced by `COMPLYTIME_EXPORT_ENABLED` env var per this change
+- [x] 6.2 Update `README.md` scan section with `COMPLYTIME_EXPORT_ENABLED` env var and usage example
+- [x] 6.3 Update `AGENTS.md` "Recent Changes" section with breaking change entry
+- [x] 6.4 Draft release notes / CHANGELOG entry covering the breaking change, migration path, and new capability
+
+## 7. Final cleanup and verify
+
+- [x] 7.1 Search codebase for remaining references to `OutputFormatOTEL`, `"otel"`, `--format otel`, and `format otel` in code and comments — remove/update all
+- [x] 7.2 Run `go build ./...` and `go test ./...` to verify all changes compile and pass

--- a/openspec/schemas/unbound-force/schema.yaml
+++ b/openspec/schemas/unbound-force/schema.yaml
@@ -74,4 +74,4 @@ apply:
     task as you complete it. Verify that the
     implementation maintains constitution alignment
     as documented in the proposal.
-# scaffolded by uf vdev
+# scaffolded by uf v0.14.0

--- a/openspec/schemas/unbound-force/templates/design.md
+++ b/openspec/schemas/unbound-force/templates/design.md
@@ -17,4 +17,4 @@
 ## Risks / Trade-offs
 
 <!-- Known risks and accepted trade-offs -->
-<!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf v0.14.0 -->

--- a/openspec/schemas/unbound-force/templates/proposal.md
+++ b/openspec/schemas/unbound-force/templates/proposal.md
@@ -54,4 +54,4 @@ output? Does it maintain provenance metadata? -->
 
 <!-- Does this change verify observable side effects?
 Are components testable in isolation? -->
-<!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf v0.14.0 -->

--- a/openspec/schemas/unbound-force/templates/spec.md
+++ b/openspec/schemas/unbound-force/templates/spec.md
@@ -20,4 +20,4 @@
 ### Requirement: <!-- name -->
 
 <!-- reason for removal -->
-<!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf v0.14.0 -->

--- a/openspec/schemas/unbound-force/templates/tasks.md
+++ b/openspec/schemas/unbound-force/templates/tasks.md
@@ -19,4 +19,4 @@
 ## 2. <!-- Task Group -->
 
 - [ ] 2.1 <!-- task description -->
-<!-- scaffolded by uf vdev -->
+<!-- scaffolded by uf v0.14.0 -->

--- a/specs/003-complybeacon-export/spec.md
+++ b/specs/003-complybeacon-export/spec.md
@@ -2,7 +2,8 @@
 
 **Feature Branch**: `003-complybeacon-export`
 **Created**: 2026-03-10
-**Status**: Draft
+**Status**: Amended
+**Amended By**: `openspec/changes/envvar-otel-export/` — The `--format otel` trigger mechanism (FR-001, FR-011, FR-012) has been replaced by the `COMPLYTIME_EXPORT_ENABLED` environment variable. All other requirements (Export RPC, provider routing, collector config, OIDC auth, export summary) remain unchanged.
 **Input**: Jira ticket: "Improve Integration with ComplyBeacon. Plugins leverage Proofwatch and send results directly to the collector on a plugin by plugin basis."
 
 ## Clarifications

--- a/specs/004-providers-repository-split/contracts/provider-sdk.md
+++ b/specs/004-providers-repository-split/contracts/provider-sdk.md
@@ -245,7 +245,7 @@ func (s *MyProviderServer) Describe(_ context.Context, _ *provider.DescribeReque
 ```
 
 complyctl detects export support at runtime via a type assertion on the gRPC client; providers
-that return `SupportsExport: false` (or omit it) are silently skipped during `--format otel`.
+that return `SupportsExport: false` (or omit it) are silently skipped when `COMPLYTIME_EXPORT_ENABLED` triggers export.
 
 ---
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -500,6 +500,109 @@ func TestE2E_NestedPolicyID(t *testing.T) {
 	})
 }
 
+// TestE2E_ScanExportEnabled verifies export orchestration via COMPLYTIME_EXPORT_ENABLED:
+//  1. Validates collector config in complytime.yaml
+//  2. Runs the scan, then calls Export RPC on capable providers
+//  3. Renders the export summary table
+//
+// Uses the test-provider which returns a fake export response (no real OTLP
+// emission), so this test does not require a running Beacon collector.
+func TestE2E_ScanExportEnabled(t *testing.T) {
+	binary := locateBinary(t)
+	srv := startMockRegistry(t)
+	defer srv.Close()
+
+	homeDir := t.TempDir()
+	workDir := t.TempDir()
+	installTestPlugin(t, homeDir)
+	// Use a dummy endpoint — the test-provider fakes the export, so it never
+	// actually connects. Any non-empty endpoint satisfies config validation.
+	writeWorkspaceConfigWithCollector(t, workDir, srv.URL, testPolicyID, "localhost:4317")
+	env := append(buildEnv(homeDir), complytime.ExportEnabledEnvVar+"=true")
+
+	// Fetch policy
+	runComplytime(t, binary, workDir, env, "get")
+
+	// Scan with export enabled via env var
+	scanDir := filepath.Join(workDir, "scan-export")
+	require.NoError(t, os.MkdirAll(scanDir, 0755))
+	copyWorkspaceConfig(t, workDir, scanDir)
+
+	out := runComplytime(t, binary, scanDir, env,
+		"scan", "--policy-id", testPolicyID)
+	t.Log(out)
+
+	// Verify scan completed (requirements summary still printed)
+	assert.Contains(t, out, "requirements:")
+
+	// Verify export summary was printed
+	assert.Contains(t, out, "Export Summary")
+	assert.Contains(t, out, "PROVIDER")
+	assert.Contains(t, out, "EXPORTED")
+	assert.Contains(t, out, "test")
+
+	// Verify evaluation log was produced (scan still creates internal artifacts)
+	evalDir := filepath.Join(scanDir, complytime.WorkspaceDir, complytime.ScanOutputDir)
+	assertOutputFile(t, evalDir, "evaluation-log-", ".yaml")
+}
+
+// TestE2E_ScanExportEnabledNoCollector verifies that export enabled via env var
+// fails gracefully when no collector section is configured.
+func TestE2E_ScanExportEnabledNoCollector(t *testing.T) {
+	binary := locateBinary(t)
+	srv := startMockRegistry(t)
+	defer srv.Close()
+
+	homeDir := t.TempDir()
+	workDir := t.TempDir()
+	installTestPlugin(t, homeDir)
+	// Standard config without collector section
+	writeWorkspaceConfig(t, workDir, srv.URL, testPolicyID)
+	env := append(buildEnv(homeDir), complytime.ExportEnabledEnvVar+"=true")
+
+	runComplytime(t, binary, workDir, env, "get")
+
+	cmd := exec.Command(binary,
+		"scan", "--policy-id", testPolicyID)
+	cmd.Dir = workDir
+	cmd.Env = env
+	output, err := cmd.CombinedOutput()
+	assert.Error(t, err, "scan with export enabled but no collector config must fail")
+	assert.Contains(t, string(output), "collector")
+}
+
+// TestE2E_ScanExportEnabledWithFormatSarif verifies that export works
+// alongside --format sarif: both the SARIF report and export summary are produced.
+func TestE2E_ScanExportEnabledWithFormatSarif(t *testing.T) {
+	binary := locateBinary(t)
+	srv := startMockRegistry(t)
+	defer srv.Close()
+
+	homeDir := t.TempDir()
+	workDir := t.TempDir()
+	installTestPlugin(t, homeDir)
+	writeWorkspaceConfigWithCollector(t, workDir, srv.URL, testPolicyID, "localhost:4317")
+	env := append(buildEnv(homeDir), complytime.ExportEnabledEnvVar+"=true")
+
+	runComplytime(t, binary, workDir, env, "get")
+
+	scanDir := filepath.Join(workDir, "scan-sarif-export")
+	require.NoError(t, os.MkdirAll(scanDir, 0755))
+	copyWorkspaceConfig(t, workDir, scanDir)
+
+	out := runComplytime(t, binary, scanDir, env,
+		"scan", "--policy-id", testPolicyID, "--format", "sarif")
+	t.Log(out)
+
+	// Verify SARIF report was produced
+	assert.Contains(t, out, "SARIF report written")
+	assertOutputFile(t, scanDir, "scan-", ".sarif.json")
+
+	// Verify export summary was also printed
+	assert.Contains(t, out, "Export Summary")
+	assert.Contains(t, out, "EXPORTED")
+}
+
 // TestE2E_ListFilterByPolicyID verifies the --policy-id filter on list.
 func TestE2E_ListFilterByPolicyID(t *testing.T) {
 	binary := locateBinary(t)

--- a/tests/e2e/helpers_test.go
+++ b/tests/e2e/helpers_test.go
@@ -408,6 +408,27 @@ targets:
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "complytime.yaml"), []byte(yaml), 0644))
 }
 
+// writeWorkspaceConfigWithCollector creates a complytime.yaml with a collector section
+// for testing export functionality (COMPLYTIME_EXPORT_ENABLED).
+func writeWorkspaceConfigWithCollector(t *testing.T, dir, registryURL, policyID, collectorEndpoint string) {
+	t.Helper()
+	yaml := fmt.Sprintf(`policies:
+  - url: %s/%s
+    id: %s
+variables:
+  workspace: /tmp/e2e-workspace
+targets:
+  - id: e2e-target
+    policies:
+      - %s
+    variables:
+      env: test
+collector:
+  endpoint: "%s"
+`, registryURL, policyID, policyID, policyID, collectorEndpoint)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "complytime.yaml"), []byte(yaml), 0644))
+}
+
 // copyWorkspaceConfig copies complytime.yaml from src to dst directory.
 func copyWorkspaceConfig(t *testing.T, srcDir, dstDir string) {
 	t.Helper()


### PR DESCRIPTION
## Summary

- Remove `--format otel` from the `scan` command. Export to a Beacon collector is now triggered via the `COMPLYTIME_EXPORT_ENABLED` environment variable.
- Export now works alongside any `--format` flag (e.g., `--format sarif` + export in the same invocation).
- Env var parsed via `strconv.ParseBool` — accepts `true`, `TRUE`, `1`, `t`, etc. Unrecognized values like `yes` log a warning.
- Doctor now proactively warns when a collector is configured but `COMPLYTIME_EXPORT_ENABLED` is not set.
- Shared `ExportEnabled()` helper extracted to `internal/complytime/consts.go` as single source of truth for env var parsing.

## Migration

```bash
# Before
complyctl scan --policy-id nist-800-53-r5 --format otel

# After
COMPLYTIME_EXPORT_ENABLED=true complyctl scan --policy-id nist-800-53-r5 [--format sarif]
```

## Test Coverage

- Table-driven unit test for env var parsing (15 cases: truthy, falsy, unrecognized, unset)
- 4 dedicated `checkExportEnabled()` doctor unit tests
- E2E tests: export enabled, export without collector, export + `--format sarif` combo
- Help text content test

## Spec Artifacts

OpenSpec change at `openspec/changes/envvar-otel-export/` with proposal, design, specs, and tasks.