### PR TITLE
feat: add cross-repo integration test infrastructure for complyctl + Ampel provider

### DIFF
--- a/.github/workflows/ci_cross_repo_integration.yml
+++ b/.github/workflows/ci_cross_repo_integration.yml
@@ -3,7 +3,7 @@
 # builds the Ampel provider binary, installs snappy and ampel, and runs the
 # cross-repo integration test script to validate the full complyctl + Ampel
 # provider pipeline end-to-end.
-name: ci-cross-repo-integration
+name: Cross-Repo Integration Test
 
 on:
     push:
@@ -53,10 +53,10 @@ jobs:
               working-directory: _providers
 
             - name: Install snappy
-              uses: carabiner-dev/actions/install/snappy@360ffa1eb909b0105d4eccb6d6ef337911c34952
+              uses: carabiner-dev/actions/install/snappy@e0e3b8149dafed833431095bc148d50e7eade4e8 # v1.2.0
 
             - name: Install ampel
-              uses: carabiner-dev/actions/install/ampel@360ffa1eb909b0105d4eccb6d6ef337911c34952
+              uses: carabiner-dev/actions/install/ampel@e0e3b8149dafed833431095bc148d50e7eade4e8 # v1.2.0
 
             - name: Run cross-repo integration test
               env:

--- a/.github/workflows/ci_cross_repo_integration.yml
+++ b/.github/workflows/ci_cross_repo_integration.yml
@@ -1,0 +1,65 @@
+# Cross-repo integration test workflow.
+# Builds complyctl from the PR branch, checks out complytime-providers@main,
+# builds the Ampel provider binary, installs snappy and ampel, and runs the
+# cross-repo integration test script to validate the full complyctl + Ampel
+# provider pipeline end-to-end.
+name: ci-cross-repo-integration
+
+on:
+    push:
+        branches:
+            - main
+    pull_request:
+
+permissions:
+    contents: read
+
+jobs:
+    cross-repo-integration:
+        name: Cross-Repo Integration Test
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout complyctl
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+
+            - name: Set up Go (complyctl)
+              uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+              with:
+                  go-version-file: './go.mod'
+
+            - name: Build complyctl
+              run: make build
+
+            # Intentionally tracks main for HEAD-to-HEAD cross-repo integration.
+            # This is a same-org repo under the same maintainer trust boundary.
+            - name: Checkout complytime-providers
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  repository: complytime/complytime-providers
+                  ref: main
+                  path: _providers
+                  persist-credentials: false
+
+            - name: Set up Go (complytime-providers)
+              uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+              with:
+                  go-version-file: './_providers/go.mod'
+
+            - name: Build complytime-providers
+              run: make build
+              working-directory: _providers
+
+            - name: Install snappy
+              uses: carabiner-dev/actions/install/snappy@360ffa1eb909b0105d4eccb6d6ef337911c34952
+
+            - name: Install ampel
+              uses: carabiner-dev/actions/install/ampel@360ffa1eb909b0105d4eccb6d6ef337911c34952
+
+            - name: Run cross-repo integration test
+              env:
+                  PROVIDERS_BIN_DIR: ${{ github.workspace }}/_providers/bin
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: make test-cross-repo PROVIDERS_BIN_DIR="${PROVIDERS_BIN_DIR}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,10 @@ make test-e2e
 make test-integration
 # → ./tests/integration_test.sh
 
+# Cross-repo integration tests (requires PROVIDERS_BIN_DIR and GITHUB_TOKEN)
+make test-cross-repo PROVIDERS_BIN_DIR=/path/to/providers/bin
+# → timeout 120 ./tests/cross-repo/cross_repo_integration_test.sh
+
 # Behavioral assessment (EvaluationLog + SARIF reports)
 make test-behavioral
 ```
@@ -70,6 +74,7 @@ make crapload-check     # check for CRAP regressions against baseline
 | Unit Test | `unit_test.yml` | Unit tests + buf lint |
 | E2E Test | `e2e_test.yml` | End-to-end tests with mock registry |
 | Integration Test | `integration_test.yml` | Shell-based integration tests |
+| Cross-Repo Integration | `ci_cross_repo_integration.yml` | Cross-repo integration tests with complytime-providers |
 | CRAP Load | `ci_crapload.yml` | CRAP analysis on PRs (reusable from org-infra) |
 | CRAP Main | `ci_crapload_main.yml` | CRAP baseline updates on main |
 | Security | `ci_security.yml` | Security scanning |
@@ -113,6 +118,7 @@ scripts/             # maintenance scripts (SPDX checks, workflow setup)
 specs/               # Speckit strategic specifications (NNN-*/  format)
 tests/
 ├── behavioral/      # behavioral test scenarios
+├── cross-repo/      # cross-repo integration tests (complyctl + ampel provider)
 ├── e2e/             # E2E tests (build-tag gated: -tags=e2e)
 └── integration_test.sh  # shell-based integration test
 vendor/              # vendored dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,13 @@
 # Changelog
+
+## Unreleased
+
+### Added
+
+- Cross-repo integration test infrastructure validating the complyctl + Ampel
+  provider pipeline end-to-end (`tests/cross-repo/`, `make test-cross-repo`).
+- CI workflow `ci_cross_repo_integration.yml` that builds complyctl from the PR
+  branch and complytime-providers from main, then runs the full get → generate →
+  scan pipeline with real snappy and ampel binaries.
+- Minimal test Gemara policy (`policies/test-branch-protection`) seeded in the
+  mock OCI registry for integration testing.

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,13 @@ test-integration: build build-test-provider ## run integration test (mock regist
 	./tests/integration_test.sh
 .PHONY: test-integration
 
+test-cross-repo: build ## run cross-repo integration test (requires PROVIDERS_BIN_DIR and GITHUB_TOKEN)
+ifndef PROVIDERS_BIN_DIR
+	$(error PROVIDERS_BIN_DIR is not set. Set it to the directory containing complyctl-provider-ampel)
+endif
+	timeout 120 ./tests/cross-repo/cross_repo_integration_test.sh
+.PHONY: test-cross-repo
+
 ##@ Compilation
 
 all: clean vendor test-unit build ## compile from scratch

--- a/cmd/mock-oci-registry/main.go
+++ b/cmd/mock-oci-registry/main.go
@@ -444,6 +444,25 @@ func (s *contentStore) enrich(req enrichmentRequest) enrichmentResponse {
 
 // --- Seed Data ---
 
+// seedPolicyFromFiles loads a catalog and policy YAML from embedded testdata
+// files and registers them as a versioned OCI artifact in the content store.
+func (s *contentStore) seedPolicyFromFiles(
+	repoPath, catalogFile, policyFile string, tags []string,
+) {
+	catalog, err := seedData.ReadFile(catalogFile)
+	if err != nil {
+		log.Fatalf("failed to load catalog seed data from %s: %v", catalogFile, err)
+	}
+	policy, err := seedData.ReadFile(policyFile)
+	if err != nil {
+		log.Fatalf("failed to load policy seed data from %s: %v", policyFile, err)
+	}
+	s.addArtifact(repoPath, tags, []layerDef{
+		{mediaType: gemaraCatalogType, data: catalog},
+		{mediaType: gemaraPolicyType, data: policy},
+	})
+}
+
 func (s *contentStore) seedDefaults() {
 	// policies/nist-800-53-r5
 	s.addArtifact("policies/nist-800-53-r5", []string{"v1.0.0", "latest"}, []layerDef{
@@ -601,48 +620,19 @@ guidelines:
 `)},
 	})
 
