### PR TITLE
feat: add oci-layout:// scheme for local OCI Layout policy sync

### DIFF
--- a/cmd/complyctl/cli/get.go
+++ b/cmd/complyctl/cli/get.go
@@ -109,21 +109,33 @@ func syncSinglePolicy(ctx context.Context, cacheMgr *cache.Cache, state *cache.S
 	ref := complytime.ParsePolicyRef(entry.URL)
 	version := ref.Version
 
-	client := registry.NewClient(ref.Registry, credFunc)
-	source := cache.NewRegistrySource(client)
-	sync := cache.NewSync(cacheMgr, state, source)
+	// Dispatch based on scheme: local OCI Layout vs. remote registry.
+	// For local sources, the cache key is the effective ID (not the path).
+	// For remote sources, the cache key is the repository path.
+	var source cache.PolicySource
+	var syncPolicyID string
+	if ref.Registry == complytime.OCILayoutScheme {
+		source = cache.NewLocalSource(ref.Repository)
+		syncPolicyID = entry.EffectiveID()
+	} else {
+		client := registry.NewClient(ref.Registry, credFunc)
+		source = cache.NewRegistrySource(client)
+		syncPolicyID = ref.Repository
 
-	if version == "" {
-		version = resolveLatestVersion(ctx, client, ref.Repository, entry.EffectiveID())
+		if version == "" {
+			version = resolveLatestVersion(ctx, client, ref.Repository, entry.EffectiveID())
+		}
 	}
 
+	sync := cache.NewSync(cacheMgr, state, source)
+
 	fmt.Fprintf(os.Stderr, "Syncing policy %d/%d: %s... ", index, total, entry.EffectiveID())
-	logger.Info("Syncing policy", "policy", ref.Repository, "version", version)
-	if err := sync.SyncPolicy(ctx, ref.Repository, version); err != nil {
+	logger.Info("Syncing policy", "policy", syncPolicyID, "version", version)
+	if err := sync.SyncPolicy(ctx, syncPolicyID, version); err != nil {
 		fmt.Fprintln(os.Stderr, "failed")
-		suggestMsg := suggestCachedPolicyIDs(cacheDir, ref.Repository)
-		logger.Error("Policy sync failed", "policy", ref.Repository, "error", err)
-		return fmt.Errorf("failed to sync policy %s: %w%s", ref.Repository, err, suggestMsg)
+		suggestMsg := suggestCachedPolicyIDs(cacheDir, syncPolicyID)
+		logger.Error("Policy sync failed", "policy", syncPolicyID, "error", err)
+		return fmt.Errorf("failed to sync policy %s: %w%s", syncPolicyID, err, suggestMsg)
 	}
 	fmt.Fprintln(os.Stderr, "done")
 	logger.Info("Policy synced", "policy", entry.EffectiveID())

--- a/internal/cache/source.go
+++ b/internal/cache/source.go
@@ -5,6 +5,7 @@ package cache
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
@@ -13,7 +14,7 @@ import (
 	"github.com/complytime/complyctl/internal/registry"
 )
 
-// PolicySource abstracts remote policy access for sync operations.
+// PolicySource abstracts policy access for sync operations.
 type PolicySource interface {
 	DefinitionVersion(ctx context.Context, policyID string) (digest string, version string, err error)
 	CopyPolicy(ctx context.Context, policyID, tag string, dst *ocistore.Store) (ocispec.Descriptor, error)
@@ -39,4 +40,48 @@ func (s *RegistrySource) CopyPolicy(ctx context.Context, policyID, tag string, d
 		return ocispec.Descriptor{}, fmt.Errorf("failed to create remote repository: %w", err)
 	}
 	return oras.Copy(ctx, repo, tag, dst, tag, oras.CopyOptions{})
+}
+
+// LocalSource implements PolicySource for local OCI Layout directories.
+// Uses oras.Copy() for local-to-local transfer with digest verification.
+type LocalSource struct {
+	layoutPath string
+}
+
+// NewLocalSource creates a LocalSource that reads from the given OCI Layout
+// directory path.
+func NewLocalSource(layoutPath string) *LocalSource {
+	return &LocalSource{layoutPath: layoutPath}
+}
+
+// DefinitionVersion reads the manifest digest and version tag from a local
+// OCI Layout. The policyID may include a ":tag" suffix; if absent, "latest"
+// is used.
+func (s *LocalSource) DefinitionVersion(ctx context.Context, policyID string) (string, string, error) {
+	store, err := ocistore.New(s.layoutPath)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to open local OCI layout %s: %w", s.layoutPath, err)
+	}
+
+	tag := "latest"
+	if parts := strings.SplitN(policyID, ":", 2); len(parts) == 2 {
+		tag = parts[1]
+	}
+
+	desc, err := store.Resolve(ctx, tag)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to resolve tag %q in %s: %w", tag, s.layoutPath, err)
+	}
+
+	return desc.Digest.String(), tag, nil
+}
+
+// CopyPolicy copies a tagged manifest and all its layers from the local OCI
+// Layout into the destination store using oras.Copy().
+func (s *LocalSource) CopyPolicy(ctx context.Context, _ string, tag string, dst *ocistore.Store) (ocispec.Descriptor, error) {
+	srcStore, err := ocistore.New(s.layoutPath)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to open local OCI layout %s: %w", s.layoutPath, err)
+	}
+	return oras.Copy(ctx, srcStore, tag, dst, tag, oras.CopyOptions{})
 }

