### PR TITLE
feat: add optional target positional argument to scan command

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,26 +123,32 @@ Resolves the policy dependency graph from cache, extracts assessment configurati
 ### `scan`
 
 ```bash
-# Default: EvaluationLog only
+# Scan a specific target (policy inferred if target has exactly one)
+complyctl scan prod
+
+# Scan a specific target for a specific policy
+complyctl scan prod --policy-id nist-800-53-r5
+
+# Scan all targets for a policy
 complyctl scan --policy-id nist-800-53-r5
 
-# OSCAL assessment-results
-complyctl scan --policy-id nist-800-53-r5 --format oscal
-
-# Markdown report
+# With output format
+complyctl scan prod --format oscal
 complyctl scan --policy-id nist-800-53-r5 --format pretty
-
-# SARIF for security tooling
 complyctl scan --policy-id nist-800-53-r5 --format sarif
 
 # Export evidence to Beacon collector (with optional format report)
 COMPLYTIME_EXPORT_ENABLED=true complyctl scan --policy-id nist-800-53-r5 --format sarif
 ```
 
-| Flag | Short | Description |
+| Argument / Flag | Short | Description |
 |:---|:---|:---|
-| `--policy-id` | `-p` | Policy ID to scan (required) |
+| `[target]` | | Optional target ID to scope the scan (from `complytime.yaml`) |
+| `--policy-id` | `-p` | Policy ID to scan (required when no target is given, or target has multiple policies) |
 | `--format` | `-f` | Output format: `oscal`, `pretty`, `sarif` |
+
+When a target is specified and references exactly one policy, `--policy-id` is inferred.
+At least one of `[target]` or `--policy-id` is required.
 
 | Environment Variable | Description |
 |:---|:---|

--- a/cmd/complyctl/cli/cli_test.go
+++ b/cmd/complyctl/cli/cli_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gemaraproj/go-gemara"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -180,6 +181,289 @@ func TestMaybeExport_EnvVarParsing(t *testing.T) {
 			}
 		})
 	}
