### PR TITLE
fix(doctor): improve UX for version resolution errors and diagnostics

### DIFF
--- a/.gaze/baseline.json
+++ b/.gaze/baseline.json
@@ -1946,9 +1946,9 @@
       "function": "CheckPolicyVersions",
       "file": "internal/doctor/doctor.go",
       "line": 221,
-      "complexity": 14,
+      "complexity": 15,
       "line_coverage": 100,
-      "crap": 14
+      "crap": 15
     },
     {
       "package": "doctor",
@@ -2551,9 +2551,9 @@
       "function": "(*Client).DefinitionVersion",
       "file": "internal/registry/client.go",
       "line": 47,
-      "complexity": 4,
-      "line_coverage": 44.44444444444444,
-      "crap": 6.743484224965707
+      "complexity": 6,
+      "line_coverage": 0,
+      "crap": 11.442524417731029
     },
     {
       "package": "registry",

--- a/.gaze/baseline.json
+++ b/.gaze/baseline.json
@@ -1629,10 +1629,10 @@
       "package": "cache",
       "function": "(*Sync).SyncPolicy",
       "file": "internal/cache/sync.go",
-      "line": 28,
-      "complexity": 13,
-      "line_coverage": 86.95652173913044,
-      "crap": 13.375030821073395
+      "line": 31,
+      "complexity": 14,
+      "line_coverage": 84,
+      "crap": 14.802816
     },
     {
       "package": "complytime",
@@ -1945,19 +1945,19 @@
       "package": "doctor",
       "function": "CheckPolicyVersions",
       "file": "internal/doctor/doctor.go",
-      "line": 219,
-      "complexity": 11,
+      "line": 221,
+      "complexity": 14,
       "line_coverage": 100,
-      "crap": 11
+      "crap": 14
     },
     {
       "package": "doctor",
       "function": "resolvePinnedFallback",
       "file": "internal/doctor/doctor.go",
-      "line": 294,
-      "complexity": 3,
-      "line_coverage": 100,
-      "crap": 3
+      "line": 317,
+      "complexity": 5,
+      "line_coverage": 90,
+      "crap": 5.025
     },
     {
       "package": "doctor",
@@ -2027,10 +2027,10 @@
       "package": "doctor",
       "function": "CheckCollector",
       "file": "internal/doctor/doctor.go",
-      "line": 680,
-      "complexity": 5,
+      "line": 717,
+      "complexity": 6,
       "line_coverage": 100,
-      "crap": 5
+      "crap": 6
     },
     {
       "package": "doctor",
@@ -2595,10 +2595,10 @@
       "package": "registry",
       "function": "(*Client).fetchVersion",
       "file": "internal/registry/client.go",
-      "line": 109,
-      "complexity": 5,
+      "line": 115,
+      "complexity": 6,
       "line_coverage": 0,
-      "crap": 30,
+      "crap": 42,
       "fix_strategy": "add_tests"
     },
     {

--- a/cmd/complyctl/cli/cli_test.go
+++ b/cmd/complyctl/cli/cli_test.go
@@ -689,7 +689,7 @@ targets:
 	err := o.run(context.Background())
 	require.Error(t, err)
 	// Verify it fails on sync, not on config loading or complypacks parsing.
-	assert.Contains(t, err.Error(), "sync")
+	assert.Contains(t, err.Error(), "registry")
 }
 
 // --- listOptions tests ---

--- a/cmd/complyctl/cli/get.go
+++ b/cmd/complyctl/cli/get.go
@@ -110,7 +110,7 @@ func (o *getOptions) syncPolicies(ctx context.Context, cfg *complytime.Workspace
 		return fmt.Errorf("authentication setup failed: %w", err)
 	}
 
-	return syncAllPolicies(ctx, cacheMgr, state, credFunc, cfg.Policies, o.cacheDir)
+	return syncAllPolicies(ctx, cacheMgr, state, credFunc, cfg.Policies)
 }
 
 // syncComplypacks fetches complypack artifacts listed in the workspace config.