--- a/internal/cache/source_test.go
+++ b/internal/cache/source_test.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cache_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ocistore "oras.land/oras-go/v2/content/oci"
+
+	"github.com/complytime/complyctl/internal/cache"
+)
+
+// seedTestLayout creates a minimal OCI Layout at the given path with a single
+// layer and a tagged manifest. Returns the manifest digest.
+func seedTestLayout(t *testing.T, layoutPath, tag string) string {
+	t.Helper()
+	ctx := context.Background()
+
+	store, err := ocistore.New(layoutPath)
+	require.NoError(t, err)
+
+	// Push empty config.
+	configData := []byte("{}")
+	configDesc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeEmptyJSON,
+		Digest:    digest.FromBytes(configData),
+		Size:      int64(len(configData)),
+	}
+	require.NoError(t, store.Push(ctx, configDesc, bytes.NewReader(configData)))
+
+	// Push a test layer.
+	layerData := []byte(`{"policy_id": "test-policy", "type": "test-layer"}`)
+	layerDesc := ocispec.Descriptor{
+		MediaType: "application/vnd.gemara.policy.v1+yaml",
+		Digest:    digest.FromBytes(layerData),
+		Size:      int64(len(layerData)),
+	}
+	require.NoError(t, store.Push(ctx, layerDesc, bytes.NewReader(layerData)))
+
+	// Build and push manifest.
+	manifest := ocispec.Manifest{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Config:    configDesc,
+		Layers:    []ocispec.Descriptor{layerDesc},
+	}
+	manifest.SchemaVersion = 2
+	manifestData, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	manifestDesc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    digest.FromBytes(manifestData),
+		Size:      int64(len(manifestData)),
+	}
+	require.NoError(t, store.Push(ctx, manifestDesc, bytes.NewReader(manifestData)))
+	require.NoError(t, store.Tag(ctx, manifestDesc, tag))
+
+	return manifestDesc.Digest.String()
+}
+
+func TestLocalSource_DefinitionVersion_ResolvesDigest(t *testing.T) {
+	srcDir := t.TempDir()
+	expectedDigest := seedTestLayout(t, srcDir, "latest")
+
+	src := cache.NewLocalSource(srcDir)
+	gotDigest, gotVersion, err := src.DefinitionVersion(context.Background(), "test-policy")
+	require.NoError(t, err)
+	assert.Equal(t, expectedDigest, gotDigest)
+	assert.Equal(t, "latest", gotVersion)
+}
+
+func TestLocalSource_DefinitionVersion_ExplicitTag(t *testing.T) {
+	srcDir := t.TempDir()
+	expectedDigest := seedTestLayout(t, srcDir, "v1.0.0")
+
+	src := cache.NewLocalSource(srcDir)
+	gotDigest, gotVersion, err := src.DefinitionVersion(context.Background(), "test-policy:v1.0.0")
+	require.NoError(t, err)
+	assert.Equal(t, expectedDigest, gotDigest)
+	assert.Equal(t, "v1.0.0", gotVersion)
+}
+
+func TestLocalSource_CopyPolicy(t *testing.T) {
+	ctx := context.Background()
+	srcDir := t.TempDir()
+	seedTestLayout(t, srcDir, "latest")
+
+	dstDir := filepath.Join(t.TempDir(), "dst")
+	dstStore, err := ocistore.New(dstDir)
+	require.NoError(t, err)
+
+	src := cache.NewLocalSource(srcDir)
+	desc, err := src.CopyPolicy(ctx, "test-policy", "latest", dstStore)
+	require.NoError(t, err)
+	assert.Equal(t, ocispec.MediaTypeImageManifest, desc.MediaType)
+
+	// Verify destination can resolve the tag.
+	resolved, err := dstStore.Resolve(ctx, "latest")
+	require.NoError(t, err)
+	assert.Equal(t, desc.Digest, resolved.Digest)
+}
+
+func TestLocalSource_DefinitionVersion_NonexistentPath(t *testing.T) {
+	src := cache.NewLocalSource("/nonexistent/path/to/layout")
+	_, _, err := src.DefinitionVersion(context.Background(), "test-policy")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to open local OCI layout")
+}
+
+func TestLocalSource_CopyPolicy_NonexistentPath(t *testing.T) {
+	dstDir := filepath.Join(t.TempDir(), "dst")
+	dstStore, err := ocistore.New(dstDir)
+	require.NoError(t, err)
+
+	src := cache.NewLocalSource("/nonexistent/path/to/layout")
+	_, err = src.CopyPolicy(context.Background(), "test", "latest", dstStore)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to open local OCI layout")
+}
+
+func TestLocalSource_DefinitionVersion_InvalidLayout(t *testing.T) {
+	// Create a directory that exists but has no tagged manifests.
+	// oci.New() on an empty directory creates a new OCI Layout, so the
+	// error comes from store.Resolve() failing to find the tag.
+	emptyDir := t.TempDir()
+
+	src := cache.NewLocalSource(emptyDir)
+	_, _, err := src.DefinitionVersion(context.Background(), "test-policy")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to resolve tag")
+}
+
+func TestLocalSource_CopyPolicy_NonexistentTag(t *testing.T) {
+	ctx := context.Background()
+	srcDir := t.TempDir()
+	seedTestLayout(t, srcDir, "latest")
+
+	dstDir := filepath.Join(t.TempDir(), "dst")
+	dstStore, err := ocistore.New(dstDir)
+	require.NoError(t, err)
+
+	src := cache.NewLocalSource(srcDir)
+	_, err = src.CopyPolicy(ctx, "test-policy", "v99.0.0", dstStore)
+	require.Error(t, err)
+}

