### PR TITLE
docs: update Quick Start with both providers and real examples

### DIFF
--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -10,32 +10,79 @@ Scanning providers are standalone executables placed in `~/.complytime/providers
 
 ```bash
 mkdir -p ~/.complytime/providers
-cp bin/complyctl-provider-openscap ~/.complytime/providers/
+cp bin/complyctl-provider-<name> ~/.complytime/providers/
 ```
 
 Naming convention: `complyctl-provider-<evaluator-id>`. The CLI strips the prefix to derive the evaluator ID used for routing.
 
-For the openscap provider, install prerequisites:
-- `openscap-scanner` package
-- `scap-security-guide` package
+### Available providers
+
+| Provider | Binary | What it evaluates | Prerequisites |
+|----------|--------|-------------------|---------------|
+| [openscap](https://github.com/complytime/complytime-providers/blob/main/cmd/openscap-provider/docs/configuration.md) | `complyctl-provider-openscap` | SCAP policies (CIS, STIG, HIPAA, OSPP, etc.) | `openscap-scanner`, `scap-security-guide` |
+| [ampel](https://github.com/complytime/complytime-providers/tree/main/cmd/ampel-provider) | `complyctl-provider-ampel` | GitHub / GitLab branch protection | `snappy`, `ampel`, `GITHUB_TOKEN` or `GITLAB_TOKEN` |
 
 See the [Provider Guide](https://github.com/complytime/complytime-providers/blob/main/docs/provider-guide.md) for authoring details.
 
 ## Step 3: Create workspace config
 
-Create `complytime.yaml` in your working directory. This is the runtime configuration — it declares targets, variables, and policy selections.
+Create `complytime.yaml` in your working directory. This is the runtime configuration — it declares policies, targets, and variables.
 
 ```yaml
-version: 1
 policies:
-  - url: registry.example.com/policies/nist-800-53-r5@v1.0
-    id: nist
+  - url: <oci-reference>
+    id: <short-alias>
+
+variables:
+  key: value
+
+targets:
+  - id: <target-id>
+    policies:
+      - <policy-id>
+    variables:
+      key: value
+```
+
+| Section | Purpose |
+|---------|---------|
+| `policies` | OCI references to Gemara policy bundles. `id` is a short alias used by targets and for provider routing. |
+| `variables` | Workspace-scoped constants passed to all providers (e.g., custom policy directories). |
+| `targets` | Systems to evaluate. Each target selects one or more policies and provides provider-specific variables. |
+
+**Variable expansion**: Only `targets[].variables` supports `${VAR}` environment variable substitution. Use this for secrets and per-target credentials. Top-level `variables` are workspace constants passed to providers as-is — `${...}` references there are **not** expanded.
+
+### Example: ampel branch protection
+
+```yaml
+policies:
+  - url: quay.io/complytime/complytime-policies@ampel-branch-protection
+    id: ampel-bp
+
+targets:
+  - id: my-repo
+    policies:
+      - ampel-bp
+    variables:
+      url: https://github.com/myorg/myrepo
+      specs: builtin:github/branch-rules.yaml
+```
+
+See the [ampel provider configuration](https://github.com/complytime/complytime-providers/blob/main/cmd/ampel-provider/docs/configuration.md) for all target variables.
+
+### Example: CIS Fedora L1 (OpenSCAP)
+
+```yaml
+policies:
+  - url: quay.io/complytime/complytime-policies@cis-fedora-l1-workstation
+    id: cis-fedora-l1
+
 targets:
   - id: my-system
     policies:
-      - nist
+      - cis-fedora-l1
     variables:
-      api_token: ${MY_API_TOKEN}
+      profile: xccdf_org.ssgproject.content_profile_cis_workstation_l1
 ```
 
 Or use interactive setup:
@@ -46,7 +93,7 @@ complyctl init
 
 `init` prompts for policy URLs, IDs, and targets when no `complytime.yaml` exists.
 
-**Variable expansion**: Only `targets[].variables` supports `${VAR}` environment variable substitution. Use this for secrets and per-target credentials. Top-level `variables` are workspace constants passed to providers as-is — `${...}` references there are **not** expanded.
+Available policy bundles are listed in the [complytime-policies usage guide](https://github.com/complytime/complytime-policies/blob/main/docs/usage.md).
 
 ## Step 4: Fetch policies
 
@@ -67,33 +114,52 @@ Displays cached policies and their versions.
 ## Step 6: Generate
 
 ```bash
-complyctl generate --policy-id nist-800-53-r5
+complyctl generate --policy-id ampel-bp
 ```
 
 Resolves the policy dependency graph, extracts assessment configurations, and dispatches to the matching provider via Generate RPC.
 
 ## Step 7: Scan
 
+Scan all targets for a policy:
+
 ```bash
 # EvaluationLog (default)
-complyctl scan --policy-id nist-800-53-r5
+complyctl scan --policy-id ampel-bp
 
 # Markdown report
-complyctl scan --policy-id nist-800-53-r5 --format pretty
+complyctl scan --policy-id ampel-bp --format pretty
 
 # OSCAL assessment-results
-complyctl scan --policy-id nist-800-53-r5 --format oscal
+complyctl scan --policy-id ampel-bp --format oscal
 
 # SARIF
-complyctl scan --policy-id nist-800-53-r5 --format sarif
+complyctl scan --policy-id ampel-bp --format sarif
 ```
+
+Or scan a single target (policy is inferred when the target has exactly one):
+
+```bash
+complyctl scan my-repo
+```
+
+`complyctl scan` automatically calls `generate` if artifacts are missing or the policy digest has changed.
 
 Output written to `./.complytime/scan/`.
 
 ## Authentication
 
-complyctl uses Docker credential helpers via `oras-credentials-go`. No custom configuration needed — if `docker login` works, `complyctl get` works.
+**OCI registry:** complyctl uses Docker credential helpers via `oras-credentials-go`. No custom configuration needed — if `docker login` works, `complyctl get` works.
 
 Supported sources:
 - `~/.docker/config.json` (credHelpers, credsStore, inline auths)
 - Credential helpers: `docker-credential-desktop`, `docker-credential-gcloud`, `docker-credential-ecr-login`, etc.
+
+**GitHub / GitLab API (ampel provider):** Set the appropriate token before scanning:
+
+```bash
+export GITHUB_TOKEN=ghp_your_token_here   # GitHub
+export GITLAB_TOKEN=glpat-your_token_here  # GitLab
+```
+
+Per-repository tokens can also be configured via the `access_token` target variable. See the [ampel provider configuration](https://github.com/complytime/complytime-providers/blob/main/cmd/ampel-provider/docs/configuration.md) for details.


### PR DESCRIPTION
## Summary

- Replaces the fictional `nist-800-53-r5` example with real policy bundles from complytime-policies (`ampel-branch-protection`, `cis-fedora-l1-workstation`)
- Adds a provider table covering both openscap and ampel with prerequisites and links to their configuration docs in complytime-providers
- Expands the `complytime.yaml` reference with a structure table and real examples for each provider
- Includes the required `profile` variable for the openscap provider example
- Adds ampel-specific authentication guidance (GitHub/GitLab tokens)
- Links back to complytime-policies usage guide for the list of available bundles

Companion PRs:
- complytime-policies [#33](https://github.com/complytime/complytime-policies/pull/33) — `docs/usage.md` bundle table and links
- complytime-providers [#22](https://github.com/complytime/complytime-providers/pull/22) — openscap `docs/configuration.md`

## Test plan

- [ ] Verify all markdown renders correctly on GitHub
- [ ] Verify all cross-reference links resolve (complytime-providers, complytime-policies)


Made with [Cursor](https://cursor.com)