@@ -135,12 +135,12 @@ func (o *getOptions) syncComplypacks(ctx context.Context, cfg *complytime.Worksp
 	return syncAllComplypacks(ctx, state, credFunc, cfg.Complypacks, o.cacheDir)
 }
 
-func syncAllPolicies(ctx context.Context, cacheMgr *cache.Cache, state *cache.State, credFunc auth.CredentialFunc, policies []complytime.PolicyEntry, cacheDir string) error {
+func syncAllPolicies(ctx context.Context, cacheMgr *cache.Cache, state *cache.State, credFunc auth.CredentialFunc, policies []complytime.PolicyEntry) error {
 	logger.Info("Starting policy synchronization", "policy_count", len(policies))
 
 	total := len(policies)
 	for i, entry := range policies {
-		if err := syncSinglePolicy(ctx, cacheMgr, state, credFunc, entry, i+1, total, cacheDir); err != nil {
+		if err := syncSinglePolicy(ctx, cacheMgr, state, credFunc, entry, i+1, total); err != nil {
 			return err
 		}
 	}
@@ -150,7 +150,7 @@ func syncAllPolicies(ctx context.Context, cacheMgr *cache.Cache, state *cache.St
 	return nil
 }
 
-func syncSinglePolicy(ctx context.Context, cacheMgr *cache.Cache, state *cache.State, credFunc auth.CredentialFunc, entry complytime.PolicyEntry, index, total int, cacheDir string) error {
+func syncSinglePolicy(ctx context.Context, cacheMgr *cache.Cache, state *cache.State, credFunc auth.CredentialFunc, entry complytime.PolicyEntry, index, total int) error {
 	ref := complytime.ParsePolicyRef(entry.URL)
 	version := ref.Version
 
@@ -166,9 +166,8 @@ func syncSinglePolicy(ctx context.Context, cacheMgr *cache.Cache, state *cache.S
 	logger.Info("Syncing policy", "policy", ref.Repository, "version", version)
 	if err := sync.SyncPolicy(ctx, ref.Repository, version); err != nil {
 		fmt.Fprintln(os.Stderr, "failed")
-		suggestMsg := suggestCachedPolicyIDs(cacheDir, ref.Repository)
 		logger.Error("Policy sync failed", "policy", ref.Repository, "error", err)
-		return fmt.Errorf("failed to sync policy %s: %w%s", ref.Repository, err, suggestMsg)
+		return err
 	}
 	fmt.Fprintln(os.Stderr, "done")
 	logger.Info("Policy synced", "policy", entry.EffectiveID())
@@ -185,23 +184,6 @@ func resolveLatestVersion(ctx context.Context, client *registry.Client, reposito
 	}
 	logger.Info("Resolved version", "policy", policyID, "version", resolvedVersion)
 	return resolvedVersion
-}
-
-func suggestCachedPolicyIDs(cacheDir, failedPolicyID string) string {
-	state, err := cache.LoadState(cacheDir)
-	if err != nil || len(state.Policies) == 0 {
-		return ""
-	}
-	cached := make([]string, 0, len(state.Policies))
-	for id := range state.Policies {
-		if id != failedPolicyID {
-			cached = append(cached, id)
-		}
-	}
-	if len(cached) == 0 {
-		return ""
-	}
-	return fmt.Sprintf(" (cached policies: %v)", cached)
 }
 
 func syncAllComplypacks(ctx context.Context, state *cache.State, credFunc auth.CredentialFunc, complypacks []complytime.PolicyEntry, cacheDir string) error {
@@ -232,7 +214,6 @@ func syncSingleComplypack(ctx context.Context, state *cache.State, credFunc auth
 		version = resolveLatestVersion(ctx, client, ref.Repository, entry.EffectiveID())
 	}
 
-	// Task 4.5: Progress output — mirrors the policy sync pattern.
 	fmt.Fprintf(os.Stderr, "Syncing complypack %d/%d: %s... ", index, total, entry.EffectiveID())
 	logger.Info("Syncing complypack", "complypack", ref.Repository, "version", version)
 	fetched, err := cpSync.SyncComplypack(ctx, ref.Repository, version)
@@ -244,9 +225,6 @@ func syncSingleComplypack(ctx context.Context, state *cache.State, credFunc auth
 	fmt.Fprintln(os.Stderr, "done")
 	logger.Info("Complypack synced", "complypack", entry.EffectiveID())
 
-	// Task 4.4: Warn that the artifact has not been cryptographically verified.
-	// Only emit when content was actually downloaded — skip for incremental
-	// no-ops where the cached content is already up-to-date.
 	if fetched {
 		fmt.Fprintf(os.Stderr, "WARNING: complypack %s has not been cryptographically verified\n", entry.EffectiveID())
 		logger.Warn("Complypack not cryptographically verified", "complypack", entry.EffectiveID())

--- a/internal/cache/sync.go
+++ b/internal/cache/sync.go
@@ -4,7 +4,10 @@ package cache
 
 import (
 	"context"
+	"errors"
 	"fmt"
+
+	"github.com/complytime/complyctl/internal/registry"
 )
 
 // Sync provides incremental sync using oras.Copy() for remote-to-local transfer.
@@ -37,10 +40,10 @@ func (s *Sync) SyncPolicy(ctx context.Context, policyID, version string) error {
 
 	remoteDigest, remoteVersion, err := s.source.DefinitionVersion(ctx, lookupRef)
 	if err != nil {
-		return fmt.Errorf(
-			"policy %s: registry unreachable: %w (cached data may still be available)",
-			policyID, err,
-		)
+		if errors.Is(err, registry.ErrVersionNotFound) {
+			return fmt.Errorf("policy %s: %w", policyID, err)
+		}
+		return fmt.Errorf("policy %s: registry unreachable: %w", policyID, err)
 	}
 
 	if version == "" || version == "latest" {
@@ -59,10 +62,7 @@ func (s *Sync) SyncPolicy(ctx context.Context, policyID, version string) error {
 
 	_, err = s.source.CopyPolicy(ctx, policyID, version, localStore)
 	if err != nil {
-		return fmt.Errorf(
-			"policy %s@%s: registry unreachable: %w (local cache unchanged)",
-			policyID, version, err,
-		)
+		return fmt.Errorf("policy %s@%s: copy failed: %w", policyID, version, err)
 	}
 
 	s.state.UpdatePolicyState(policyID, version, remoteDigest)

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -262,7 +262,7 @@ func CheckPolicyVersions(cfg *complytime.WorkspaceConfig, cacheDir string, versi
 		latestVersion, err := versionResolver.ResolveLatestVersion(ref.Registry, ref.Repository)
 		if err != nil {
 			result := resolvePinnedFallback(versionResolver, ref, eid, cachedState.Version, err)
-			if result.Status == StatusWarn {
+			if result.Status == StatusWarn && !errors.Is(err, registry.ErrVersionNotFound) {
 				unreachable[ref.Registry] = true
 			}
 			results = append(results, result)

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -4,6 +4,7 @@ package doctor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 	"github.com/complytime/complyctl/internal/cache"
 	"github.com/complytime/complyctl/internal/complytime"
 	"github.com/complytime/complyctl/internal/policy"
+	"github.com/complytime/complyctl/internal/registry"
 	"github.com/complytime/complyctl/pkg/provider"
 )
 
@@ -268,7 +270,28 @@ func CheckPolicyVersions(cfg *complytime.WorkspaceConfig, cacheDir string, versi
 		}
 
 		cachedVersion := cachedState.Version
-		if cachedVersion == latestVersion {
+
+		if ref.Version != "" {
+			if cachedVersion == ref.Version {
+				msg := fmt.Sprintf("%s (pinned)", cachedVersion)
+				if latestVersion != cachedVersion {
+					msg = fmt.Sprintf("%s (pinned — latest available: %s)", cachedVersion, latestVersion)
+				}
+				results = append(results, CheckResult{
+					Name:     fmt.Sprintf("policy/%s", eid),
+					Status:   StatusPass,
+					Message:  msg,
+					Blocking: false,
+				})
+			} else {
+				results = append(results, CheckResult{
+					Name:     fmt.Sprintf("policy/%s", eid),
+					Status:   StatusWarn,
+					Message:  fmt.Sprintf("cached %s does not match configured pin @%s — run complyctl get", cachedVersion, ref.Version),
+					Blocking: false,
+				})
+			}
+		} else if cachedVersion == latestVersion {
 			results = append(results, CheckResult{
 				Name:     fmt.Sprintf("policy/%s", eid),
 				Status:   StatusPass,
@@ -290,7 +313,7 @@ func CheckPolicyVersions(cfg *complytime.WorkspaceConfig, cacheDir string, versi
 
 // resolvePinnedFallback attempts to resolve a pinned version when the latest
 // tag is unavailable. Returns a pass result if the pinned version resolves,
-// or a warn result marking the registry as unreachable.
+// or a warn result with a user-friendly diagnosis.
 func resolvePinnedFallback(
 	resolver VersionResolver,
 	ref complytime.PolicyRef,
@@ -308,6 +331,20 @@ func resolvePinnedFallback(
 			}
 		}
 	}
+
+	if errors.Is(latestErr, registry.ErrVersionNotFound) {
+		msg := "latest tag not found — pin a specific version with @<tag>"
+		if ref.Version != "" {
+			msg = fmt.Sprintf("version %q not found in registry", ref.Version)
+		}
+		return CheckResult{
+			Name:     fmt.Sprintf("policy/%s", eid),
+			Status:   StatusWarn,
+			Message:  msg,
+			Blocking: false,
+		}
+	}
+
 	return CheckResult{
 		Name:     fmt.Sprintf("registry/%s", ref.Registry),
 		Status:   StatusWarn,
@@ -678,6 +715,9 @@ func unmappedReason(resolver PolicyGraphResolver, resolveFailures int) string {
 // Non-blocking — the collector is optional. When configured, checks that the
 // endpoint format looks valid and auth fields are complete.
 func CheckCollector(cfg *complytime.WorkspaceConfig) []CheckResult {
+	if cfg == nil {
+		return nil
+	}
 	if cfg.Collector == nil {
 		return []CheckResult{{
 			Name:    "collector",

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/complytime/complyctl/internal/cache"
 	"github.com/complytime/complyctl/internal/complytime"
 	"github.com/complytime/complyctl/internal/policy"
+	"github.com/complytime/complyctl/internal/registry"
 )
 
 // --- Mock VersionResolver ---
@@ -35,32 +36,32 @@ func newMockVersionResolver() *mockVersionResolver {
 	}
 }
 
-func (m *mockVersionResolver) ResolveLatestVersion(registry, repository string) (string, error) {
-	if m.unreachable[registry] {
+func (m *mockVersionResolver) ResolveLatestVersion(reg, repository string) (string, error) {
+	if m.unreachable[reg] {
 		return "", fmt.Errorf("connection refused")
 	}
-	if m.latestMissing[registry] {
-		return "", fmt.Errorf("OCI version resolution failed for %s/%s:latest: not found", registry, repository)
+	if m.latestMissing[reg] {
+		return "", fmt.Errorf("%w: %s/%s tag %q", registry.ErrVersionNotFound, reg, repository, "latest")
 	}
-	key := registry + "|" + repository
+	key := reg + "|" + repository
 	if err, ok := m.errOnResolve[key]; ok {
 		return "", err
 	}
 	if v, ok := m.versions[key]; ok {
 		return v, nil
 	}
-	return "", fmt.Errorf("not found: %s/%s", registry, repository)
+	return "", fmt.Errorf("not found: %s/%s", reg, repository)
 }
 
-func (m *mockVersionResolver) ResolveVersion(registry, repository, version string) (string, error) {
-	if m.unreachable[registry] {
+func (m *mockVersionResolver) ResolveVersion(reg, repository, version string) (string, error) {
+	if m.unreachable[reg] {
 		return "", fmt.Errorf("connection refused")
 	}
-	key := registry + "|" + repository + "|" + version
+	key := reg + "|" + repository + "|" + version
 	if v, ok := m.pinnedVersions[key]; ok {
 		return v, nil
 	}
-	return "", fmt.Errorf("not found: %s/%s:%s", registry, repository, version)
+	return "", fmt.Errorf("not found: %s/%s:%s", reg, repository, version)
 }
 
 // --- Mock PolicyGraphResolver ---
@@ -146,12 +147,43 @@ func TestCheckPolicyVersions_PolicyAtLatest(t *testing.T) {
 	if results[0].Status != StatusPass {
 		t.Errorf("expected pass, got %s: %s", results[0].Status, results[0].Message)
 	}
+	if !strings.Contains(results[0].Message, "(pinned)") {
+		t.Errorf("expected '(pinned)' in message, got %q", results[0].Message)
+	}
+}
+
+func TestCheckPolicyVersions_UnpinnedAtLatest(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	state := &cache.State{Policies: map[string]cache.PolicyState{
+		"policies/nist": {Version: "v1.0.0"},
+	}}
+	if err := cache.SaveState(state, tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &complytime.WorkspaceConfig{
+		Policies: []complytime.PolicyEntry{
+			{URL: "reg.io/policies/nist"},
+		},
+	}
+
+	vr := newMockVersionResolver()
+	vr.versions["reg.io|policies/nist"] = "v1.0.0"
+
+	results := CheckPolicyVersions(cfg, tmpDir, vr)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Status != StatusPass {
+		t.Errorf("expected pass, got %s: %s", results[0].Status, results[0].Message)
+	}
 	if !strings.Contains(results[0].Message, "(latest)") {
 		t.Errorf("expected '(latest)' in message, got %q", results[0].Message)
 	}
 }
 
-func TestCheckPolicyVersions_PolicyStale(t *testing.T) {
+func TestCheckPolicyVersions_PinnedMatchesCached_LatestDiffers(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	state := &cache.State{Policies: map[string]cache.PolicyState{
@@ -174,6 +206,40 @@ func TestCheckPolicyVersions_PolicyStale(t *testing.T) {
 	if len(results) != 1 {
 		t.Fatalf("expected 1 result, got %d", len(results))
 	}
+	if results[0].Status != StatusPass {
+		t.Errorf("expected pass for pinned matching cached, got %s: %s", results[0].Status, results[0].Message)
+	}
+	if !strings.Contains(results[0].Message, "(pinned") {
+		t.Errorf("expected 'pinned' in message, got %q", results[0].Message)
+	}
+	if !strings.Contains(results[0].Message, "latest available: v1.1.0") {
+		t.Errorf("expected 'latest available' info in message, got %q", results[0].Message)
+	}
+}
+
+func TestCheckPolicyVersions_UnpinnedStale(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	state := &cache.State{Policies: map[string]cache.PolicyState{
+		"policies/nist": {Version: "v1.0.0"},
+	}}
+	if err := cache.SaveState(state, tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &complytime.WorkspaceConfig{
+		Policies: []complytime.PolicyEntry{
+			{URL: "reg.io/policies/nist"},
+		},
+	}
+
+	vr := newMockVersionResolver()
+	vr.versions["reg.io|policies/nist"] = "v1.1.0"
+
+	results := CheckPolicyVersions(cfg, tmpDir, vr)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
 	if results[0].Status != StatusWarn {
 		t.Errorf("expected warn, got %s: %s", results[0].Status, results[0].Message)
 	}
@@ -182,6 +248,40 @@ func TestCheckPolicyVersions_PolicyStale(t *testing.T) {
 	}
 	if !strings.Contains(results[0].Message, "available v1.1.0") {
 		t.Errorf("expected available version in message, got %q", results[0].Message)
+	}
+}
+
+func TestCheckPolicyVersions_PinnedMismatchCached(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	state := &cache.State{Policies: map[string]cache.PolicyState{
+		"policies/nist": {Version: "v1.0.0"},
+	}}
+	if err := cache.SaveState(state, tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &complytime.WorkspaceConfig{
+		Policies: []complytime.PolicyEntry{
+			{URL: "reg.io/policies/nist@v2.0.0"},
+		},
+	}
+
+	vr := newMockVersionResolver()
+	vr.versions["reg.io|policies/nist"] = "v2.0.0"
+
+	results := CheckPolicyVersions(cfg, tmpDir, vr)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Status != StatusWarn {
+		t.Errorf("expected warn for pin mismatch, got %s: %s", results[0].Status, results[0].Message)
+	}
+	if !strings.Contains(results[0].Message, "does not match configured pin") {
+		t.Errorf("expected pin mismatch message, got %q", results[0].Message)
+	}
+	if !strings.Contains(results[0].Message, "@v2.0.0") {
+		t.Errorf("expected configured version in message, got %q", results[0].Message)
 	}
 }
 
@@ -317,8 +417,11 @@ func TestCheckPolicyVersions_LatestMissing_NoPinnedVersion(t *testing.T) {
 	if results[0].Status != StatusWarn {
 		t.Errorf("expected warn, got %s: %s", results[0].Status, results[0].Message)
 	}
-	if results[0].Name != "registry/reg.io" {
-		t.Errorf("expected registry warning, got %q", results[0].Name)
+	if !strings.Contains(results[0].Message, "latest tag not found") {
+		t.Errorf("expected 'latest tag not found' in message, got %q", results[0].Message)
+	}
+	if !strings.Contains(results[0].Message, "pin a specific version") {
+		t.Errorf("expected guidance to pin version, got %q", results[0].Message)
 	}
 }
 
@@ -942,6 +1045,13 @@ func TestCheckConfig_MissingFile(t *testing.T) {
 }
 
 // --- CheckCollector Tests ---
+
+func TestCheckCollector_NilConfig(t *testing.T) {
+	results := CheckCollector(nil)
+	if results != nil {
+		t.Errorf("expected nil for nil config, got %d results", len(results))
+	}
+}
 
 func TestCheckCollector_NilCollector(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -425,6 +425,143 @@ func TestCheckPolicyVersions_LatestMissing_NoPinnedVersion(t *testing.T) {
 	}
 }
 
+func TestCheckPolicyVersions_LatestMissing_DoesNotPoisonSameRegistry(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	state := &cache.State{Policies: map[string]cache.PolicyState{
+		"policies/alpha": {Version: "v1.0.0"},
+		"policies/beta":  {Version: "v2.0.0"},
+	}}
+	if err := cache.SaveState(state, tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &complytime.WorkspaceConfig{
+		Policies: []complytime.PolicyEntry{
+			{URL: "reg.io/policies/alpha"},
+			{URL: "reg.io/policies/beta"},
+		},
+	}
+
+	vr := newMockVersionResolver()
+	vr.latestMissing["reg.io"] = true
+
+	results := CheckPolicyVersions(cfg, tmpDir, vr)
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results (404 should not skip second policy), got %d: %+v", len(results), results)
+	}
+	for _, r := range results {
+		if r.Status != StatusWarn {
+			t.Errorf("expected warn for %s, got %s", r.Name, r.Status)
+		}
+		if !strings.Contains(r.Message, "latest tag not found") {
+			t.Errorf("expected 'latest tag not found' in %s message, got %q", r.Name, r.Message)
+		}
+	}
+}
+
+func TestCheckPolicyVersions_PinnedBoth404(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	state := &cache.State{Policies: map[string]cache.PolicyState{
+		"policies/nist": {Version: "v1.0.0"},
+	}}
+	if err := cache.SaveState(state, tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &complytime.WorkspaceConfig{
+		Policies: []complytime.PolicyEntry{
+			{URL: "reg.io/policies/nist@v2.0.0"},
+		},
+	}
+
+	vr := newMockVersionResolver()
+	vr.latestMissing["reg.io"] = true
+	// pinnedVersions NOT populated → ResolveVersion also fails
+
+	results := CheckPolicyVersions(cfg, tmpDir, vr)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d: %+v", len(results), results)
+	}
+	if results[0].Status != StatusWarn {
+		t.Errorf("expected warn, got %s: %s", results[0].Status, results[0].Message)
+	}
+	if !strings.Contains(results[0].Message, "not found in registry") {
+		t.Errorf("expected 'not found in registry' in message, got %q", results[0].Message)
+	}
+}
+
+func TestCheckPolicyVersions_MixedRegistries_Unreachable_And_404(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	state := &cache.State{Policies: map[string]cache.PolicyState{
+		"policies/alpha": {Version: "v1.0.0"},
+		"policies/beta":  {Version: "v2.0.0"},
+	}}
+	if err := cache.SaveState(state, tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &complytime.WorkspaceConfig{
+		Policies: []complytime.PolicyEntry{
+			{URL: "down.io/policies/alpha"},
+			{URL: "up.io/policies/beta"},
+		},
+	}
+
+	vr := newMockVersionResolver()
+	vr.unreachable["down.io"] = true
+	vr.latestMissing["up.io"] = true
+
+	results := CheckPolicyVersions(cfg, tmpDir, vr)
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results (one per registry), got %d: %+v", len(results), results)
+	}
+	if results[0].Name != "registry/down.io" {
+		t.Errorf("expected registry/down.io, got %q", results[0].Name)
+	}
+	if !strings.Contains(results[0].Message, "unreachable") {
+		t.Errorf("expected 'unreachable' for down.io, got %q", results[0].Message)
+	}
+	if !strings.Contains(results[1].Message, "latest tag not found") {
+		t.Errorf("expected '404' message for up.io, got %q", results[1].Message)
+	}
+}
+
+func TestCheckPolicyVersions_PinnedNetworkFailure_BothFail(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	state := &cache.State{Policies: map[string]cache.PolicyState{
+		"policies/nist": {Version: "v1.0.0"},
+		"policies/cis":  {Version: "v1.0.0"},
+	}}
+	if err := cache.SaveState(state, tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &complytime.WorkspaceConfig{
+		Policies: []complytime.PolicyEntry{
+			{URL: "flaky.io/policies/nist@v1.0.0"},
+			{URL: "flaky.io/policies/cis@v1.0.0", ID: "cis"},
+		},
+	}
+
+	vr := newMockVersionResolver()
+	vr.unreachable["flaky.io"] = true
+
+	results := CheckPolicyVersions(cfg, tmpDir, vr)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result (second policy skipped via unreachable), got %d: %+v", len(results), results)
+	}
+	if results[0].Name != "registry/flaky.io" {
+		t.Errorf("expected registry-level warning, got %q", results[0].Name)
+	}
+	if !strings.Contains(results[0].Message, "unreachable") {
+		t.Errorf("expected 'unreachable' in message, got %q", results[0].Message)
+	}
+}
+
 func TestCheckPolicyVersions_BadCacheState(t *testing.T) {
 	tmpDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(tmpDir, complytime.StateFileName), []byte("{bad json"), 0600); err != nil {

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -62,7 +62,10 @@ func (c *Client) DefinitionVersion(ctx context.Context, modulePath string) (stri
 	ref := buildRef(c.registryHost(), modulePath)
 	digest, version, err := c.fetchVersion(ctx, ref)
 	if err != nil {
-		return "", "", err
+		if errors.Is(err, ErrVersionNotFound) {
+			return "", "", err
+		}
+		return "", "", fmt.Errorf("failed to fetch version for %s: %w", modulePath, err)
 	}
 
 	return digest, version, nil

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -4,14 +4,20 @@ package registry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 
+	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/registry"
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
 )
+
+// ErrVersionNotFound indicates the requested tag/version does not exist in the
+// registry. Callers can use errors.Is to distinguish from network failures.
+var ErrVersionNotFound = errors.New("version not found in registry")
 
 // Fetcher abstracts registry access for testing without a live OCI registry.
 type Fetcher interface {
@@ -56,7 +62,7 @@ func (c *Client) DefinitionVersion(ctx context.Context, modulePath string) (stri
 	ref := buildRef(c.registryHost(), modulePath)
 	digest, version, err := c.fetchVersion(ctx, ref)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to fetch version for %s: %w", modulePath, err)
+		return "", "", err
 	}
 
 	return digest, version, nil
@@ -125,7 +131,10 @@ func (c *Client) fetchVersion(ctx context.Context, ref string) (string, string, 
 
 	desc, err := repo.Resolve(ctx, tag)
 	if err != nil {
-		return "", "", fmt.Errorf("OCI version resolution failed for %s: %w", ref, err)
+		if errors.Is(err, errdef.ErrNotFound) {
+			return "", "", fmt.Errorf("%w: %s tag %q", ErrVersionNotFound, ref, tag)
+		}
+		return "", "", fmt.Errorf("registry communication failed for %s: %w", ref, err)
 	}
 
 	digest := desc.Digest.String()


### PR DESCRIPTION
## Summary

Addresses all 5 sub-issues from #503:

- **Pinned version staleness**: Doctor no longer warns "run complyctl get to update" on deliberately pinned versions. Reports `(pinned)` with optional latest-availability note.
- **Misdiagnosed "registry unreachable"**: New `ErrVersionNotFound` sentinel classifies 404 responses, enabling accurate messages like "latest tag not found — pin a specific version with @<tag>".
- **Error nesting flattened**: Removes redundant `"failed to sync policy … registry unreachable … (cached data may still be available) (cached policies: [...])"` wrapping. Errors pass through cleanly. Non-404 errors retain module path context.
- **Configured-vs-cached mismatch**: If a user pins `@v2.0.0` but cache holds `v1.0.0`, doctor reports the mismatch with guidance to run `complyctl get`.
- **Nil panic in CheckCollector**: `cfg == nil` guard prevents SIGSEGV when `complytime.yaml` is absent.

Closes #503

## Changes

| File | Purpose |
|------|---------|
| `internal/registry/client.go` | `ErrVersionNotFound` sentinel; classify 404 vs network errors; restore context wrapping for non-404 |
| `internal/cache/sync.go` | Flatten error wrapping; distinguish "not found" from "unreachable" |
| `internal/doctor/doctor.go` | Pinned-version logic, mismatch detection, `resolvePinnedFallback` improvement, nil guard, 404 poison-guard fix |
| `internal/doctor/doctor_test.go` | Tests for all 5 scenarios + regression tests (poison-guard, pinned+both 404, mixed registries, pinned network failure) |
| `cmd/complyctl/cli/get.go` | Remove redundant error re-wrapping and `suggestCachedPolicyIDs` |
| `cmd/complyctl/cli/cli_test.go` | Update assertion to match flattened error format |

## Test plan

- [x] `go test ./internal/doctor/` — all 17 `TestCheckPolicyVersions*` tests pass
- [x] `go test ./internal/cache/ ./internal/registry/ ./cmd/complyctl/cli/` — all pass
- [x] `go build ./...` — compiles cleanly
- [ ] CI unit tests
- [ ] E2E tests with mock registry (pinned, unpinned, missing-tag, mismatch scenarios)