--- a/internal/complytime/config.go
+++ b/internal/complytime/config.go
@@ -17,9 +17,13 @@ var envVarPattern = regexp.MustCompile(`\$\{([^}]+)\}`)
 // and are commonly used for shell injection.
 var unsafeRefChars = regexp.MustCompile("[;|&$`!><(){}\\[\\]\\\\]")
 
+// OCILayoutScheme is the URL scheme for local OCI Layout directory references.
+const OCILayoutScheme = "oci-layout://"
+
 // ValidateOCIRef checks that raw looks like a valid OCI reference
-// (registry/repository with optional :tag or @version). It rejects empty
-// strings, shell metacharacters, and bare names without a registry component.
+// (registry/repository with optional :tag or @version) or a local OCI Layout
+// reference (oci-layout:///path). It rejects empty strings, shell
+// metacharacters, and bare names without a registry component.
 func ValidateOCIRef(raw string) error {
 	s := strings.TrimSpace(raw)
 	if s == "" {
@@ -27,6 +31,19 @@ func ValidateOCIRef(raw string) error {
 	}
 	if unsafeRefChars.MatchString(s) {
 		return fmt.Errorf("policy URL contains invalid characters: %s", s)
+	}
+
+	// Local OCI Layout references bypass registry host validation.
+	if strings.HasPrefix(s, OCILayoutScheme) {
+		path := strings.TrimPrefix(s, OCILayoutScheme)
+		// Strip @version suffix before checking path.
+		if idx := strings.LastIndex(path, "@"); idx > 0 {
+			path = path[:idx]
+		}
+		if path == "" {
+			return fmt.Errorf("oci-layout:// URL must include a path")
+		}
+		return nil
 	}
 
 	stripped := strings.TrimPrefix(strings.TrimPrefix(s, "https://"), "http://")
@@ -106,11 +123,23 @@ type PolicyRef struct {
 }
 
 // ParsePolicyRef parses a full OCI reference into its components.
-// Handles optional scheme (http://, https://), registry host detection,
-// and @version suffix.
+// Handles optional scheme (http://, https://, oci-layout://), registry host
+// detection, and @version suffix.
 func ParsePolicyRef(raw string) PolicyRef {
 	ref := PolicyRef{Raw: raw}
 	s := strings.TrimSpace(raw)
+
+	// Local OCI Layout: path is the "repository", no registry host.
+	if strings.HasPrefix(s, OCILayoutScheme) {
+		path := strings.TrimPrefix(s, OCILayoutScheme)
+		if idx := strings.LastIndex(path, "@"); idx > 0 && idx < len(path)-1 {
+			ref.Version = path[idx+1:]
+			path = path[:idx]
+		}
+		ref.Registry = OCILayoutScheme
+		ref.Repository = path
+		return ref
+	}
 
 	var scheme string
 	if strings.HasPrefix(s, "http://") {

--- a/internal/complytime/config_test.go
+++ b/internal/complytime/config_test.go
@@ -505,6 +505,80 @@ func TestValidateOCIRef_RejectNoRegistryHost(t *testing.T) {
 	assert.Contains(t, err.Error(), "must include a registry host")
 }
 
+// oci-layout:// scheme tests
+
+func TestValidateOCIRef_ValidOCILayout(t *testing.T) {
+	assert.NoError(t, complytime.ValidateOCIRef("oci-layout:///home/user/bundles/my-policy"))
+}
+
+func TestValidateOCIRef_ValidOCILayoutWithVersion(t *testing.T) {
+	assert.NoError(t, complytime.ValidateOCIRef("oci-layout:///home/user/bundles/my-policy@v1.0.0"))
+}
+
+func TestValidateOCIRef_RejectOCILayoutEmptyPath(t *testing.T) {
+	err := complytime.ValidateOCIRef("oci-layout://")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must include a path")
+}
+
+func TestValidateOCIRef_RejectOCILayoutMetachars(t *testing.T) {
+	err := complytime.ValidateOCIRef("oci-layout:///path/with;semicolon")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid characters")
+}
+
+func TestParsePolicyRef_OCILayout(t *testing.T) {
+	ref := complytime.ParsePolicyRef("oci-layout:///home/user/bundles/my-policy")
+	assert.Equal(t, "oci-layout://", ref.Registry)
+	assert.Equal(t, "/home/user/bundles/my-policy", ref.Repository)
+	assert.Empty(t, ref.Version)
+}
+
+func TestParsePolicyRef_OCILayoutWithVersion(t *testing.T) {
+	ref := complytime.ParsePolicyRef("oci-layout:///home/user/bundles/my-policy@v1.0.0")
+	assert.Equal(t, "oci-layout://", ref.Registry)
+	assert.Equal(t, "/home/user/bundles/my-policy", ref.Repository)
+	assert.Equal(t, "v1.0.0", ref.Version)
+}
+
+func TestParsePolicyRef_OCILayoutRelativePath(t *testing.T) {
+	ref := complytime.ParsePolicyRef("oci-layout://bundles/my-policy@v2.0")
+	assert.Equal(t, "oci-layout://", ref.Registry)
+	assert.Equal(t, "bundles/my-policy", ref.Repository)
+	assert.Equal(t, "v2.0", ref.Version)
+}
+
+func TestPolicyEntry_EffectiveID_OCILayout(t *testing.T) {
+	p := complytime.PolicyEntry{URL: "oci-layout:///home/user/bundles/my-policy", ID: "my-policy"}
+	assert.Equal(t, "my-policy", p.EffectiveID())
+}
+
+func TestPolicyEntry_EffectiveID_OCILayoutDerived(t *testing.T) {
+	p := complytime.PolicyEntry{URL: "oci-layout:///home/user/bundles/my-policy"}
+	assert.Equal(t, "my-policy", p.EffectiveID())
+}
+
+func TestPolicyEntry_EffectiveID_OCILayoutTrailingSlash(t *testing.T) {
+	p := complytime.PolicyEntry{URL: "oci-layout:///home/user/bundles/my-policy/"}
+	// Trailing slash produces an empty last segment, so EffectiveID returns "".
+	// Users should always provide an explicit ID for oci-layout:// paths with
+	// trailing slashes, or avoid trailing slashes.
+	assert.Equal(t, "", p.EffectiveID())
+}
+
+func TestValidate_OCILayoutPolicy(t *testing.T) {
+	cfg := &complytime.WorkspaceConfig{
+		Policies: []complytime.PolicyEntry{
+			{URL: "oci-layout:///tmp/bundles/test-policy", ID: "test-local"},
+		},
+		Targets: []complytime.TargetConfig{{
+			ID:       "local",
+			Policies: []string{"test-local"},
+		}},
+	}
+	assert.NoError(t, complytime.Validate(cfg))
+}
+
 // T256: Validate catches duplicate URLs (already tested above, but verify
 // the OCI validation runs first for malformed entries)
 

--- a/openspec/changes/local-oci-layout-source/.openspec.yaml
+++ b/openspec/changes/local-oci-layout-source/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-02

--- a/openspec/changes/local-oci-layout-source/design.md
+++ b/openspec/changes/local-oci-layout-source/design.md
@@ -1,0 +1,68 @@
+## Context
+
+`complyctl get` syncs policies from OCI registries into a local cache at `~/.complytime/policies/{id}/` as OCI Layout directories. The sync pipeline is: `complytime.yaml` -> `ParsePolicyRef` -> `registry.NewClient` -> `cache.NewRegistrySource` -> `cache.NewSync` -> `oras.Copy` (remote-to-local). The downstream commands (`generate`, `scan`) operate entirely from the local OCI Layout cache via `oci.New()` and never re-contact the registry.
+
+The `PolicySource` interface (`internal/cache/source.go`) has only two methods (`DefinitionVersion`, `CopyPolicy`) and a single production implementation (`RegistrySource`). The test infrastructure (`MockPolicySource`, `MockBundlePolicySource` in `internal/cache/cachetest/`) already demonstrates pushing content into `*oci.Store` without a network, proving the interface supports local sources.
+
+`ValidateOCIRef` (`internal/complytime/config.go`) is called at config load time by `get`, `generate`, and `scan`. It rejects URLs without a registry host containing `.` or `:`. This is the primary gate preventing local file paths.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Enable `complyctl get` to sync from a local OCI Layout directory via `oci-layout://` scheme
+- Preserve full backward compatibility with existing registry-based behavior
+- Use `oras.Copy()` for local-to-local transfer so incremental sync, digest verification, and state tracking all work identically to remote sources
+- Require no changes to `generate`, `scan`, or the policy loader
+
+**Non-Goals:**
+- Supporting arbitrary file paths or directories that are not valid OCI Layouts (the source must be a proper OCI Layout with `oci-layout`, `index.json`, and `blobs/`)
+- Adding a general-purpose `file://` scheme (too ambiguous about expected format)
+- Modifying the mock OCI registry or devcontainer setup in this change (follow-up work)
+- Supporting writing/publishing to local layouts (read-only source)
+
+## Decisions
+
+### 1. Use `oci-layout://` as the URL scheme
+
+Use `oci-layout:///path/to/layout` as the URL format in `complytime.yaml`. The triple slash follows URI convention for local paths (scheme + empty authority + absolute path).
+
+**Alternatives considered:**
+- `file:///path` -- Too generic; does not communicate that the path must be a valid OCI Layout. Could be confused with raw YAML files.
+- `oci:/path` -- Non-standard, could conflict with future OCI specification schemes.
+- Bare paths (`/tmp/my-bundle`) -- Rejected by `ValidateOCIRef` host validation and ambiguous about expected directory structure.
+
+### 2. Sentinel registry value for dispatch
+
+`ParsePolicyRef` sets `ref.Registry = "oci-layout://"` for local sources. `syncSinglePolicy` checks this value to dispatch to `LocalSource` instead of `RegistrySource`. This avoids adding a new field to `PolicyRef` and keeps the dispatch logic minimal.
+
+**Alternatives considered:**
+- Add a `Scheme` field to `PolicyRef` -- Cleaner but touches more code for a single new scheme. Revisit if more schemes are added.
+- Boolean `IsLocal` field -- Less extensible than the sentinel approach.
+
+### 3. `LocalSource` uses `oras.Copy()` for local-to-local transfer
+
+`LocalSource.CopyPolicy` opens the source OCI Layout with `oci.New()` and calls `oras.Copy(ctx, srcStore, tag, dstStore, tag, oras.CopyOptions{})`. This provides atomic transfer with digest verification, identical to the remote path.
+
+**Alternatives considered:**
+- Direct file copy (symlink or `os.Link`) -- Breaks digest verification, skips `oras` content-addressing guarantees, and couples the cache to the source directory lifecycle.
+- Read manifest and push blobs individually -- Reimplements what `oras.Copy` already does.
+
+### 4. Validate path existence at sync time, not config parse time
+
+`ValidateOCIRef` accepts `oci-layout://` paths without checking if the path exists on disk. Path existence is validated when `LocalSource.CopyPolicy` calls `oci.New()` at sync time. This matches the existing pattern where registry reachability is not validated at config parse time.
+
+**Alternatives considered:**
+- Validate path existence in `ValidateOCIRef` -- Would make config loading side-effectful and fail for paths that will exist later (e.g., mounted volumes in containers).
+
+### 5. Version handling defaults to `latest`
+
+For `oci-layout://` sources without a `@version` suffix, the version defaults to `latest`. `LocalSource.DefinitionVersion` resolves the tag from the source layout's `index.json` via `store.Resolve(ctx, tag)`.
+
+**Alternatives considered:**
+- Require explicit version -- Adds friction for local use where there is typically only one version.
+
+## Risks / Trade-offs
+
+- **[Path portability]** `oci-layout://` paths are absolute and host-specific. A `complytime.yaml` with local paths is not portable across machines. Mitigation: this is the intended use case (private, local evaluation). Portable configs should use registry URLs.
+- **[Source directory mutation]** If the source OCI Layout is modified after sync, `complyctl get` will detect the digest change on next run and re-sync. This is correct behavior but may surprise users who expect the cache to be independent. Mitigation: matches remote registry behavior exactly.
+- **[No auth for local paths]** `LocalSource` does not use credentials. Filesystem permissions are the access control mechanism. Mitigation: appropriate for local files; registry auth remains for remote sources.

--- a/openspec/changes/local-oci-layout-source/proposal.md
+++ b/openspec/changes/local-oci-layout-source/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Private policy bundles cannot be committed to GitHub or pushed to a public OCI registry. Today `complyctl get` only supports syncing from remote OCI registries (or a local mock registry that requires content embedded at compile time). Users evaluating private compliance policies need a way to run the full `get` -> `generate` -> `scan` pipeline from a local OCI Layout directory without network access or content exposure.
+
+## What Changes
+
+- Introduce `oci-layout://` URL scheme in `complytime.yaml` policy entries, enabling `complyctl get` to sync from a local OCI Layout directory
+- Add `LocalSource` implementation of the `PolicySource` interface that reads from a local OCI Layout using `oci.New()` and copies to the cache via `oras.Copy()` (local-to-local, no network)
+- Extend `ValidateOCIRef()` to accept `oci-layout://` scheme, bypassing registry host validation while preserving shell metacharacter rejection
+- Extend `ParsePolicyRef()` to parse `oci-layout://` URLs into `PolicyRef` with a sentinel `Registry` value for dispatch
+- Add scheme dispatch in `syncSinglePolicy()` to route `oci-layout://` URLs to `LocalSource` instead of `RegistrySource`
+- No changes to `generate`, `scan`, or the policy loader -- these already operate entirely from the local OCI Layout cache
+
+## Capabilities
+
+### New Capabilities
+- `local-oci-source`: Sync policies from local OCI Layout directories via `oci-layout://` scheme in `complyctl get`, enabling private policy evaluation without a registry
+
+### Modified Capabilities
+
+## Impact
+
+- **Code**: `internal/cache/source.go` (new `LocalSource`), `internal/complytime/config.go` (`ValidateOCIRef`, `ParsePolicyRef`), `cmd/complyctl/cli/get.go` (scheme dispatch)
+- **Tests**: `internal/cache/source_test.go` (new), `internal/complytime/config_test.go` (extended), E2E test for local layout pipeline
+- **Dependencies**: No new dependencies. Uses existing `oras-go/v2/content/oci` for local OCI Layout access (already vendored)
+- **No breaking changes**: All existing registry-based behavior is unchanged. The `oci-layout://` scheme is additive.

--- a/openspec/changes/local-oci-layout-source/specs/local-oci-source/spec.md
+++ b/openspec/changes/local-oci-layout-source/specs/local-oci-source/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Accept oci-layout scheme in policy URL
+The system SHALL accept `oci-layout://` as a valid URL scheme in `complytime.yaml` policy entries. The URL format SHALL be `oci-layout://<absolute-path>` where `<absolute-path>` is an absolute filesystem path to a directory containing a valid OCI Layout. An optional `@<version>` suffix MAY specify the tag to resolve.
+
+#### Scenario: Valid oci-layout URL passes validation
+- **WHEN** `complytime.yaml` contains a policy with `url: oci-layout:///home/user/bundles/my-policy`
+- **THEN** `ValidateOCIRef` SHALL accept the URL without error
+
+#### Scenario: oci-layout URL with version suffix
+- **WHEN** `complytime.yaml` contains a policy with `url: oci-layout:///home/user/bundles/my-policy@v1.0.0`
+- **THEN** `ParsePolicyRef` SHALL extract `Version: "v1.0.0"` and `Repository: "/home/user/bundles/my-policy"`
+
+#### Scenario: Empty path rejected
+- **WHEN** `complytime.yaml` contains a policy with `url: oci-layout://`
+- **THEN** `ValidateOCIRef` SHALL return an error indicating the path must not be empty
+
+#### Scenario: Shell metacharacters rejected
+- **WHEN** `complytime.yaml` contains a policy with `url: oci-layout:///path/with;semicolon`
+- **THEN** `ValidateOCIRef` SHALL return an error indicating invalid characters
+
+### Requirement: Sync from local OCI Layout
+The system SHALL sync policies from a local OCI Layout directory when the policy URL uses the `oci-layout://` scheme. The sync SHALL use `oras.Copy()` for local-to-local transfer with digest verification. No network access SHALL occur during sync of `oci-layout://` policies.
+
+#### Scenario: Successful sync from local layout
+- **WHEN** user runs `complyctl get` with a policy configured as `oci-layout:///path/to/bundle`
+- **AND** the path contains a valid OCI Layout with a tagged manifest
+- **THEN** the system SHALL copy the manifest and all layers into `~/.complytime/policies/{id}/`
+- **AND** the system SHALL update `state.json` with the manifest digest, version, and timestamp
+
+#### Scenario: Incremental sync skips unchanged content
+- **WHEN** user runs `complyctl get` with a previously synced `oci-layout://` policy
+- **AND** the source OCI Layout manifest digest matches the cached digest in `state.json`
+- **THEN** the system SHALL skip the sync and report the policy as up-to-date
+
+#### Scenario: Source layout does not exist
+- **WHEN** user runs `complyctl get` with `oci-layout:///nonexistent/path`
+- **THEN** the system SHALL return an error indicating the local OCI Layout could not be opened
+
+#### Scenario: Source layout is not a valid OCI Layout
+- **WHEN** user runs `complyctl get` with `oci-layout:///path/to/empty-dir`
+- **AND** the directory does not contain an `oci-layout` marker file
+- **THEN** the system SHALL return an error indicating the path is not a valid OCI Layout
+
+### Requirement: Downstream commands work with locally synced policies
+The `generate` and `scan` commands SHALL work without modification for policies synced from `oci-layout://` sources. The commands SHALL read from the local cache at `~/.complytime/policies/{id}/` regardless of the original source scheme.
+
+#### Scenario: Generate after local sync
+- **WHEN** user runs `complyctl get` with an `oci-layout://` policy
+- **AND** then runs `complyctl generate --policy-id <id>`
+- **THEN** the system SHALL resolve the policy from the local cache and generate output
+
+#### Scenario: Mixed sources in single config
+- **WHEN** `complytime.yaml` contains both `oci-layout://` and registry-based policy URLs
+- **THEN** `complyctl get` SHALL sync each policy from its respective source
+- **AND** `complyctl generate` and `complyctl scan` SHALL work for all policies regardless of source
+
+### Requirement: Version resolution for local sources
+The system SHALL resolve the manifest tag from the local OCI Layout when no `@version` suffix is specified. The default tag SHALL be `latest`.
+
+#### Scenario: Default version resolution
+- **WHEN** the policy URL is `oci-layout:///path/to/bundle` (no version suffix)
+- **THEN** `LocalSource.DefinitionVersion` SHALL resolve the `latest` tag from the source layout's `index.json`
+
+#### Scenario: Explicit version resolution
+- **WHEN** the policy URL is `oci-layout:///path/to/bundle@v2.0.0`
+- **THEN** `LocalSource.DefinitionVersion` SHALL resolve the `v2.0.0` tag from the source layout

--- a/openspec/changes/local-oci-layout-source/tasks.md
+++ b/openspec/changes/local-oci-layout-source/tasks.md
@@ -1,0 +1,32 @@
+## 1. Config Parsing: Accept oci-layout:// Scheme
+
+- [x] 1.1 Add `oci-layout://` early return in `ValidateOCIRef` (`internal/complytime/config.go`): accept the scheme, reject empty path, preserve shell metachar check
+- [x] 1.2 Add `oci-layout://` branch in `ParsePolicyRef` (`internal/complytime/config.go`): set `Registry = "oci-layout://"`, `Repository = path`, extract `@version` suffix
+- [x] 1.3 Add unit tests for `ValidateOCIRef` with `oci-layout://` URLs (`internal/complytime/config_test.go`): valid path, empty path rejection, metachar rejection, version suffix
+- [x] 1.4 Add unit tests for `ParsePolicyRef` with `oci-layout://` URLs (`internal/complytime/config_test.go`): path extraction, version extraction, no-version default
+
+## 2. LocalSource Implementation
+
+- [x] 2.1 Add `LocalSource` struct and `NewLocalSource` constructor in `internal/cache/source.go`
+- [x] 2.2 Implement `LocalSource.DefinitionVersion`: open source layout with `oci.New()`, resolve tag via `store.Resolve()`, return digest and version
+- [x] 2.3 Implement `LocalSource.CopyPolicy`: open source layout with `oci.New()`, call `oras.Copy()` from source store to destination store
+- [x] 2.4 Add unit tests for `LocalSource` (`internal/cache/source_test.go`): create temp OCI Layout with test manifest and layer, verify `DefinitionVersion` returns correct digest and tag, verify `CopyPolicy` copies all content to destination store
+- [x] 2.5 Add unit test for `LocalSource` with nonexistent path: verify meaningful error message
+- [x] 2.6 Add unit test for `LocalSource` with invalid OCI Layout (missing `oci-layout` marker): verify error
+
+## 3. Scheme Dispatch in complyctl get
+
+- [x] 3.1 Add scheme dispatch in `syncSinglePolicy` (`cmd/complyctl/cli/get.go`): if `ref.Registry == "oci-layout://"`, create `LocalSource` instead of `RegistrySource`
+- [x] 3.2 Skip `resolveLatestVersion` for local sources: local version resolution is handled by `LocalSource.DefinitionVersion`
+
+## 4. Integration Testing
+
+- [x] 4.1 Add E2E test for local OCI Layout sync (`tests/e2e/`): create temp OCI Layout with test policy, write `complytime.yaml` with `oci-layout://` URL, run `complyctl get`, verify cache is populated
+- [x] 4.2 Add E2E test for mixed sources: config with both `oci-layout://` and registry-based URLs, verify both sync correctly
+- [x] 4.3 Add E2E test for incremental sync: run `complyctl get` twice with unchanged local layout, verify second run skips sync
+
+## 5. Validation
+
+- [x] 5.1 Run `make test-unit` and confirm all tests pass
+- [x] 5.2 Run `make lint` and `make vet` and confirm no issues
+- [x] 5.3 Run `make test-e2e` and confirm E2E tests pass including new local layout tests

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -722,3 +722,139 @@ targets:
 	assert.NotContains(t, out, "nist-800-53-r5",
 		"filter must exclude non-matching policies")
 }
+
+// TestE2E_LocalOCILayoutSync exercises syncing from a local OCI Layout
+// directory via the oci-layout:// scheme.
+func TestE2E_LocalOCILayoutSync(t *testing.T) {
+	binary := locateBinary(t)
+	homeDir := t.TempDir()
+	workDir := t.TempDir()
+
+	// Create a local OCI Layout with a test policy.
+	localLayoutDir := filepath.Join(t.TempDir(), "test-local-policy")
+	seedLocalOCILayout(t, localLayoutDir, "latest")
+
+	// Write complytime.yaml pointing at the local layout.
+	configYAML := fmt.Sprintf(`policies:
+  - url: oci-layout://%s
+    id: local-test-policy
+targets:
+  - id: local-target
+    policies:
+      - local-test-policy
+    variables:
+      env: test
+`, localLayoutDir)
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "complytime.yaml"), []byte(configYAML), 0644))
+
+	env := buildEnv(homeDir)
+
+	// Run get — should sync from local layout.
+	out := runComplytime(t, binary, workDir, env, "get")
+	t.Log(out)
+	assert.Contains(t, out, "Synchronization completed.")
+
+	// Verify cache is populated.
+	cacheDir := filepath.Join(homeDir, ".complytime", "policies", "local-test-policy")
+	assert.DirExists(t, cacheDir, "policy cache directory must exist after get")
+	assert.FileExists(t, filepath.Join(cacheDir, "oci-layout"), "OCI layout marker required")
+
+	// Verify state.json tracks the policy.
+	stateFile := filepath.Join(homeDir, ".complytime", "state.json")
+	assert.FileExists(t, stateFile)
+	stateData, err := os.ReadFile(stateFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(stateData), "local-test-policy")
+}
+
+// TestE2E_LocalOCILayoutMixedSources exercises syncing with both local and
+// registry-based policy sources in the same config.
+func TestE2E_LocalOCILayoutMixedSources(t *testing.T) {
+	binary := locateBinary(t)
+	srv := startMockRegistry(t)
+	defer srv.Close()
+
+	homeDir := t.TempDir()
+	workDir := t.TempDir()
+
+	// Create a local OCI Layout.
+	localLayoutDir := filepath.Join(t.TempDir(), "local-policy")
+	seedLocalOCILayout(t, localLayoutDir, "latest")
+
+	// Write config with both local and remote sources.
+	configYAML := fmt.Sprintf(`policies:
+  - url: %s/nist-800-53-r5
+    id: nist-800-53-r5
+  - url: oci-layout://%s
+    id: local-policy
+targets:
+  - id: mixed-target
+    policies:
+      - nist-800-53-r5
+      - local-policy
+    variables:
+      env: test
+`, srv.URL, localLayoutDir)
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "complytime.yaml"), []byte(configYAML), 0644))
+
+	env := buildEnv(homeDir)
+
+	out := runComplytime(t, binary, workDir, env, "get")
+	t.Log(out)
+	assert.Contains(t, out, "Synchronization completed.")
+
+	// Verify both policies are cached.
+	assert.DirExists(t, filepath.Join(homeDir, ".complytime", "policies", "nist-800-53-r5"))
+	assert.DirExists(t, filepath.Join(homeDir, ".complytime", "policies", "local-policy"))
+}
+
+// TestE2E_LocalOCILayoutIncrementalSync verifies that a second get with an
+// unchanged local layout skips the sync.
+func TestE2E_LocalOCILayoutIncrementalSync(t *testing.T) {
+	binary := locateBinary(t)
+	homeDir := t.TempDir()
+	workDir := t.TempDir()
+
+	localLayoutDir := filepath.Join(t.TempDir(), "incr-policy")
+	seedLocalOCILayout(t, localLayoutDir, "latest")
+
+	configYAML := fmt.Sprintf(`policies:
+  - url: oci-layout://%s
+    id: incr-policy
+targets:
+  - id: incr-target
+    policies:
+      - incr-policy
+    variables:
+      env: test
+`, localLayoutDir)
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "complytime.yaml"), []byte(configYAML), 0644))
+
+	env := buildEnv(homeDir)
+
+	// First sync.
+	out1 := runComplytime(t, binary, workDir, env, "get")
+	assert.Contains(t, out1, "Synchronization completed.")
+
+	// Read state after first sync.
+	stateFile := filepath.Join(homeDir, ".complytime", "state.json")
+	stateData1, err := os.ReadFile(stateFile)
+	require.NoError(t, err)
+
+	// Second sync — should complete (incremental skip is internal).
+	out2 := runComplytime(t, binary, workDir, env, "get")
+	assert.Contains(t, out2, "Synchronization completed.")
+
+	// State digest should remain the same.
+	stateData2, err := os.ReadFile(stateFile)
+	require.NoError(t, err)
+
+	var state1, state2 map[string]interface{}
+	require.NoError(t, json.Unmarshal(stateData1, &state1))
+	require.NoError(t, json.Unmarshal(stateData2, &state2))
+
+	policies1 := state1["policies"].(map[string]interface{})["incr-policy"].(map[string]interface{})
+	policies2 := state2["policies"].(map[string]interface{})["incr-policy"].(map[string]interface{})
+	assert.Equal(t, policies1["digest"], policies2["digest"],
+		"digest must remain the same across incremental syncs")
+}