+}
+
+// --- target resolution tests ---
+
+// multiPolicyConfig has a target referencing two policies for disambiguation tests.
+const multiPolicyConfig = `policies:
+  - url: registry.example.com/policies/nist@v1.0
+    id: nist
+  - url: registry.example.com/policies/cis@v1.0
+    id: cis
+targets:
+  - id: prod
+    policies:
+      - nist
+      - cis
+    variables:
+      env: production
+  - id: staging
+    policies:
+      - nist
+    variables:
+      env: staging
+`
+
+func TestResolveTarget_Found(t *testing.T) {
+	cfg := &complytime.WorkspaceConfig{
+		Targets: []complytime.TargetConfig{
+			{ID: "prod", Policies: []string{"nist"}},
+			{ID: "staging", Policies: []string{"nist"}},
+		},
+	}
+	target, err := resolveTarget(cfg, "prod")
+	require.NoError(t, err)
+	assert.Equal(t, "prod", target.ID)
+}
+
+func TestResolveTarget_NotFound(t *testing.T) {
+	cfg := &complytime.WorkspaceConfig{
+		Targets: []complytime.TargetConfig{
+			{ID: "prod", Policies: []string{"nist"}},
+			{ID: "staging", Policies: []string{"nist"}},
+		},
+	}
+	_, err := resolveTarget(cfg, "nonexistent")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+	assert.Contains(t, err.Error(), "prod")
+	assert.Contains(t, err.Error(), "staging")
+}
+
+func TestResolvePolicy_BothTargetAndPolicyID_Valid(t *testing.T) {
+	target := &complytime.TargetConfig{
+		ID:       "prod",
+		Policies: []string{"nist", "cis"},
+	}
+	policyID, err := resolvePolicy(target, "nist")
+	require.NoError(t, err)
+	assert.Equal(t, "nist", policyID)
+}
+
+func TestResolvePolicy_BothTargetAndPolicyID_Mismatch(t *testing.T) {
+	target := &complytime.TargetConfig{
+		ID:       "prod",
+		Policies: []string{"nist"},
+	}
+	_, err := resolvePolicy(target, "cis")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not reference policy")
+	assert.Contains(t, err.Error(), "nist")
+}
+
+func TestResolvePolicy_TargetOnly_SinglePolicy(t *testing.T) {
+	target := &complytime.TargetConfig{
+		ID:       "staging",
+		Policies: []string{"nist"},
+	}
+	policyID, err := resolvePolicy(target, "")
+	require.NoError(t, err)
+	assert.Equal(t, "nist", policyID)
+}
+
+func TestResolvePolicy_TargetOnly_MultiplePolicies(t *testing.T) {
+	target := &complytime.TargetConfig{
+		ID:       "prod",
+		Policies: []string{"nist", "cis"},
+	}
+	_, err := resolvePolicy(target, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "multiple policies")
+	assert.Contains(t, err.Error(), "nist")
+	assert.Contains(t, err.Error(), "cis")
+}
+
+func TestResolvePolicy_TargetOnly_ZeroPolicies(t *testing.T) {
+	target := &complytime.TargetConfig{
+		ID:       "empty",
+		Policies: []string{},
+	}
+	_, err := resolvePolicy(target, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no policies configured")
+}
+
+func TestResolvePolicy_NeitherTargetNorPolicyID(t *testing.T) {
+	_, err := resolvePolicy(nil, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "specify a target or --policy-id")
+}
+
+func TestResolvePolicy_PolicyIDOnly(t *testing.T) {
+	policyID, err := resolvePolicy(nil, "nist")
+	require.NoError(t, err)
+	assert.Equal(t, "nist", policyID)
+}
+
+// TestScanOptions_Run_TargetNotFound verifies that specifying a nonexistent
+// target produces an error listing available target IDs.
+func TestScanOptions_Run_TargetNotFound(t *testing.T) {
+	chdirTemp(t)
+	writeWorkspaceConfig(t, minimalConfig)
+	o := &scanOptions{
+		Common:  &Common{},
+		target:  "nonexistent",
+		timeout: 5 * time.Second,
+	}
+	err := o.run(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+	assert.Contains(t, err.Error(), "local")
+}
+
+// TestScanOptions_Run_TargetPolicyMismatch verifies that specifying a target
+// and a policy the target doesn't reference produces a mismatch error.
+func TestScanOptions_Run_TargetPolicyMismatch(t *testing.T) {
+	chdirTemp(t)
+	writeWorkspaceConfig(t, multiPolicyConfig)
+	o := &scanOptions{
+		Common:   &Common{},
+		target:   "staging",
+		policyID: "cis",
+		timeout:  5 * time.Second,
+	}
+	err := o.run(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not reference policy")
+	assert.Contains(t, err.Error(), "nist")
+}
+
+// TestScanOptions_Run_TargetMultiplePoliciesNoPolicyID verifies that a target
+// with multiple policies and no --policy-id produces an error listing policies.
+func TestScanOptions_Run_TargetMultiplePoliciesNoPolicyID(t *testing.T) {
+	chdirTemp(t)
+	writeWorkspaceConfig(t, multiPolicyConfig)
+	o := &scanOptions{
+		Common:  &Common{},
+		target:  "prod",
+		timeout: 5 * time.Second,
+	}
+	err := o.run(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "multiple policies")
+	assert.Contains(t, err.Error(), "nist")
+	assert.Contains(t, err.Error(), "cis")
+}
+
+// TestScanOptions_Run_NoArgsNoPolicyID verifies that running scan with neither
+// a target nor --policy-id produces a clear error.
+func TestScanOptions_Run_NoArgsNoPolicyID(t *testing.T) {
+	chdirTemp(t)
+	writeWorkspaceConfig(t, minimalConfig)
+	o := &scanOptions{
+		Common:  &Common{},
+		timeout: 5 * time.Second,
+	}
+	err := o.run(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "specify a target or --policy-id")
+}
+
+// TestScanOptions_Run_TargetSinglePolicyInferred verifies that a target with
+// exactly one policy infers the policy ID (proceeds past resolution to
+// policy lookup, which fails because the cache is empty — that's expected).
+func TestScanOptions_Run_TargetSinglePolicyInferred(t *testing.T) {
+	chdirTemp(t)
+	writeWorkspaceConfig(t, multiPolicyConfig)
+	o := &scanOptions{
+		Common:   &Common{},
+		target:   "staging",
+		timeout:  5 * time.Second,
+		cacheDir: t.TempDir(),
+	}
+	// The resolution succeeds (infers "nist") but the scan fails later
+	// because the policy is not cached. We verify it gets past resolution.
+	err := o.run(context.Background())
+	require.Error(t, err)
+	// Should NOT contain resolution errors — it should fail at a later stage.
+	assert.NotContains(t, err.Error(), "specify a target or --policy-id")
+	assert.NotContains(t, err.Error(), "multiple policies")
+	assert.NotContains(t, err.Error(), "not found in complytime.yaml")
+}
+
+// TestScanOptions_Run_PolicyIDOnlyBackwardCompat verifies that the existing
+// --policy-id-only flow still works (backward compatibility).
+func TestScanOptions_Run_PolicyIDOnlyBackwardCompat(t *testing.T) {
+	chdirTemp(t)
+	writeWorkspaceConfig(t, minimalConfig)
+	o := &scanOptions{
+		Common:   &Common{},
+		policyID: "test-policy",
+		timeout:  5 * time.Second,
+		cacheDir: t.TempDir(),
+	}
+	// Resolution succeeds, scan fails later at cache lookup — expected.
+	err := o.run(context.Background())
+	require.Error(t, err)
+	// Should NOT contain resolution errors.
+	assert.NotContains(t, err.Error(), "specify a target or --policy-id")
+	assert.NotContains(t, err.Error(), "not found in complytime.yaml")
+}
+
+// TestScanOptions_Run_TargetWithPolicyID verifies that specifying both a valid
+// target and a matching policy-id proceeds past resolution.
+func TestScanOptions_Run_TargetWithPolicyID(t *testing.T) {
+	chdirTemp(t)
+	writeWorkspaceConfig(t, multiPolicyConfig)
+	o := &scanOptions{
+		Common:   &Common{},
+		target:   "prod",
+		policyID: "nist",
+		timeout:  5 * time.Second,
+		cacheDir: t.TempDir(),
+	}
+	err := o.run(context.Background())
+	require.Error(t, err)
+	// Should NOT contain resolution errors.
+	assert.NotContains(t, err.Error(), "specify a target or --policy-id")
+	assert.NotContains(t, err.Error(), "does not reference policy")
+	assert.NotContains(t, err.Error(), "not found in complytime.yaml")
+}
+
+func TestFilterTargetByID_Found(t *testing.T) {
+	targets := []complytime.TargetConfig{
+		{ID: "prod", Policies: []string{"nist"}},
+		{ID: "staging", Policies: []string{"nist"}},
+	}
+	result := filterTargetByID(targets, "prod")
+	require.Len(t, result, 1)
+	assert.Equal(t, "prod", result[0].ID)
+}
+
+func TestFilterTargetByID_NotFound(t *testing.T) {
+	targets := []complytime.TargetConfig{
+		{ID: "prod", Policies: []string{"nist"}},
+		{ID: "staging", Policies: []string{"cis"}},
+	}
+	result := filterTargetByID(targets, "nonexistent")
+	require.Len(t, result, 2, "returns original slice when ID not found")
+	assert.Equal(t, "prod", result[0].ID)
+	assert.Equal(t, "staging", result[1].ID)
+}
+
+func TestCompleteTargetIDs_NoConfig(t *testing.T) {
+	chdirTemp(t)
+	ids, directive := completeTargetIDs(nil, nil, "")
+	assert.Nil(t, ids)
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+}
+
+func TestCompleteTargetIDs_WithConfig(t *testing.T) {
+	chdirTemp(t)
+	writeWorkspaceConfig(t, multiPolicyConfig)
+	ids, directive := completeTargetIDs(nil, nil, "")
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+	assert.Contains(t, ids, "prod")
+	assert.Contains(t, ids, "staging")
+}
+
+func TestCompleteTargetIDs_AlreadyHasArg(t *testing.T) {
+	chdirTemp(t)
+	writeWorkspaceConfig(t, multiPolicyConfig)
+	ids, directive := completeTargetIDs(nil, []string{"prod"}, "")
+	assert.Nil(t, ids, "should not complete when arg already provided")
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
 }
 
 // --- export helpers ---

--- a/cmd/complyctl/cli/scan.go
+++ b/cmd/complyctl/cli/scan.go
@@ -24,6 +24,7 @@ import (
 
 type scanOptions struct {
 	*Common
+	target      string
 	policyID    string
 	format      string
 	timeout     time.Duration
@@ -36,23 +37,40 @@ func scanCmd(common *Common) *cobra.Command {
 		Common: common,
 	}
 	cmd := &cobra.Command{
-		Use:   "scan [flags]",
+		Use:   "scan [target] [flags]",
 		Short: "Scan targets and produce compliance reports",
 		Long: `Scan targets and produce compliance reports.
+
+Specify a target to scope the scan to a single target from complytime.yaml.
+When the target references exactly one policy, --policy-id is inferred.
+When no target is given, --policy-id is required and all matching targets are scanned.
 
 Set COMPLYTIME_EXPORT_ENABLED=true to export evidence to a Beacon collector
 after the scan completes. Requires a collector section in complytime.yaml.
 Export works alongside any --format flag. The variable must be set in the
 same shell session or CI job step that invokes complyctl scan.`,
-		Example: `complyctl scan --policy-id nist-800-53-r5
-  complyctl scan --policy-id nist-800-53-r5 --format pretty
+		Example: `  # Scan a specific target (policy inferred if target has exactly one)
+  complyctl scan prod
+
+  # Scan a specific target for a specific policy
+  complyctl scan prod --policy-id nist-800-53-r5
+
+  # Scan all targets for a policy (backward compatible)
+  complyctl scan --policy-id nist-800-53-r5
+
+  # Scan with output format
+  complyctl scan prod --policy-id nist-800-53-r5 --format pretty
   complyctl scan --policy-id nist-800-53-r5 --format oscal
-  complyctl scan --policy-id nist-800-53-r5 --format sarif
-  COMPLYTIME_EXPORT_ENABLED=true complyctl scan --policy-id nist-800-53-r5 --format sarif`,
+
+  # Export evidence to Beacon collector alongside format report
+  COMPLYTIME_EXPORT_ENABLED=true complyctl scan prod --format sarif`,
 		SilenceUsage:      true,
-		Args:              cobra.NoArgs,
-		ValidArgsFunction: cobra.NoFileCompletions,
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: completeTargetIDs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				o.target = args[0]
+			}
 			if err := o.validate(); err != nil {
 				return err
 			}
@@ -65,9 +83,6 @@ same shell session or CI job step that invokes complyctl scan.`,
 	cmd.Flags().StringVarP(&o.policyID, "policy-id", "p", "", "Policy ID to scan (see complyctl list)")
 	cmd.Flags().StringVarP(&o.format, "format", "f", "", "Output format: oscal, pretty, sarif")
 	cmd.Flags().DurationVarP(&o.timeout, "timeout", "t", complytime.DefaultCommandTimeout, "Maximum time for the scan operation (e.g. 5m, 10m, 1h)")
-	if err := cmd.MarkFlagRequired("policy-id"); err != nil {
-		logger.Error("Failed to mark policy-id as required", "error", err)
-	}
 	if err := cmd.RegisterFlagCompletionFunc("format", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{complytime.OutputFormatOSCAL, complytime.OutputFormatPretty, complytime.OutputFormatSARIF}, cobra.ShellCompDirectiveNoFileComp
 	}); err != nil {
@@ -79,6 +94,24 @@ same shell session or CI job step that invokes complyctl scan.`,
 		logger.Error("Failed to register policy-id completion", "error", err)
 	}
 	return cmd
+}
+
+// completeTargetIDs provides shell completion for the scan command's
+// positional target argument by reading target IDs from complytime.yaml.
+func completeTargetIDs(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+	// Only complete the first positional argument.
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	cfg, err := loadWorkspaceConfig()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	ids := make([]string, 0, len(cfg.Targets))
+	for _, t := range cfg.Targets {
+		ids = append(ids, t.ID)
+	}
+	return ids, cobra.ShellCompDirectiveNoFileComp
 }
 
 func (o *scanOptions) validate() error {
@@ -119,12 +152,77 @@ func (o *scanOptions) run(ctx context.Context) error {
 		return fmt.Errorf("no targets in complytime.yaml (add targets with policies)")
 	}
 
-	entry, found := complytime.FindPolicy(cfg.Policies, o.policyID)
-	if !found {
-		return fmt.Errorf("policy %q not found in config — run complyctl list to see available policy IDs", o.policyID)
+	// Resolve target (if specified) and determine the effective policy ID.
+	var target *complytime.TargetConfig
+	if o.target != "" {
+		target, err = resolveTarget(cfg, o.target)
+		if err != nil {
+			return err
+		}
 	}
 
-	return o.scanPolicy(ctx, cfg, *entry)
+	policyID, err := resolvePolicy(target, o.policyID)
+	if err != nil {
+		return err
+	}
+
+	entry, found := complytime.FindPolicy(cfg.Policies, policyID)
+	if !found {
+		return fmt.Errorf("policy %q not found in config — run complyctl list to see available policy IDs", policyID)
+	}
+
+	return o.scanPolicy(ctx, cfg, *entry, o.target)
+}
+
+// resolveTarget finds a target by ID in the config's target list.
+// Returns an error listing available target IDs if the target is not found.
+func resolveTarget(cfg *complytime.WorkspaceConfig, targetID string) (*complytime.TargetConfig, error) {
+	for i, t := range cfg.Targets {
+		if t.ID == targetID {
+			return &cfg.Targets[i], nil
+		}
+	}
+	available := make([]string, 0, len(cfg.Targets))
+	for _, t := range cfg.Targets {
+		available = append(available, t.ID)
+	}
+	return nil, fmt.Errorf("target %q not found in complytime.yaml (available targets: %s)",
+		targetID, strings.Join(available, ", "))
+}
+
+// resolvePolicy determines the policy ID to use based on the target and
+// --policy-id flag combination. It handles three cases:
+//   - Both target and policy-id: validates the target references the policy
+//   - Target without policy-id: infers policy if target has exactly one
+//   - No target: requires policy-id (backward compatible)
+func resolvePolicy(target *complytime.TargetConfig, policyID string) (string, error) {
+	if target != nil && policyID != "" {
+		// Both specified — validate the target references the policy.
+		if !slices.Contains(target.Policies, policyID) {
+			return "", fmt.Errorf("target %q does not reference policy %q (available policies: %s)",
+				target.ID, policyID, strings.Join(target.Policies, ", "))
+		}
+		return policyID, nil
+	}
+
+	if target != nil && policyID == "" {
+		// Target without policy-id — infer if single policy.
+		switch len(target.Policies) {
+		case 0:
+			return "", fmt.Errorf("target %q has no policies configured", target.ID)
+		case 1:
+			return target.Policies[0], nil
+		default:
+			return "", fmt.Errorf("target %q references multiple policies — specify one with --policy-id: %s",
+				target.ID, strings.Join(target.Policies, ", "))
+		}
+	}
+
+	// No target — require policy-id.
+	if policyID == "" {
+		return "", fmt.Errorf("specify a target or --policy-id (see complyctl scan --help)")
+	}
+	return policyID, nil
 }
 
 func loadWorkspaceConfig() (*complytime.WorkspaceConfig, error) {
@@ -135,7 +233,7 @@ func loadWorkspaceConfig() (*complytime.WorkspaceConfig, error) {
 	return ws.Config(), nil
 }
 
-func (o *scanOptions) scanPolicy(ctx context.Context, cfg *complytime.WorkspaceConfig, entry complytime.PolicyEntry) error {
+func (o *scanOptions) scanPolicy(ctx context.Context, cfg *complytime.WorkspaceConfig, entry complytime.PolicyEntry, targetID string) error {
 	ref := complytime.ParsePolicyRef(entry.URL)
 	eid := entry.EffectiveID()
 
@@ -157,8 +255,16 @@ func (o *scanOptions) scanPolicy(ctx context.Context, cfg *complytime.WorkspaceC
 	policyTargets := filterTargetsForPolicy(cfg.Targets, eid)
 	evaluatorIDs := evaluatorIDList(groups)
 
+	// Generation runs for ALL targets referencing the policy (per D7:
+	// generation freshness is policy-scoped, not target-scoped). Narrowing
+	// before generation would silently skip targets that were never generated.
 	if err := ensureGenerated(ctx, o.cacheDir, mgr, groups, policyTargets, cfg.Variables, ref.Repository, eid, evaluatorIDs); err != nil {
 		return err
+	}
+
+	// Narrow to the requested target AFTER generation, BEFORE scan execution.
+	if targetID != "" {
+		policyTargets = filterTargetByID(policyTargets, targetID)
 	}
 
 	targetIDs := targetIDList(policyTargets)
@@ -272,6 +378,18 @@ func buildEvaluator(repository string, reqToControl map[string]string, policyTar
 		eval.AddTarget(targetAssessments)
 	}
 	return eval
+}
+
+// filterTargetByID narrows a target slice to the single target matching the
+// given ID. Returns the original slice unchanged if no match is found (the
+// caller has already validated the target exists via resolveTarget).
+func filterTargetByID(targets []complytime.TargetConfig, targetID string) []complytime.TargetConfig {
+	for _, t := range targets {
+		if t.ID == targetID {
+			return []complytime.TargetConfig{t}
+		}
+	}
+	return targets
 }
 
 func filterTargetsForPolicy(targets []complytime.TargetConfig, policyID string) []complytime.TargetConfig {

--- a/openspec/changes/scan-target-arg/.openspec.yaml
+++ b/openspec/changes/scan-target-arg/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-07

--- a/openspec/changes/scan-target-arg/design.md
+++ b/openspec/changes/scan-target-arg/design.md
@@ -1,0 +1,77 @@
+## Context
+
+The `complyctl scan` command currently uses `cobra.NoArgs` and requires `--policy-id`. Target filtering is done exclusively by `filterTargetsForPolicy()` which returns all targets referencing the given policy. There is no mechanism to select a specific target.
+
+The scan flow is: `run()` → `scanPolicy()` → `filterTargetsForPolicy()` → `executeScanPhase()` → `scanAllTargets()`. The target filtering happens at one place (`scanPolicy()` line 157), making it straightforward to add an additional filter.
+
+The `generate` command has the same pattern and could benefit from the same target scoping, but that is out of scope for this change.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add optional positional `<target>` argument to `complyctl scan`
+- Make `--policy-id` inferrable when a target references exactly one policy
+- Maintain full backward compatibility — `complyctl scan --policy-id X` works identically
+- Provide shell completion for target IDs
+
+**Non-Goals:**
+- Supporting multiple positional target arguments (single target only)
+- Adding target scoping to the `generate` command (future work)
+- Changing how targets are defined in `complytime.yaml`
+
+## Decisions
+
+### D1: Positional argument, not a flag
+
+Use a positional argument (`complyctl scan <target>`) rather than a flag (`--target`).
+
+Rationale: The target is the primary noun of the scan operation — "scan this target." Positional arguments are the natural CLI idiom for the primary subject of a command (like `git checkout <branch>`, `docker run <image>`). A flag would work but feels heavier for something used frequently.
+
+### D2: Policy inference from single-policy targets
+
+When a target references exactly one policy, `--policy-id` can be omitted — the policy is inferred. When a target references multiple policies, `--policy-id` is required to disambiguate. The error message in the multi-policy case lists the available policies for that target.
+
+Rationale: Most targets reference a single policy. Requiring `--policy-id` in that case is redundant typing. The inference rule is simple and deterministic — no ambiguity.
+
+### D3: Require at least one of target or --policy-id
+
+`complyctl scan` with neither a target nor `--policy-id` is an error. The error message explains the two options.
+
+Rationale: Scanning "everything" (all targets × all policies) is a complex operation that could be slow and produce confusing output. It's better to require explicit scoping. This also avoids a breaking change — `--policy-id` was previously required, so existing scripts that omit it already get an error.
+
+### D4: Hard error on target/policy mismatch
+
+When both `<target>` and `--policy-id` are specified but the target does not reference that policy, the command exits with an error: `target "X" does not reference policy "Y" (available policies: a, b)`.
+
+Rationale: Silent skip or empty results would be confusing. A clear error with the target's available policies helps the user correct the invocation immediately.
+
+### D5: cobra.MaximumNArgs(1) for the positional argument
+
+Change from `cobra.NoArgs` to `cobra.MaximumNArgs(1)`. The argument is optional — when omitted, the command falls back to `--policy-id`-only behavior (scan all targets for that policy).
+
+Rationale: `MaximumNArgs(1)` allows zero or one positional arg, preserving backward compatibility while enabling the new target-scoped flow.
+
+### D6: Resolution in run(), filtering in scanPolicy()
+
+Target resolution (lookup by ID, existence validation, policy inference) happens in `run()` alongside the existing config loading and policy lookup. The resolved target ID is passed through to `scanPolicy()`, which performs the actual filtering after `filterTargetsForPolicy()` — narrowing the `policyTargets` slice to just the specified target. This keeps `run()` as the validation layer and `scanPolicy()` as the execution layer, matching the existing pattern.
+
+Rationale: Clean separation of concerns. `run()` validates inputs and resolves references. `scanPolicy()` already does target filtering via `filterTargetsForPolicy()` — adding a second filter step there is natural and minimal diff. Avoids mutating `cfg.Targets` before passing it through.
+
+### D7: Target narrowing happens AFTER generation, BEFORE scan
+
+In `scanPolicy()`, the target filter must be applied after `ensureGenerated()` but before `executeScanPhase()`. Generation freshness is tracked per-policy (via `GenerationState.PolicyDigest`), not per-target. If we narrow targets before generation, a sequence like:
+
+```
+complyctl scan prod --policy-id nist    → generates for prod only
+complyctl scan staging --policy-id nist → skips generation (digest fresh) — staging never generated
+```
+
+would silently skip generation for `staging` because the policy digest hasn't changed. By keeping generation on the full `policyTargets` set and narrowing only for the scan execution, generation always covers all targets that reference the policy (matching current behavior), while the scan itself is scoped to the requested target.
+
+Rationale: Correctness with minimal change. Fixing generation state to be target-aware would work but is scope creep. The ordering approach is a one-line difference — filter after `ensureGenerated()`, not before.
+
+## Risks / Trade-offs
+
+- **[UX] Positional + flag interaction**: Users must understand that `<target>` is the first positional arg, not a subcommand. Mitigated by clear help text and examples.
+- **[Backward compat] --policy-id no longer marked required**: Cobra's `MarkFlagRequired` is removed, replaced by custom validation. Existing `--policy-id`-only invocations still work, but the cobra-generated "required flag" error message changes to our custom one.
+- **[Performance] Generation runs for all targets even when scanning one**: When a target is specified, generation still runs for all targets referencing the policy. This matches current behavior and ensures correctness. Optimizing generation to be target-aware is future work.

--- a/openspec/changes/scan-target-arg/proposal.md
+++ b/openspec/changes/scan-target-arg/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The `complyctl scan` command currently requires `--policy-id` and scans every target in `complytime.yaml` that references that policy. In workspaces with multiple targets (e.g., `production-cluster`, `staging`, `dev-workstation`), there is no way to scan a single target without editing the config file. Users need to scope scans to specific targets for faster iteration, CI pipeline per-environment runs, and debugging individual target configurations.
+
+## What Changes
+
+- Add an optional positional argument `<target>` to the `scan` command: `complyctl scan <target> [--policy-id <ID>]`
+- When `<target>` is specified, the scan is scoped to only that target (matched by its `id` field in `complytime.yaml`)
+- Make `--policy-id` optional when a target is specified and that target references exactly one policy (inferred). When the target references multiple policies, `--policy-id` is required to disambiguate.
+- When neither `<target>` nor `--policy-id` is provided, the command returns an error requiring at least one.
+- When both are specified, validate that the target actually references the given policy — hard error if it doesn't.
+- Add shell completion for the `<target>` positional argument based on target IDs from `complytime.yaml`.
+
+## Capabilities
+
+### New Capabilities
+- `scan-target-arg`: Positional target argument for the scan command with policy inference and validation.
+
+### Modified Capabilities
+
+## Impact
+
+- **CLI surface**: `complyctl scan` gains an optional positional argument. `--policy-id` changes from required to conditionally required. Fully backward-compatible — existing `complyctl scan --policy-id X` invocations continue to work unchanged.
+- **Code**: `cmd/complyctl/cli/scan.go` (command definition, validation, target resolution), `cmd/complyctl/cli/generate.go` (may benefit from same target scoping).
+- **Tests**: Unit tests for new validation logic, E2E tests for target-scoped scans, shell completion tests.
+- **No dependency changes**.

--- a/openspec/changes/scan-target-arg/specs/scan-target-arg/spec.md
+++ b/openspec/changes/scan-target-arg/specs/scan-target-arg/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: Scan command accepts optional target positional argument
+The `complyctl scan` command SHALL accept an optional positional argument specifying a target ID from `complytime.yaml`. When provided, the scan SHALL be scoped to only that target.
+
+#### Scenario: Scan a specific target with --policy-id
+- **GIVEN** a `complytime.yaml` with targets `prod` and `staging`, both referencing policy `nist`
+- **WHEN** the user runs `complyctl scan prod --policy-id nist`
+- **THEN** only target `prod` is scanned for policy `nist`
+
+#### Scenario: Scan a specific target without --policy-id (single policy)
+- **GIVEN** a `complytime.yaml` with target `prod` referencing exactly one policy `nist`
+- **WHEN** the user runs `complyctl scan prod`
+- **THEN** the policy `nist` is inferred and target `prod` is scanned for it
+
+#### Scenario: Scan a specific target without --policy-id (multiple policies)
+- **GIVEN** a `complytime.yaml` with target `prod` referencing policies `nist` and `cis`
+- **WHEN** the user runs `complyctl scan prod`
+- **THEN** the command SHALL exit with an error listing the available policies for target `prod` and instructing the user to specify `--policy-id`
+
+#### Scenario: Target not found in config
+- **GIVEN** a `complytime.yaml` with targets `prod` and `staging`
+- **WHEN** the user runs `complyctl scan nonexistent`
+- **THEN** the command SHALL exit with an error indicating target `nonexistent` was not found and listing available target IDs
+
+### Requirement: Target and policy mismatch produces an error
+When both a target positional argument and `--policy-id` are specified, the command SHALL validate that the target references the given policy.
+
+#### Scenario: Target does not reference the given policy
+- **GIVEN** a `complytime.yaml` with target `prod` referencing policy `nist` only
+- **WHEN** the user runs `complyctl scan prod --policy-id cis`
+- **THEN** the command SHALL exit with an error indicating target `prod` does not reference policy `cis` and listing the target's available policies
+
+### Requirement: At least one of target or --policy-id is required
+The `complyctl scan` command SHALL require at least one of a target positional argument or the `--policy-id` flag.
+
+#### Scenario: Neither target nor --policy-id provided
+- **WHEN** the user runs `complyctl scan` with no arguments and no `--policy-id`
+- **THEN** the command SHALL exit with an error explaining that at least a target or `--policy-id` is required
+
+### Requirement: Backward compatibility with --policy-id only
+When no positional argument is provided and `--policy-id` is specified, the scan command SHALL behave identically to the current implementation — scanning all targets that reference the given policy.
+
+#### Scenario: Policy-only scan (existing behavior)
+- **GIVEN** a `complytime.yaml` with targets `prod` and `staging`, both referencing policy `nist`
+- **WHEN** the user runs `complyctl scan --policy-id nist`
+- **THEN** both `prod` and `staging` are scanned for policy `nist` (unchanged behavior)
+
+### Requirement: Shell completion for target argument
+The scan command SHALL provide shell completion for the target positional argument using target IDs from `complytime.yaml`.
+
+#### Scenario: Tab completion suggests target IDs
+- **WHEN** the user invokes shell completion for the first positional argument of `complyctl scan`
+- **THEN** the completion SHALL offer the target IDs defined in `complytime.yaml`
+
+## MODIFIED Requirements
+
+None.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/scan-target-arg/tasks.md
+++ b/openspec/changes/scan-target-arg/tasks.md
@@ -1,0 +1,32 @@
+## 1. Update scan command definition
+
+- [x] 1.1 Change `cobra.NoArgs` to `cobra.MaximumNArgs(1)` in `scanCmd()`
+- [x] 1.2 Remove `cmd.MarkFlagRequired("policy-id")` — validation moves to custom logic
+- [x] 1.3 Add a `target` field to `scanOptions` struct, populated from `args[0]` when present
+- [x] 1.4 Update scan command `Use` to `scan [target] [flags]`, update `Short`, `Long`, and `Example` with target usage
+- [x] 1.5 Add `ValidArgsFunction` for the positional arg that reads `complytime.yaml` and returns target IDs for shell completion
+
+## 2. Implement target resolution and policy inference
+
+- [x] 2.1 Add `resolveTarget(cfg, targetID)` helper that finds a target by ID in `cfg.Targets`, returns error with available IDs if not found
+- [x] 2.2 Add `resolvePolicy(cfg, target, policyID)` helper that handles the three cases: (a) both target and policy-id given — validate target references the policy, (b) target given without policy-id — infer if single policy, error with list if multiple, (c) no target — require policy-id
+- [x] 2.3 Modify `run()` to call resolution logic: resolve target first (if provided), then resolve policy. Pass the resolved target ID through to `scanPolicy()`.
+- [x] 2.5 In `scanPolicy()`, narrow `policyTargets` AFTER `ensureGenerated()` but BEFORE `executeScanPhase()`. Generation must run for all targets referencing the policy (per D7), only the scan execution is target-scoped.
+- [x] 2.4 Update the error message for missing policy-id to reflect the new options: "specify a target or --policy-id (see complyctl scan --help)"
+
+## 3. Update tests
+
+- [x] 3.1 [P] Add unit test: `complyctl scan prod --policy-id nist` scopes to single target
+- [x] 3.2 [P] Add unit test: `complyctl scan prod` with single-policy target infers policy
+- [x] 3.3 [P] Add unit test: `complyctl scan prod` with multi-policy target produces error listing policies
+- [x] 3.4 [P] Add unit test: `complyctl scan nonexistent` produces error with available target IDs
+- [x] 3.5 [P] Add unit test: `complyctl scan prod --policy-id cis` when prod doesn't have cis produces mismatch error
+- [x] 3.6 [P] Add unit test: `complyctl scan` with no args and no --policy-id produces error
+- [x] 3.7 [P] Add unit test: `complyctl scan --policy-id nist` without target scans all targets (backward compat)
+- [x] 3.8 Update existing `TestScanOptions_Validate_*` tests if validation logic changes
+- [x] 3.9 Add E2E test for target-scoped scan
+
+## 4. Cleanup and verify
+
+- [x] 4.1 Update `README.md` scan section with target argument documentation
+- [x] 4.2 Run `go build ./...` and `go test ./...` to verify

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -266,6 +266,91 @@ func TestE2E_ScanDefaultFormat(t *testing.T) {
 	}
 }
 
+// TestE2E_ScanTargetArg verifies the target positional argument scopes scans
+// to a single target and that policy inference works for single-policy targets.
+func TestE2E_ScanTargetArg(t *testing.T) {
+	binary := locateBinary(t)
+	srv := startMockRegistry(t)
+	defer srv.Close()
+
+	homeDir := t.TempDir()
+	workDir := t.TempDir()
+	installTestPlugin(t, homeDir)
+	env := buildEnv(homeDir)
+
+	// Multi-target config: two targets referencing the same policy.
+	configYAML := fmt.Sprintf(`policies:
+  - url: %s/nist-800-53-r5
+    id: nist-800-53-r5
+targets:
+  - id: prod
+    policies:
+      - nist-800-53-r5
+    variables:
+      env: production
+  - id: staging
+    policies:
+      - nist-800-53-r5
+    variables:
+      env: staging
+`, srv.URL)
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "complytime.yaml"), []byte(configYAML), 0644))
+
+	runComplytime(t, binary, workDir, env, "get")
+
+	// Subtest: scan with target and --policy-id
+	t.Run("target_with_policy_id", func(t *testing.T) {
+		scanDir := filepath.Join(workDir, "scan-target-policy")
+		require.NoError(t, os.MkdirAll(scanDir, 0755))
+		copyWorkspaceConfig(t, workDir, scanDir)
+
+		out := runComplytime(t, binary, scanDir, env,
+			"scan", "prod", "--policy-id", testPolicyID)
+		t.Log(out)
+		assert.Contains(t, out, "requirements:", "scan must complete with requirements summary")
+		// Verify evaluation log was produced
+		evalDir := filepath.Join(scanDir, complytime.WorkspaceDir, complytime.ScanOutputDir)
+		assertOutputFile(t, evalDir, "evaluation-log-", ".yaml")
+	})
+
+	// Subtest: scan with target only (policy inferred from single-policy target)
+	t.Run("target_inferred_policy", func(t *testing.T) {
+		scanDir := filepath.Join(workDir, "scan-target-inferred")
+		require.NoError(t, os.MkdirAll(scanDir, 0755))
+		copyWorkspaceConfig(t, workDir, scanDir)
+
+		out := runComplytime(t, binary, scanDir, env,
+			"scan", "staging")
+		t.Log(out)
+		assert.Contains(t, out, "requirements:", "scan must complete with requirements summary")
+		// Verify evaluation log was produced
+		evalDir := filepath.Join(scanDir, complytime.WorkspaceDir, complytime.ScanOutputDir)
+		assertOutputFile(t, evalDir, "evaluation-log-", ".yaml")
+	})
+
+	// Subtest: scan with nonexistent target produces error
+	t.Run("target_not_found", func(t *testing.T) {
+		cmd := exec.Command(binary, "scan", "nonexistent")
+		cmd.Dir = workDir
+		cmd.Env = env
+		output, err := cmd.CombinedOutput()
+		require.Error(t, err, "nonexistent target must produce error")
+		assert.Contains(t, string(output), "not found")
+		assert.Contains(t, string(output), "prod")
+		assert.Contains(t, string(output), "staging")
+	})
+
+	// Subtest: scan with no args and no --policy-id produces error
+	t.Run("no_args_no_policy", func(t *testing.T) {
+		cmd := exec.Command(binary, "scan")
+		cmd.Dir = workDir
+		cmd.Env = env
+		output, err := cmd.CombinedOutput()
+		require.Error(t, err, "scan with no args must produce error")
+		assert.Contains(t, string(output), "specify a target or --policy-id")
+	})
+}
+
 // TestE2E_InvalidFormat verifies invalid scan format is rejected.
 func TestE2E_InvalidFormat(t *testing.T) {
 	binary := locateBinary(t)


### PR DESCRIPTION
## Summary

Add an optional positional `[target]` argument to `complyctl scan` so users can scope scans to a single target from `complytime.yaml`.

- `complyctl scan prod` — scan only target `prod`, infer policy if target references exactly one
- `complyctl scan prod --policy-id nist` — scan `prod` for a specific policy, error if target doesn't reference it
- `complyctl scan --policy-id nist` — backward compatible, scan all targets for that policy (unchanged)
- `complyctl scan` — error, require at least one of target or `--policy-id`
- Shell completion for target IDs from `complytime.yaml`

## Design Decisions

- **D6**: Target resolution (lookup, validation) in `run()`, filtering in `scanPolicy()` — clean separation of validation vs execution layers
- **D7**: Target narrowing happens AFTER `ensureGenerated()` but BEFORE `executeScanPhase()` — generation freshness is policy-scoped, not target-scoped. If we narrowed before generation, subsequent target-scoped scans would skip generation for targets that were never generated.

## Test Coverage

- 20 new unit tests covering all resolution paths (target found/not found, policy match/mismatch, single/multi-policy inference, backward compat)
- E2E test with 4 subtests (target+policy, inferred policy, not found, no args)
- Manually validated on a Fedora VM with mock OCI registry and test provider

## Spec Artifacts

OpenSpec change at `openspec/changes/scan-target-arg/` with proposal, design (7 decisions), specs (5 requirements, 7 scenarios), and tasks.