-	// policies/cis-fedora-l1-workstation — real CIS Fedora L1 Workstation data
-	// sourced from ComplianceAsCode/oscal-content component-definitions
-	cisCatalog, err := seedData.ReadFile("testdata/cis-fedora-l1-workstation-catalog.yaml")
-	if err != nil {
-		log.Fatalf("failed to load CIS Fedora catalog seed data: %v", err)
-	}
-	cisPolicy, err := seedData.ReadFile("testdata/cis-fedora-l1-workstation-policy.yaml")
-	if err != nil {
-		log.Fatalf("failed to load CIS Fedora policy seed data: %v", err)
-	}
-	s.addArtifact("policies/cis-fedora-l1-workstation", []string{"v1.0.0", "latest"}, []layerDef{
-		{mediaType: gemaraCatalogType, data: cisCatalog},
-		{mediaType: gemaraPolicyType, data: cisPolicy},
-	})
-
-	// policies/ampel-branch-protection — AMPEL branch protection controls
-	ampelCatalog, err := seedData.ReadFile("testdata/ampel-branch-protection-catalog.yaml")
-	if err != nil {
-		log.Fatalf("failed to load AMPEL branch protection catalog seed data: %v", err)
-	}
-	ampelPolicy, err := seedData.ReadFile("testdata/ampel-branch-protection-policy.yaml")
-	if err != nil {
-		log.Fatalf("failed to load AMPEL branch protection policy seed data: %v", err)
-	}
-	s.addArtifact("policies/ampel-branch-protection", []string{"v1.0.0", "latest"}, []layerDef{
-		{mediaType: gemaraCatalogType, data: ampelCatalog},
-		{mediaType: gemaraPolicyType, data: ampelPolicy},
-	})
-
-	// policies/test-branch-protection — minimal policy for cross-repo integration testing
-	testCatalog, err := seedData.ReadFile("testdata/test-branch-protection-catalog.yaml")
-	if err != nil {
-		log.Fatalf("failed to load test branch protection catalog seed data: %v", err)
-	}
-	testPolicy, err := seedData.ReadFile("testdata/test-branch-protection-policy.yaml")
-	if err != nil {
-		log.Fatalf("failed to load test branch protection policy seed data: %v", err)
-	}
-	s.addArtifact("policies/test-branch-protection", []string{"v1.0.0", "latest"}, []layerDef{
-		{mediaType: gemaraCatalogType, data: testCatalog},
-		{mediaType: gemaraPolicyType, data: testPolicy},
-	})
+	// File-based policies — catalog + policy YAML loaded from testdata/
+	s.seedPolicyFromFiles("policies/cis-fedora-l1-workstation",
+		"testdata/cis-fedora-l1-workstation-catalog.yaml",
+		"testdata/cis-fedora-l1-workstation-policy.yaml",
+		[]string{"v1.0.0", "latest"})
+	s.seedPolicyFromFiles("policies/ampel-branch-protection",
+		"testdata/ampel-branch-protection-catalog.yaml",
+		"testdata/ampel-branch-protection-policy.yaml",
+		[]string{"v1.0.0", "latest"})
+	s.seedPolicyFromFiles("policies/test-branch-protection",
+		"testdata/test-branch-protection-catalog.yaml",
+		"testdata/test-branch-protection-policy.yaml",
+		[]string{"v1.0.0", "latest"})
 
 	// Enrichment mappings
 	s.enrichments["OPA:deny-root-user"] = &enrichmentMapping{

--- a/cmd/mock-oci-registry/main.go
+++ b/cmd/mock-oci-registry/main.go
@@ -630,6 +630,20 @@ guidelines:
 		{mediaType: gemaraPolicyType, data: ampelPolicy},
 	})
 