--- a/tests/e2e/helpers_test.go
+++ b/tests/e2e/helpers_test.go
@@ -5,6 +5,8 @@
 package e2e
 
 import (
+	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
@@ -17,8 +19,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	ocistore "oras.land/oras-go/v2/content/oci"
 )
 
 // testPolicyYAML is a valid Gemara Policy with two assessment-plans bound to
@@ -485,4 +490,69 @@ func assertOutputFile(t *testing.T, dir, prefix, suffix string) string {
 	}
 	t.Fatalf("no file matching %s*%s found in %s (contents: %v)", prefix, suffix, dir, entries)
 	return ""
+}
+
+// seedLocalOCILayout creates a minimal OCI Layout directory at layoutPath
+// with a catalog and policy layer, matching the structure produced by the
+// mock registry. The manifest is tagged with the given tag.
+func seedLocalOCILayout(t *testing.T, layoutPath, tag string) {
+	t.Helper()
+	ctx := context.Background()
+
+	store, err := ocistore.New(layoutPath)
+	require.NoError(t, err)
+
+	// Push empty config.
+	configData := []byte("{}")
+	configDesc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeEmptyJSON,
+		Digest:    digest.FromBytes(configData),
+		Size:      int64(len(configData)),
+	}
+	require.NoError(t, store.Push(ctx, configDesc, bytes.NewReader(configData)))
+
+	// Push catalog layer.
+	catalogData := []byte(`id: local-test-catalog
+title: Local Test Catalog
+controls:
+  - id: LC-1
+    title: Local Control 1
+`)
+	catalogDesc := ocispec.Descriptor{
+		MediaType: "application/vnd.gemara.catalog.v1+yaml",
+		Digest:    digest.FromBytes(catalogData),
+		Size:      int64(len(catalogData)),
+	}
+	require.NoError(t, store.Push(ctx, catalogDesc, bytes.NewReader(catalogData)))
+
+	// Push policy layer.
+	policyData := []byte(`title: Local Test Policy
+metadata:
+  id: local-test-policy
+  version: "1.0.0"
+`)
+	policyDesc := ocispec.Descriptor{
+		MediaType: "application/vnd.gemara.policy.v1+yaml",
+		Digest:    digest.FromBytes(policyData),
+		Size:      int64(len(policyData)),
+	}
+	require.NoError(t, store.Push(ctx, policyDesc, bytes.NewReader(policyData)))
+
+	// Build and push manifest.
+	manifest := ocispec.Manifest{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Config:    configDesc,
+		Layers:    []ocispec.Descriptor{catalogDesc, policyDesc},
+	}
+	manifest.SchemaVersion = 2
+	manifestData, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	manifestDesc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    digest.FromBytes(manifestData),
+		Size:      int64(len(manifestData)),
+	}
+	require.NoError(t, store.Push(ctx, manifestDesc, bytes.NewReader(manifestData)))
+	require.NoError(t, store.Tag(ctx, manifestDesc, tag))
 }


