### PR TITLE
docs: update policy URLs to per-bundle repo format with policies- prefix

### DIFF
--- a/complytime.yaml
+++ b/complytime.yaml
@@ -1,5 +1,5 @@
 policies:
-  - url: http://localhost:8765/policies/ampel-branch-protection
+  - url: quay.io/complytime/policies-ampel-branch-protection:latest
     id: ampel-bp
 
 targets:

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -56,7 +56,7 @@ targets:
 
 ```yaml
 policies:
-  - url: quay.io/complytime/complytime-policies@ampel-branch-protection
+  - url: quay.io/complytime/policies-ampel-branch-protection:latest
     id: ampel-bp
 
 targets:
@@ -74,7 +74,7 @@ See the [ampel provider configuration](https://github.com/complytime/complytime-
 
 ```yaml
 policies:
-  - url: quay.io/complytime/complytime-policies@cis-fedora-l1-workstation
+  - url: quay.io/complytime/policies-cis-fedora-l1-workstation:latest
     id: cis-fedora-l1
 
 targets:

--- a/docs/adr/0001-one-quay-repo-per-bundle.md
+++ b/docs/adr/0001-one-quay-repo-per-bundle.md
@@ -1,0 +1,47 @@
+# ADR-0001: One Quay Repository Per Policy Bundle
+
+- **Status:** Accepted
+- **Date:** 2026-05-20
+- **Canonical Location:** [complytime-policies/docs/adr/0001-one-quay-repo-per-bundle.md](https://github.com/complytime/complytime-policies/blob/main/docs/adr/0001-one-quay-repo-per-bundle.md)
+
+## Summary
+
+Policy bundles published from `complytime-policies` will each get their
+own Quay.io repository with a `policies-` prefix (e.g.,
+`quay.io/complytime/policies-ampel-branch-protection`) instead of sharing
+a single repository with bundle-name tags.
+
+## Impact on complyctl
+
+**None.** `complyctl` treats `complytime.yaml` URLs as opaque OCI
+references. The `ParsePolicyRef` and registry client code already
+support any valid OCI reference format — single-repo or multi-repo.
+
+### Consumer configuration change
+
+Before (single repo, bundle-name tag):
+
+```yaml
+policies:
+  - id: ampel-branch-protection
+    url: quay.io/complytime/complytime-policies@ampel-branch-protection
+```
+
+After (per-bundle repo with policies- prefix, version tag):
+
+```yaml
+policies:
+  - id: ampel-branch-protection
+    url: quay.io/complytime/policies-ampel-branch-protection:latest
+```
+
+### Documentation updates needed
+
+- `docs/QUICK_START.md` — update OCI reference examples
+- README policy reference examples (if any)
+
+## Full Decision Record
+
+See the canonical ADR in
+[complytime-policies](https://github.com/complytime/complytime-policies/blob/main/docs/adr/0001-one-quay-repo-per-bundle.md)
+for full context, rationale, and alternatives considered.


### PR DESCRIPTION
## Summary

- Updates `complytime.yaml` to pull policies from `quay.io/complytime/policies-ampel-branch-protection:latest` instead of localhost
- Updates `docs/QUICK_START.md` examples to use new per-bundle OCI repository naming
- Adds cross-reference ADR (`docs/adr/0001-one-quay-repo-per-bundle.md`) pointing to the canonical decision in `complytime-policies`

## Context

Follows from [complytime-policies#36](https://github.com/complytime/complytime-policies/pull/36) (merged) which refactors OCI publishing to use one Quay repository per policy bundle with a `policies-` prefix.

**Before:** `quay.io/complytime/complytime-policies@ampel-branch-protection`
**After:** `quay.io/complytime/policies-ampel-branch-protection:latest`

All three per-bundle repos are now live and publicly accessible on Quay:
- `quay.io/complytime/policies-ampel-branch-protection:latest`
- `quay.io/complytime/policies-cis-fedora-l1-workstation:latest`
- `quay.io/complytime/policies-cis-fedora-l1-server:latest`

## Merge order

| Order | Repo | PR | Purpose | Depends on |
|-------|------|----|---------|------------|
| 1 | org-infra | [#277](https://github.com/complytime/org-infra/pull/277) | Fix reusable compliance workflow + Quay direct fetch | — |
| 2 | complytime-providers | [#22](https://github.com/complytime/complytime-providers/pull/22) | OpenSCAP configuration docs | — |
| **3** | **complyctl** | **#525 (this)** | **Update policy URLs in QUICK_START + complytime.yaml** | #277 merged (for CI) |
| 4 | complytime-policies | [#33](https://github.com/complytime/complytime-policies/pull/33) | Usage docs with provider table + further reading | #22 merged (for doc links) |

## Test plan

- [ ] `complyctl get` resolves the new Quay URLs correctly
- [ ] Quick Start instructions are accurate for new users
- [ ] CI compliance workflow passes after org-infra#277 is merged and re-pinned

Relates to - https://github.com/complytime/complytime-policies/issues/5
Closes https://github.com/complytime/complytime-policies/issues/23