+	// policies/test-branch-protection — minimal policy for cross-repo integration testing
+	testCatalog, err := seedData.ReadFile("testdata/test-branch-protection-catalog.yaml")
+	if err != nil {
+		log.Fatalf("failed to load test branch protection catalog seed data: %v", err)
+	}
+	testPolicy, err := seedData.ReadFile("testdata/test-branch-protection-policy.yaml")
+	if err != nil {
+		log.Fatalf("failed to load test branch protection policy seed data: %v", err)
+	}
+	s.addArtifact("policies/test-branch-protection", []string{"v1.0.0", "latest"}, []layerDef{
+		{mediaType: gemaraCatalogType, data: testCatalog},
+		{mediaType: gemaraPolicyType, data: testPolicy},
+	})
+
 	// Enrichment mappings
 	s.enrichments["OPA:deny-root-user"] = &enrichmentMapping{
 		control: enrichmentControl{

--- a/cmd/mock-oci-registry/testdata/test-branch-protection-catalog.yaml
+++ b/cmd/mock-oci-registry/testdata/test-branch-protection-catalog.yaml
@@ -1,0 +1,26 @@
+title: Test Branch Protection Controls
+controls:
+    - id: force-push-protection
+      title: Restrict Force Pushes
+      objective: Force pushes to protected branches must be blocked
+      group: source-code
+      assessment-requirements:
+          - id: block-force-push
+            text: Force pushes to protected branches must be blocked
+            applicability:
+                - GitHub repositories
+            state: Active
+      state: Active
+groups:
+    - id: source-code
+      title: Source Code Protection
+      description: Controls for protecting source code repositories via branch protection rules
+metadata:
+    id: test-branch-protection
+    type: ControlCatalog
+    gemara-version: 1.0.0
+    description: Minimal branch protection catalog for cross-repo integration testing
+    author:
+        id: complytime
+        name: ComplyTime
+        type: Software Assisted

--- a/cmd/mock-oci-registry/testdata/test-branch-protection-policy.yaml
+++ b/cmd/mock-oci-registry/testdata/test-branch-protection-policy.yaml
@@ -1,0 +1,43 @@
+title: Test Branch Protection Policy
+metadata:
+    id: test-branch-protection-policy
+    description: Minimal policy for cross-repo integration testing using the Ampel provider
+    author:
+        id: complytime
+        name: ComplyTime
+        type: Software Assisted
+    mapping-references:
+        - id: test-branch-protection
+          title: Test Branch Protection Controls
+          version: 1.0.0
+          description: Minimal control catalog for cross-repo integration testing
+contacts:
+    responsible:
+        - name: Repository Administrator
+    accountable:
+        - name: Security Team
+scope:
+    in:
+        technologies:
+            - GitHub
+        users:
+            - Repository maintainers
+imports:
+    catalogs:
+        - reference-id: test-branch-protection
+adherence:
+    evaluation-methods:
+        - type: Behavioral
+          description: Ampel automated branch protection evaluation
+          executor:
+              id: ampel
+              name: AMPEL
+              type: Software
+    assessment-plans:
+        - id: block-force-push
+          requirement-id: block-force-push
+          frequency: on-demand
+          evaluation-methods:
+              - type: Behavioral
+                executor:
+                    id: ampel

--- a/openspec/changes/cross-repo-integration-tests/.openspec.yaml
+++ b/openspec/changes/cross-repo-integration-tests/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-13

--- a/openspec/changes/cross-repo-integration-tests/design.md
+++ b/openspec/changes/cross-repo-integration-tests/design.md
@@ -1,0 +1,192 @@
+## Context
+
+complyctl and complytime-providers were a single repository until spec 004 split the
+providers into their own repo. The split preserved the SDK contract (`pkg/provider`) and
+the gRPC wire protocol (`api/plugin/plugin.proto`) as the integration boundary, but left
+no automated mechanism to verify that the two repositories remain compatible after
+independent changes. All existing tests in both repositories are self-contained: complyctl
+uses a purpose-built `test-provider` binary stub; complytime-providers uses interface-based
+mocks and injectable command runners. Neither exercises the real binary integration.
+
+The `reusable_compliance.yml` workflow in org-infra is the only existing workflow that
+wires the two together, but it was written before the provider split and now references
+stale paths (`bin/ampel-plugin`, `cmd/ampel-plugin/`). Fixing that workflow is a
+follow-up; this change establishes the correct pattern for PR-time cross-repo testing.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Validate on every PR that the `complyctl` binary and the real `complyctl-provider-ampel`
+  binary can discover each other, complete the gRPC handshake, exchange typed data
+  through Describe / Generate / Scan RPCs, and produce correctly formatted scan output.
+- Validate that the Gemara policy layer (OCI fetch, policy resolution, assessment
+  configuration extraction) correctly drives the Ampel provider through the full pipeline.
+- Keep test content minimal (1 control, 1 assessment plan, 1 granular policy) so the
+  test is fast, deterministic, and easy to understand.
+- Design for easy extension: adding a second Ampel rule or a future OpenSCAP provider
+  should require only additive changes (new files, new test functions).
+
+**Non-Goals:**
+
+- Testing the Ampel provider's internal logic (CEL evaluation, attestation parsing) —
+  that is covered by complytime-providers unit tests.
+- Testing all 5 branch-protection rules from the existing policy — 1 rule is sufficient
+  to validate the integration boundary.
+- Adding the mirrored CI workflow to `complytime-providers` — tracked as a separate
+  change in that repository, to be implemented once this change is merged.
+- Updating `org-infra/reusable_compliance.yml` — noted as a follow-up.
+- OpenSCAP provider integration — deferred to a future change.
+- RPM-level integration testing — deferred per spec 005 (FR-027).
+
+## Decisions
+
+### D1: complyctl owns the test script (Option C)
+
+The integration test script and all test fixture content live in the complyctl
+repository. The complytime-providers CI workflow checks out complyctl and runs the
+script from there.
+
+**Rationale**: complyctl defines the integration contract — the provider SDK, the gRPC
+protocol, and the Gemara policy format. Owning the test harness here means the contract
+owner also owns the test that validates it. The providers repo only needs to build its
+binary and delegate. This avoids duplicating test logic across repositories and keeps
+the test script in sync with the codebase it primarily exercises.
+
+**Alternative rejected**: Each repo maintains its own workflow with duplicated test
+logic (Option A). Rejected because duplication creates drift — the two scripts would
+inevitably diverge.
+
+**Alternative rejected**: Centralize the test script in org-infra (Option B). Rejected
+because the test content (mock registry testdata, assertion logic) is tightly coupled
+to complyctl internals and would be harder to maintain in a separate repo.
+
+### D2: PR branch vs main for each repo
+
+When a PR is filed in complyctl, the workflow builds complyctl from the PR branch and
+checks out `complytime-providers@main` to build the stable provider binary. When the
+mirrored workflow is later added to `complytime-providers`, it will do the inverse:
+build the provider from the PR branch and check out `complyctl@main`.
+
+**Rationale**: The goal is to catch regressions introduced by the PR under review. Using
+`main` for the stable side is the least surprising convention. Building from source
+(not release artifacts) is required because PRs have not been released yet.
+
+**Note on spec 004 guidance**: Spec 004 recommended using release artifacts for the
+`ci_compliance.yml` workflow to avoid coupling CI to source. That guidance applies to
+compliance scanning workflows (which run against stable releases), not to PR-time
+integration tests (which by definition need the unreleased change). The distinction is:
+release-time integration uses artifacts; PR-time integration builds from source.
+
+### D3: Real tools (snappy + ampel), real scan target
+
+The integration test uses the real `snappy` and `ampel` CLI binaries installed via
+`carabiner-dev/actions/install/snappy` and `carabiner-dev/actions/install/ampel`.
+The scan target is `https://github.com/complytime/complyctl`, a public repository with
+branch protection enabled. The standard `GITHUB_TOKEN` (automatically available in
+Actions) provides read access to the GitHub branch rules API.
+
+**Rationale**: The user's requirement is functional integration ("ensure the binaries
+can read expected content format and produce correct outcomes"). Mock shims would not
+validate that snappy correctly collects branch protection data or that ampel correctly
+evaluates the CEL policy. Using the real tools and a real public target provides
+meaningful coverage of the full pipeline without requiring secrets beyond the
+standard token.
+
+**Risk**: If `complytime/complyctl` branch protection rules change, the test outcome
+(PASS/FAIL) may change. Mitigation: the test asserts that scan completes and produces
+output (attestation files exist, results contain the expected requirement ID), not
+that a specific PASS/FAIL result is returned. A failed policy check is a valid scan
+outcome, not a test failure.
+
+### D4: Minimal test-specific Gemara content, new mock registry entry
+
+Rather than reusing the existing 5-rule `ampel-branch-protection` policy (which would
+require providing all 5 granular policy files or silently skipping 4 of them), a
+dedicated minimal policy is added to the mock registry under
+`policies/test-branch-protection`. It contains exactly 1 control (`force-push-protection`)
+and 1 assessment plan (`block-force-push`) with executor `ampel`.
+
+**Rationale**: Using a dedicated test policy makes the test self-contained and its
+intent obvious. The ID chain (catalog → policy → granular policy → complytime.yaml) uses
+descriptive names (`block-force-push`) rather than opaque framework codes (`BP-3.01`),
+making the test easier to read and extend.
+
+### D5: Granular policy file lives in complyctl test fixtures
+
+The `block-force-push.json` granular policy file is stored in
+`tests/cross-repo/testdata/granular-policies/` within the complyctl repository (not in
+complytime-providers). The CI workflow copies it into the workspace before running the
+test.
+
+**Rationale**: Granular policies are provider-side artifacts that a user (or CI) must
+supply; they are not distributed via OCI. For the integration test, having the fixture
+in complyctl keeps the test self-contained. If the granular policy format changes in the
+future (e.g., new required fields), the test will fail and the fixture will need
+updating — which is the desired behavior, as it signals a breaking change.
+
+### D6: Scan outcome assertion strategy
+
+The test asserts:
+1. `complyctl get` succeeds and the OCI layout is written to disk.
+2. `complyctl generate` succeeds and the policy bundle JSON is written.
+3. `complyctl scan` exits 0 (tool-level success, even if policy controls evaluate FAIL).
+4. Snappy attestation file exists in `.complytime/ampel/results/`.
+5. Ampel result attestation file exists in `.complytime/ampel/results/`.
+6. The ampel result attestation contains the `block-force-push` requirement ID.
+
+**Exit-code semantics**: `complyctl scan` exits 0 when the pipeline completed (snappy
+collected data, ampel evaluated the policy, and attestations were written), regardless
+of whether individual controls passed or failed. A non-zero exit indicates a tool-level
+failure (binary not found, gRPC handshake failure, OCI fetch error, etc.). The test
+treats exit 0 as success and any non-zero exit as a test failure.
+
+The test does NOT assert a specific PASS or FAIL result for the scanned repository,
+because branch protection configuration can change. It asserts that the pipeline ran
+to completion and produced structured output.
+
+## Risks / Trade-offs
+
+**[Network dependency]** → The test calls the live GitHub API via snappy. Transient
+API failures or rate limiting could cause flaky CI. Mitigation: the standard
+`GITHUB_TOKEN` has generous rate limits for branch rules API calls. The test scans a
+single branch of a single public repository, requiring at most 1 API call per run.
+
+**[Branch protection configuration drift]** → If `complytime/complyctl` branch
+protection rules change, the scan result (PASS/FAIL) changes. Mitigation: assertions
+check output structure, not specific pass/fail status (see D6).
+
+**[snappy/ampel version pinning]** → The `carabiner-dev/actions/install/` actions
+install a specific version of snappy and ampel. If those versions become incompatible
+with the provider's expected attestation format, the test will fail.
+Mitigation: the action versions are pinned by SHA in the workflow.
+
+**[Build time]** → Building both repositories from source in CI adds time compared to
+downloading release artifacts. With Go module caching this is acceptable for PR
+validation. The test is scoped to one provider and one rule to keep total runtime low.
+
+**[complytime-providers CI coupling]** → Once the mirrored workflow is added to
+`complytime-providers`, it will pin `complyctl@main`. If complyctl's main branch is
+broken, providers PRs will also fail the cross-repo test. Mitigation: complyctl's own
+CI must pass before merging to main, so main should be stable.
+
+**[complytime-providers@main mutable ref]** → The CI workflow checks out
+`complytime/complytime-providers@main` by branch name, not by SHA. If a breaking
+change is merged to providers main without a corresponding complyctl change, the
+cross-repo test will fail on complyctl PRs until the breakage is resolved. Accepted
+risk: SHA-pinning the providers checkout would require a manual update process for
+every providers merge, adding maintenance burden that outweighs the stability benefit
+for a non-release workflow. The expected failure mode (test fails, team investigates)
+is acceptable for PR-time integration testing.
+
+## Open Questions
+
+- Should the cross-repo integration test block PR merge (required status check) or run
+  as an informational check? Recommended: required, to enforce the integration contract.
+- When should the mirrored workflow be added to `complytime-providers`? It should follow
+  immediately after this change is merged so the integration boundary is validated from
+  both sides.
+- When should the `org-infra/reusable_compliance.yml` stale-path issue be addressed?
+  This change exposes the gap but does not fix it. A follow-up OpenSpec change should
+  update the reusable workflow to check out complytime-providers for the provider binary
+  and granular policies.

--- a/openspec/changes/cross-repo-integration-tests/proposal.md
+++ b/openspec/changes/cross-repo-integration-tests/proposal.md
@@ -1,0 +1,73 @@
+## Why
+
+After the provider split (spec 004), `complyctl` and `complytime-providers` are
+developed independently, but the two must interoperate correctly at runtime: complyctl
+discovers, launches, and communicates with provider binaries over gRPC, while providers
+consume the `pkg/provider` SDK and respond to Describe/Generate/Scan RPCs. Neither
+repository currently has tests that verify this integration boundary, meaning a breaking
+change in either repo can go undetected until a user encounters it. This change
+establishes the complyctl side of the cross-repo integration test infrastructure: the
+test script, test fixtures, mock registry content, and the CI workflow that validates
+every complyctl PR against the Ampel provider from `complytime-providers@main`.
+
+The corresponding CI workflow in `complytime-providers` is tracked separately and will
+be implemented once this change is merged.
+
+## What Changes
+
+- **New test content**: Minimal Gemara catalog and policy (1 control, 1 assessment plan,
+  executor `ampel`) added to `cmd/mock-oci-registry/testdata/` and seeded in the mock
+  registry under `policies/test-branch-protection`.
+- **New test fixture**: A single Ampel granular policy JSON file (`block-force-push.json`)
+  with one tenet and GitHub-only CEL expression, placed in
+  `tests/cross-repo/testdata/granular-policies/`.
+- **New test workspace config**: `tests/cross-repo/testdata/complytime.yaml` pointing at
+  the mock registry and the `complytime/complyctl` GitHub repository as scan target.
+- **New integration test script**: `tests/cross-repo/cross_repo_integration_test.sh`
+  that orchestrates the full `get` / `generate` / `scan` pipeline using the real
+  `complyctl-provider-ampel` binary and real `snappy` / `ampel` CLI tools. This script
+  is designed to be consumed by the complytime-providers CI workflow as well.
+- **New Makefile target**: `test-cross-repo` that builds complyctl and runs the script.
+- **New CI workflow in complyctl**: `.github/workflows/ci_cross_repo_integration.yml`
+  triggers on PRs to main, builds complyctl from the PR branch, checks out
+  `complytime-providers@main`, builds the real provider binary, installs snappy and
+  ampel, and runs the integration test script.
+
+## Capabilities
+
+### New Capabilities
+
+- `cross-repo-integration-test`: End-to-end functional integration test that validates
+  complyctl and the Ampel provider binary interoperate correctly across repository
+  boundaries, covering provider discovery, gRPC lifecycle, policy resolution, and scan
+  output. The test script is designed to be reusable by `complytime-providers` CI.
+
+### Modified Capabilities
+
+## Impact
+
+- **complyctl**: `cmd/mock-oci-registry/main.go` (new policy seed), new files under
+  `tests/cross-repo/`, new Makefile target, new CI workflow.
+- **complytime-providers**: not modified by this change. A follow-up change in that
+  repository will add the mirrored CI workflow that checks out `complyctl@main` and
+  runs this test script with the providers PR branch as the binary under test.
+- **org-infra `reusable_compliance.yml`**: currently references stale paths
+  (`bin/ampel-plugin`, `cmd/ampel-plugin/`) that were valid before the provider split.
+  The new integration test design exposes this gap; a follow-up to update the reusable
+  workflow is noted but out of scope for this change.
+- **Dependencies**: `snappy` and `ampel` CLI tools installed via
+  `carabiner-dev/actions/install/` composite actions; `GITHUB_TOKEN` (standard Actions
+  token) for snappy to read branch protection rules from the public
+  `complytime/complyctl` repository.
+
+## Constitution Alignment
+
+| Principle | Assessment |
+|:----------|:-----------|
+| I. Single Source of Truth | Test script, fixtures, and CI workflow live in one place (complyctl). No duplication with complytime-providers. |
+| II. Simplicity & Isolation | Minimal test content (1 control, 1 rule). Each test function is isolated and independently verifiable. |
+| III. Incremental Improvement | Scoped to complyctl side only. Providers side is a separate change. |
+| IV. Readability First | Descriptive IDs (`block-force-push`, `force-push-protection`) throughout. Script follows existing `integration_test.sh` style. |
+| V. Do Not Reinvent the Wheel | Uses established `carabiner-dev/actions` for tool installation; reuses existing mock registry infrastructure. |
+| VI. Composability | Test script is reusable by `complytime-providers` CI. `make test-cross-repo` is a composable Makefile target. |
+| VII. Convention Over Configuration | `PROVIDERS_BIN_DIR` is the only required input; all other paths derived from conventions. |

--- a/openspec/changes/cross-repo-integration-tests/specs/cross-repo-integration-test/spec.md
+++ b/openspec/changes/cross-repo-integration-tests/specs/cross-repo-integration-test/spec.md
@@ -1,0 +1,139 @@
+## ADDED Requirements
+
+### Requirement: Cross-repo integration test script
+
+The complyctl repository SHALL provide a shell-based integration test script at
+`tests/cross-repo/cross_repo_integration_test.sh` that accepts `PROVIDERS_BIN_DIR`
+and `GITHUB_TOKEN` as environment variables and validates the full complyctl + Ampel
+provider pipeline end-to-end using real binaries and real external tools. The script
+SHALL derive the complyctl binary path from its own location (`REPO_ROOT/bin/complyctl`)
+without requiring a separate environment variable.
+
+#### Scenario: Script runs with required environment variables
+
+- **WHEN** `PROVIDERS_BIN_DIR` points to a directory containing `complyctl-provider-ampel`
+  and `GITHUB_TOKEN` is set
+- **THEN** the script completes successfully and reports all tests passed
+
+#### Scenario: Script fails when provider binary is missing
+
+- **WHEN** `PROVIDERS_BIN_DIR` points to a directory that does not contain
+  `complyctl-provider-ampel`
+- **THEN** the script exits with a non-zero status and reports an error
+
+### Requirement: Minimal test Gemara content in mock registry
+
+The mock OCI registry SHALL serve a minimal test policy under
+`policies/test-branch-protection` containing exactly one control
+(`force-push-protection`) and one assessment plan (`block-force-push`) with executor
+`ampel`. This policy SHALL be seeded at startup alongside existing policies.
+
+#### Scenario: Policy is discoverable via the mock registry API
+
+- **WHEN** the mock OCI registry is running
+- **THEN** `GET /v2/policies/test-branch-protection/manifests/latest` returns a valid
+  OCI manifest with a catalog layer and a policy layer
+
+#### Scenario: Policy contains the block-force-push assessment plan
+
+- **WHEN** complyctl fetches `policies/test-branch-protection` and resolves the policy
+- **THEN** exactly one `AssessmentConfiguration` with `RequirementID: "block-force-push"`
+  is produced for the Ampel provider
+
+### Requirement: Minimal test granular policy fixture
+
+The complyctl repository SHALL provide a minimal Ampel granular policy JSON file at
+`tests/cross-repo/testdata/granular-policies/block-force-push.json` with `id:
+"block-force-push"`, one tenet, and the GitHub branch-rules predicate type. This file
+SHALL be used by the integration test to populate `.complytime/ampel/granular-policies/`
+before running `complyctl generate`.
+
+#### Scenario: Granular policy matches the assessment plan requirement ID
+
+- **WHEN** the Ampel provider's Generate RPC receives `RequirementID: "block-force-push"`
+- **THEN** the provider loads `block-force-push.json`, matches it by ID, and writes a
+  policy bundle containing that single policy to
+  `.complytime/ampel/policy/complytime-ampel-policy.json`
+
+### Requirement: complyctl get fetches the test policy
+
+The integration test SHALL run `complyctl get` against the mock registry and verify
+that the policy is cached locally as an OCI layout.
+
+#### Scenario: Policy is fetched and cached
+
+- **WHEN** `complyctl get` is executed with `test-ampel-bp` configured in
+  `complytime.yaml`
+- **THEN** an OCI layout directory and `state.json` tracking file are written under
+  `~/.complytime/policies/`
+
+### Requirement: complyctl generate produces the Ampel policy bundle
+
+The integration test SHALL run `complyctl generate --policy-id test-ampel-bp` and
+verify that the provider creates the merged policy bundle.
+
+#### Scenario: Generate produces the policy bundle
+
+- **WHEN** `complyctl generate --policy-id test-ampel-bp` is executed with the granular
+  policy file pre-populated
+- **THEN** `.complytime/ampel/policy/complytime-ampel-policy.json` is created and
+  contains the `block-force-push` policy
+
+### Requirement: complyctl scan completes and produces attestation output
+
+The integration test SHALL run `complyctl scan --policy-id test-ampel-bp` and verify
+that snappy and ampel run to completion and produce attestation files, regardless of
+the PASS/FAIL scan result. `complyctl scan` SHALL exit 0 when the scan pipeline ran
+successfully, even if individual policy controls evaluated to FAIL. It SHALL exit
+non-zero only on tool-level errors (binary not found, gRPC failure, OCI fetch error,
+etc.). The test SHALL assert exit 0 and treat any non-zero exit as a test failure.
+
+#### Scenario: Scan produces snappy and ampel attestation files
+
+- **WHEN** `complyctl scan --policy-id test-ampel-bp` is executed with
+  `GITHUB_TOKEN` set and `url: https://github.com/complytime/complyctl` as the target
+- **THEN** at least one `*-snappy.intoto.json` file and one `*-ampel.intoto.json` file
+  exist in `.complytime/ampel/results/`
+
+#### Scenario: Ampel result attestation references the expected requirement ID
+
+- **WHEN** the ampel result attestation is parsed
+- **THEN** `predicate.results` contains an entry with `policy.id: "block-force-push"`
+
+### Requirement: complyctl CI triggers cross-repo integration on PRs
+
+The complyctl repository SHALL have a GitHub Actions workflow at
+`.github/workflows/ci_cross_repo_integration.yml` that triggers on pull requests
+targeting `main`, builds complyctl from the PR branch, checks out
+`complytime-providers@main`, builds the Ampel provider binary, installs `snappy` and
+`ampel`, and runs the integration test script.
+
+#### Scenario: Workflow runs on PR to main
+
+- **WHEN** a pull request targeting `main` is opened or synchronized in complyctl
+- **THEN** the `ci_cross_repo_integration` workflow is triggered and runs the full
+  integration test
+
+#### Scenario: complyctl binary comes from the PR branch
+
+- **WHEN** the workflow runs
+- **THEN** the `complyctl` binary and `mock-oci-registry` binary are built from the
+  PR branch source, not from a release artifact
+
+#### Scenario: Ampel provider binary comes from complytime-providers main
+
+- **WHEN** the workflow runs
+- **THEN** `complyctl-provider-ampel` is built from `complytime-providers@main`
+
+### Requirement: Makefile test-cross-repo target
+
+The complyctl Makefile SHALL provide a `test-cross-repo` target that builds complyctl
+and runs the cross-repo integration test script. `PROVIDERS_BIN_DIR` SHALL be a
+required input with no default, so the target fails explicitly when the provider
+binary location is not specified.
+
+#### Scenario: Target runs the integration test
+
+- **WHEN** `make test-cross-repo PROVIDERS_BIN_DIR=/path/to/providers/bin` is executed
+  with a built provider binary present
+- **THEN** the integration test script runs and exits with status 0 on success

--- a/openspec/changes/cross-repo-integration-tests/tasks.md
+++ b/openspec/changes/cross-repo-integration-tests/tasks.md
@@ -1,0 +1,77 @@
+<!-- spec-review: passed -->
+
+## 1. Test Gemara Content (mock registry testdata)
+
+- [x] 1.1 Create `cmd/mock-oci-registry/testdata/test-branch-protection-catalog.yaml`
+  with one control (`force-push-protection`) and assessment requirement
+  (`block-force-push`)
+- [x] 1.2 Create `cmd/mock-oci-registry/testdata/test-branch-protection-policy.yaml`
+  with one assessment plan (`block-force-push`), executor `ampel`, frequency
+  `on-demand`
+- [x] 1.3 Add `policies/test-branch-protection` seed entry to `seedDefaults()` in
+  `cmd/mock-oci-registry/main.go` using the two new testdata files
+
+## 2. Test Fixtures (cross-repo testdata)
+
+- [x] 2.1 Create `tests/cross-repo/testdata/granular-policies/block-force-push.json`
+  with `id: "block-force-push"`, one tenet, GitHub branch-rules predicate type, and
+  a simple force-push CEL expression
+- [x] 2.2 Create `tests/cross-repo/testdata/complytime.yaml` pointing at
+  `http://localhost:8765/policies/test-branch-protection` with policy ID `test-ampel-bp`
+  and a target with `url: https://github.com/complytime/complyctl` and
+  `specs: builtin:github/branch-rules.yaml` both under `targets[].variables`
+
+## 3. Integration Test Script
+
+- [x] 3.1 Create `tests/cross-repo/cross_repo_integration_test.sh` with setup and
+  teardown functions: isolated temp `HOME` and `WORK_DIR`, provider binary install to
+  `~/.complytime/providers/`, mock registry start with readiness poll, cleanup trap.
+  Derive complyctl and mock-oci-registry binary paths from `REPO_ROOT` (script location),
+  not from a separate env var.
+- [x] 3.2 Implement `test_get` function: runs `complyctl get`, asserts OCI layout and
+  `state.json` exist
+- [x] 3.3 Implement `test_generate` function: runs `complyctl generate --policy-id
+  test-ampel-bp`, asserts `complytime-ampel-policy.json` exists in
+  `.complytime/ampel/policy/`
+- [x] 3.4 Implement `test_scan` function: runs `complyctl scan --policy-id test-ampel-bp`,
+  asserts snappy and ampel attestation files exist in `.complytime/ampel/results/`,
+  asserts ampel result JSON contains `block-force-push` requirement ID
+- [x] 3.5 Add assertion helpers (`assert_contains`, `assert_file_exists`,
+  `assert_json_contains`) and pass/fail summary consistent with existing
+  `tests/integration_test.sh` style
+- [x] 3.6 Validate that `PROVIDERS_BIN_DIR` is set and `complyctl-provider-ampel`
+  exists there; exit with a clear error message if not. Also validate that `GITHUB_TOKEN`
+  is set and the complyctl and mock-oci-registry binaries exist at their derived paths.
+
+## 4. Makefile Target
+
+- [x] 4.1 Add `test-cross-repo` target to `Makefile` that depends on `build`, requires
+  `PROVIDERS_BIN_DIR` to be set (error if empty), and runs
+  `tests/cross-repo/cross_repo_integration_test.sh`
+
+## 5. complyctl CI Workflow
+
+- [x] 5.1 Create `.github/workflows/ci_cross_repo_integration.yml` that triggers on
+  `pull_request` to `main` (opened and synchronize events) and on `push` to `main`
+- [x] 5.2 Add step to check out complyctl (current ref) and build with `make build`
+- [x] 5.3 Add step to check out `complytime/complytime-providers@main` into
+  `_providers/` and build with `make build` in that directory
+- [x] 5.4 Add steps to install `snappy` and `ampel` via
+  `carabiner-dev/actions/install/snappy` and `carabiner-dev/actions/install/ampel`
+  (pin to SHA)
+- [x] 5.5 Add step to run `tests/cross-repo/cross_repo_integration_test.sh` with
+  `PROVIDERS_BIN_DIR: ${{ github.workspace }}/_providers/bin` and
+  `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}`
+- [x] 5.6 Set minimum permissions: `contents: read` at workflow level;
+  no additional permissions needed
+
+## 6. Verification
+
+- [x] 6.1 Run `make build` in complyctl and confirm the mock registry binary includes
+  the new `policies/test-branch-protection` endpoint
+- [x] 6.2 Run `make test-cross-repo PROVIDERS_BIN_DIR=<path>` locally with a built
+  `complyctl-provider-ampel` binary and confirm all test functions pass
+- [x] 6.3 Confirm `make test-unit` and `make test-integration` still pass (no
+  regressions from mock registry change)
+- [ ] 6.4 Open a draft PR in complyctl and confirm the `ci_cross_repo_integration`
+  workflow triggers and passes

--- a/tests/cross-repo/cross_repo_integration_test.sh
+++ b/tests/cross-repo/cross_repo_integration_test.sh
@@ -1,0 +1,312 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Cross-repo integration test: complyctl + complytime-provider-ampel.
+# Validates the full get → generate → scan pipeline using real binaries
+# and the real GitHub API via snappy and ampel.
+#
+# Required environment variables:
+#   PROVIDERS_BIN_DIR   Directory containing complyctl-provider-ampel
+#   GITHUB_TOKEN        GitHub token with read access to public repositories
+#
+# Run locally:  make test-cross-repo PROVIDERS_BIN_DIR=/path/to/providers/bin
+# Run directly: PROVIDERS_BIN_DIR=... GITHUB_TOKEN=... ./tests/cross-repo/cross_repo_integration_test.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+BINARY="${REPO_ROOT}/bin/complyctl"
+MOCK_REGISTRY="${REPO_ROOT}/bin/mock-oci-registry"
+TESTDATA_DIR="${REPO_ROOT}/tests/cross-repo/testdata"
+
+REGISTRY_PORT="${GEMARA_SERVICE_PORT:-8765}"
+REGISTRY_URL="http://localhost:${REGISTRY_PORT}"
+POLICY_ID="test-ampel-bp"
+
+WORK_DIR=""
+TEST_HOME=""
+REGISTRY_PID=""
+PASSED=0
+FAILED=0
+
+# FOUND_FILE is set by assert_file_exists to return a matched path without
+# using a subshell capture ($()). This avoids the counter-loss bug present in
+# integration_test.sh where PASSED/FAILED increments inside $() are discarded.
+FOUND_FILE=""
+
+# Capture and unset GITHUB_TOKEN so only run_complyctl inherits it.
+# This follows least-privilege for environment inheritance (M8).
+_GITHUB_TOKEN="${GITHUB_TOKEN}"
+unset GITHUB_TOKEN
+
+cleanup() {
+    if [[ -n "${REGISTRY_PID}" ]]; then
+        kill "${REGISTRY_PID}" 2>/dev/null || true
+        wait "${REGISTRY_PID}" 2>/dev/null || true
+    fi
+    [[ -n "${WORK_DIR}" ]] && rm -rf "${WORK_DIR}"
+    [[ -n "${TEST_HOME}" ]] && rm -rf "${TEST_HOME}"
+}
+trap cleanup EXIT
+
+# --- Assertion helpers ---
+
+pass() {
+    PASSED=$((PASSED + 1))
+    echo "  PASS: $1" >&2
+}
+
+fail() {
+    FAILED=$((FAILED + 1))
+    echo "  FAIL: $1" >&2
+}
+
+assert_contains() {
+    local label="$1" haystack="$2" needle="$3"
+    if echo "${haystack}" | grep -qF "${needle}"; then
+        pass "${label}"
+    else
+        fail "${label}: expected output to contain '${needle}'"
+        echo "  --- actual output ---" >&2
+        echo "${haystack}" | head -20 >&2
+        echo "  ---" >&2
+    fi
+}
+
+# Sets FOUND_FILE to the matched path (or empty) and records pass/fail.
+# Call directly — do NOT capture in $() or counter updates are lost.
+assert_file_exists() {
+    local label="$1" pattern="$2"
+    local match dir base
+    dir="$(dirname "${pattern}")"
+    base="$(basename "${pattern}")"
+    match=$(find "${dir}" -maxdepth 1 -name "${base}" -print -quit 2>/dev/null) || true
+    if [[ -n "${match}" && -s "${match}" ]]; then
+        pass "${label}"
+        FOUND_FILE="${match}"
+    else
+        fail "${label}: no non-empty file matching ${pattern}"
+        FOUND_FILE=""
+    fi
+}
+
+assert_json_contains() {
+    local label="$1" file="$2" query="$3" expected="$4"
+    local actual
+    actual=$(jq -r "${query}" "${file}" 2>/dev/null) || true
+    if echo "${actual}" | grep -qF "${expected}"; then
+        pass "${label}"
+    else
+        fail "${label}: expected jq output to contain '${expected}', got '${actual}'"
+    fi
+}
+
+# Sanitize output to prevent GITHUB_TOKEN from appearing in CI logs.
+sanitize_output() {
+    if [[ -n "${_GITHUB_TOKEN:-}" ]]; then
+        sed "s/${_GITHUB_TOKEN}/[REDACTED]/g"
+    else
+        cat
+    fi
+}
+
+# --- Prerequisites ---
+
+echo "=== Prerequisites ==="
+
+# Validate required environment variables
+if [[ -z "${PROVIDERS_BIN_DIR:-}" ]]; then
+    echo "FATAL: PROVIDERS_BIN_DIR is not set. Set it to the directory containing complyctl-provider-ampel."
+    exit 1
+fi
+
+if [[ -z "${_GITHUB_TOKEN:-}" ]]; then
+    echo "FATAL: GITHUB_TOKEN is not set. A GitHub token is required for snappy to read branch protection rules."
+    exit 1
+fi
+
+PROVIDER_BINARY="${PROVIDERS_BIN_DIR}/complyctl-provider-ampel"
+if [[ ! -x "${PROVIDER_BINARY}" ]]; then
+    echo "FATAL: complyctl-provider-ampel not found or not executable at ${PROVIDER_BINARY}"
+    echo "       Build complytime-providers first and set PROVIDERS_BIN_DIR to its bin/ directory."
+    exit 1
+fi
+
+if [[ ! -x "${BINARY}" ]]; then
+    echo "FATAL: complyctl binary not found at ${BINARY}. Run 'make build' first."
+    exit 1
+fi
+
+if [[ ! -x "${MOCK_REGISTRY}" ]]; then
+    echo "FATAL: mock-oci-registry binary not found at ${MOCK_REGISTRY}. Run 'make build' first."
+    exit 1
+fi
+
+for cmd in jq curl; do
+    if ! command -v "${cmd}" >/dev/null 2>&1; then
+        echo "FATAL: '${cmd}' is required but not installed."
+        exit 1
+    fi
+done
+
+echo "  All prerequisites met."
+
+# --- Setup ---
+
+echo ""
+echo "=== Setup ==="
+
+TEST_HOME="$(mktemp -d)"
+WORK_DIR="$(mktemp -d)"
+export HOME="${TEST_HOME}"
+
+# Install provider binary into the isolated home
+mkdir -p "${TEST_HOME}/.complytime/providers"
+cp "${PROVIDER_BINARY}" "${TEST_HOME}/.complytime/providers/"
+echo "  HOME=${TEST_HOME}"
+echo "  WORK=${WORK_DIR}"
+
+# Generate workspace config with the correct registry port.
+# The static testdata/complytime.yaml uses port 8765 as default; sed replaces it
+# so the GEMARA_SERVICE_PORT override works end-to-end.
+sed "s|http://localhost:8765|${REGISTRY_URL}|" \
+    "${TESTDATA_DIR}/complytime.yaml" > "${WORK_DIR}/complytime.yaml"
+
+mkdir -p "${WORK_DIR}/.complytime/ampel/granular-policies"
+cp "${TESTDATA_DIR}/granular-policies/block-force-push.json" \
+    "${WORK_DIR}/.complytime/ampel/granular-policies/"
+echo "  Workspace config and granular policy copied."
+
+# Start mock registry.
+# 30 retries (15s) — longer than integration_test.sh (15 retries / 7.5s) because
+# the cross-repo CI builds two repos before starting the registry, and runner
+# resource contention can delay process startup.
+GEMARA_SERVICE_PORT="${REGISTRY_PORT}" "${MOCK_REGISTRY}" &
+REGISTRY_PID=$!
+
+for _ in $(seq 1 30); do
+    if curl -sf "${REGISTRY_URL}/v2/" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.5
+done
+if ! curl -sf "${REGISTRY_URL}/v2/" >/dev/null 2>&1; then
+    echo "FATAL: mock registry did not start on ${REGISTRY_URL}"
+    exit 1
+fi
+echo "  Mock registry ready (PID ${REGISTRY_PID})"
+
+# Only complyctl subprocesses receive GITHUB_TOKEN (least-privilege).
+run_complyctl() {
+    (cd "${WORK_DIR}" && GITHUB_TOKEN="${_GITHUB_TOKEN}" "${BINARY}" "$@" 2>&1)
+}
+
+# --- test_get ---
+
+test_get() {
+    FOUND_FILE=""
+    echo ""
+    echo "=== test_get ==="
+    local out rc=0
+    out="$(run_complyctl get)" || rc=$?
+    if [[ "${rc}" -ne 0 ]]; then
+        fail "get: unexpected exit code ${rc}"
+        echo "${out}" | sanitize_output >&2
+        return
+    fi
+    echo "${out}" | sanitize_output
+    assert_contains "get: sync completed" "${out}" "Synchronization completed."
+    assert_file_exists "get: oci-layout exists" \
+        "${TEST_HOME}/.complytime/policies/policies/test-branch-protection/oci-layout"
+    assert_file_exists "get: state.json exists" \
+        "${TEST_HOME}/.complytime/state.json"
+}
+
+# --- test_generate ---
+
+test_generate() {
+    FOUND_FILE=""
+    echo ""
+    echo "=== test_generate ==="
+    local out rc=0
+    out="$(run_complyctl generate --policy-id "${POLICY_ID}")" || rc=$?
+    if [[ "${rc}" -ne 0 ]]; then
+        fail "generate: unexpected exit code ${rc}"
+        echo "${out}" | sanitize_output >&2
+        return
+    fi
+    echo "${out}" | sanitize_output
+    assert_contains "generate: completed" "${out}" "Generation completed."
+    assert_file_exists "generate: policy bundle exists" \
+        "${WORK_DIR}/.complytime/ampel/policy/complytime-ampel-policy.json"
+    if [[ -n "${FOUND_FILE}" ]]; then
+        assert_json_contains "generate: bundle contains block-force-push policy" \
+            "${FOUND_FILE}" '.policies[].id' "block-force-push"
+    fi
+}
+
+# --- test_scan ---
+
+test_scan() {
+    FOUND_FILE=""
+    echo ""
+    echo "=== test_scan ==="
+    local out rc=0
+    # complyctl scan exits 0 on tool-level success (even if policy controls FAIL).
+    # A non-zero exit indicates a tool-level error (gRPC failure, binary not found, etc.).
+    out="$(run_complyctl scan --policy-id "${POLICY_ID}")" || rc=$?
+    if [[ "${rc}" -ne 0 ]]; then
+        fail "scan: unexpected exit code ${rc}"
+        echo "${out}" | sanitize_output >&2
+        return
+    fi
+    echo "${out}" | sanitize_output
+    assert_contains "scan: completed" "${out}" "requirements:"
+
+    assert_file_exists "scan: snappy attestation exists" \
+        "${WORK_DIR}/.complytime/ampel/results/*-snappy.intoto.json"
+
+    assert_file_exists "scan: ampel attestation exists" \
+        "${WORK_DIR}/.complytime/ampel/results/*-ampel.intoto.json"
+    local ampel_file="${FOUND_FILE}"
+
+    if [[ -n "${ampel_file}" ]]; then
+        assert_json_contains "scan: ampel result contains block-force-push requirement ID" \
+            "${ampel_file}" '.predicate.results[].policy.id' "block-force-push"
+    fi
+}
+
+# --- test_generate_bad_policy (negative test) ---
+
+test_generate_bad_policy() {
+    FOUND_FILE=""
+    echo ""
+    echo "=== test_generate_bad_policy ==="
+    local out rc=0
+    out="$(run_complyctl generate --policy-id nonexistent-policy 2>&1)" || rc=$?
+    if [[ "${rc}" -ne 0 ]]; then
+        pass "generate bad policy: non-zero exit code"
+    else
+        fail "generate bad policy: expected non-zero exit code, got 0"
+    fi
+    assert_contains "generate bad policy: error message" "${out}" "not found"
+}
+
+# --- Run all tests ---
+
+test_get
+test_generate
+test_scan
+test_generate_bad_policy
+
+# --- Summary ---
+
+echo ""
+echo "==============================="
+echo "  Passed: ${PASSED}"
+echo "  Failed: ${FAILED}"
+echo "==============================="
+
+if [[ "${FAILED}" -gt 0 ]]; then
+    exit 1
+fi

--- a/tests/cross-repo/cross_repo_integration_test.sh
+++ b/tests/cross-repo/cross_repo_integration_test.sh
@@ -35,7 +35,8 @@ FAILED=0
 FOUND_FILE=""
 
 # Capture and unset GITHUB_TOKEN so only run_complyctl inherits it.
-# This follows least-privilege for environment inheritance (M8).
+# This follows least-privilege for environment inheritance.
+# shellcheck disable=SC2153 # GITHUB_TOKEN is set externally, not a misspelling of _GITHUB_TOKEN
 _GITHUB_TOKEN="${GITHUB_TOKEN}"
 unset GITHUB_TOKEN
 

--- a/tests/cross-repo/testdata/complytime.yaml
+++ b/tests/cross-repo/testdata/complytime.yaml
@@ -1,0 +1,11 @@
+policies:
+  - url: http://localhost:8765/policies/test-branch-protection
+    id: test-ampel-bp
+
+targets:
+  - id: complyctl-repo
+    policies:
+      - test-ampel-bp
+    variables:
+      url: https://github.com/complytime/complyctl
+      specs: builtin:github/branch-rules.yaml

--- a/tests/cross-repo/testdata/granular-policies/block-force-push.json
+++ b/tests/cross-repo/testdata/granular-policies/block-force-push.json
@@ -1,0 +1,27 @@
+{
+  "id": "block-force-push",
+  "meta": {
+    "description": "Validate force push blocking is enabled on protected branches via the GitHub API",
+    "controls": [
+      { "framework": "test-branch-protection", "class": "source-code", "id": "force-push-protection" }
+    ]
+  },
+  "tenets": [
+    {
+      "id": "01",
+      "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"non_fast_forward\")) || (has(predicates[0].data.values) && type(predicates[0].data.values) != list && has(predicates[0].data.values.allow_force_push) && predicates[0].data.values.allow_force_push == false)",
+      "predicates": {
+        "types": [
+          "http://github.com/carabiner-dev/snappy/specs/branch-rules.yaml"
+        ]
+      },
+      "assessment": {
+        "message": "Force pushing is disabled in protected branch."
+      },
+      "error": {
+        "message": "Force pushes can be sent to protected branch",
+        "guidance": "Create a branch ruleset and enable 'Block force pushes' in the GitHub repository settings."
+      }
+    }
+  ]
+}

--- a/tests/cross-repo/testdata/granular-policies/block-force-push.json
+++ b/tests/cross-repo/testdata/granular-policies/block-force-push.json
@@ -12,7 +12,7 @@
       "code": "(has(predicates[0].data.values) && type(predicates[0].data.values) == list && predicates[0].data.values.exists(rule, rule.type == \"non_fast_forward\")) || (has(predicates[0].data.values) && type(predicates[0].data.values) != list && has(predicates[0].data.values.allow_force_push) && predicates[0].data.values.allow_force_push == false)",
       "predicates": {
         "types": [
-          "http://github.com/carabiner-dev/snappy/specs/branch-rules.yaml"
+          "http://github.com/carabiner-dev/snappy/specs/github/branch-rules.yaml"
         ]
       },
       "assessment": {


### PR DESCRIPTION
## Summary

- Add cross-repo integration test that validates the full complyctl + Ampel provider
  pipeline (get → generate → scan) using real binaries, a mock OCI registry, and the
  live GitHub API via snappy/ampel
- Add minimal Gemara test policy (`policies/test-branch-protection`) with 1 control
  and 1 assessment plan to the mock OCI registry
- Add CI workflow (`ci_cross_repo_integration.yml`) that builds complyctl from the PR
  branch, complytime-providers from main, and runs the integration test on every PR
- Add `make test-cross-repo` Makefile target with 120s timeout
- Refactor `seedDefaults()` into `seedPolicyFromFiles()` helper to keep CRAP score
  under the 30 threshold (56 → 2.0 + 12.0)
- Add OpenSpec change artifacts for traceability

## Review Hints

**Recommended**: review commit-by-commit in chronological order (oldest first).
Each commit is self-contained and scoped to one concern:

1. `docs(openspec)` — spec artifacts (proposal, design, spec, tasks)
2. `feat(registry)` — mock registry testdata + seed entry
3. `test` — granular policy + complytime.yaml fixtures
4. `test` — integration test script (the main deliverable)
5. `chore` — Makefile target
6. `ci` — CI workflow
7. `docs` — AGENTS.md + CHANGELOG.md updates
8. `fix` — shellcheck SC2153 directive for GITHUB_TOKEN
9. `refactor(registry)` — extract `seedPolicyFromFiles` to reduce CRAP score
10. `fix(ci)` — human-readable workflow naming

**To test locally:**

```bash
# 1. Build complyctl
make build

# 2. Build complytime-providers (in a separate checkout)
cd /path/to/complytime-providers && make build

# 3. Run the cross-repo integration test
make test-cross-repo PROVIDERS_BIN_DIR=/path/to/complytime-providers/bin
```

Requires `GITHUB_TOKEN` with read access to public repositories (for snappy
to read branch protection rules from `complytime/complyctl`). The standard
`gh auth token` or a PAT with `public_repo` scope works.

**CI example:** [Cross-Repo Integration Test job run](https://github.com/complytime/complyctl/actions/runs/25811785800/job/75829734673?pr=509)

## OpenSpec Change

`openspec/changes/cross-repo-integration-tests/` — spec-driven change with
proposal, design (6 decisions), spec (8 requirements), and tasks (22 completed).

## Companion Change

The mirrored CI workflow for `complytime-providers` is tracked as a separate
change in that repository, to be implemented once this PR is merged.