### PR DESCRIPTION
## Summary

Add `oci-layout://` URL scheme support to `complyctl get` so policies can be synced from a local OCI Layout directory instead of requiring a remote OCI registry. This enables demos and private policy evaluation without pushing content to GitHub or any registry.

## Problem

Private policy bundles cannot be committed to GitHub or pushed to a public registry. The only way to use `complyctl get` today is through a remote OCI registry (or the mock registry, which requires embedded testdata at compile time).

## Solution

Introduce `oci-layout:///path/to/bundle` as a new URL scheme in `complytime.yaml`:

```yaml
policies:
  - url: oci-layout:///home/user/bundles/my-private-policy
    id: my-private-policy
```

```bash
complyctl get      # syncs from local OCI Layout, no network
complyctl generate # works unchanged (reads from cache)
complyctl scan     # works unchanged (reads from cache)
```

### Changes

| File | Change |
|------|--------|
| `internal/complytime/config.go` | `OCILayoutScheme` const, `oci-layout://` handling in `ValidateOCIRef` and `ParsePolicyRef` |
| `internal/cache/source.go` | `LocalSource` struct implementing `PolicySource` with `DefinitionVersion` and `CopyPolicy` using `oras.Copy()` local-to-local |
| `cmd/complyctl/cli/get.go` | Scheme dispatch in `syncSinglePolicy`: `oci-layout://` -> `LocalSource`, else -> `RegistrySource` |

### Key Design Decisions

1. **`oci-layout://` scheme** -- Explicit about expected format (valid OCI Layout). `file://` rejected as too ambiguous.
2. **Sentinel dispatch** -- `ref.Registry == "oci-layout://"` routes to `LocalSource`. Minimal change surface.
3. **`oras.Copy()` local-to-local** -- Same transfer mechanism as remote, providing digest verification and incremental sync.
4. **No downstream changes** -- `generate` and `scan` read from `~/.complytime/policies/{id}/` regardless of source.

### Testing

- 10 unit tests for `ValidateOCIRef`/`ParsePolicyRef` with `oci-layout://`
- 8 unit tests for `LocalSource` (happy path, error cases, edge cases)
- 3 E2E tests (local sync, mixed sources, incremental sync)
- All existing tests pass unchanged

### No Breaking Changes

All existing registry-based behavior is unchanged. The `oci-layout://` scheme is purely additive.

## OpenSpec Artifacts

Spec artifacts at `openspec/changes/local-oci-layout-source/` (proposal, design, specs, tasks -- all complete).
