### PR TITLE
fix: use input_path instead of input for OPA target variable

### DIFF
--- a/tests/cross-repo/testdata/complytime.yaml
+++ b/tests/cross-repo/testdata/complytime.yaml
@@ -21,4 +21,4 @@ targets:
     policies:
       - test-opa-bp
     variables:
-      input: test-deployment.yaml
+      input_path: test-deployment.yaml


### PR DESCRIPTION
## Summary

The OPA target in `tests/cross-repo/testdata/complytime.yaml` uses
`input` as the variable name, but the OPA provider expects
`input_path`. This causes a scan error in the devcontainer E2E flow:

```
url or input_path is required
```

## What Changed

- `tests/cross-repo/testdata/complytime.yaml`: Rename `input` to
  `input_path` for the `test-k8s-deployment` target.

## Context

The OPA provider's `Describe` RPC declares `input_path` as a
required target variable, and `validateTargetVariables` in
`cmd/opa-provider/server/server.go` rejects requests where neither
`url` nor `input_path` is set. The variable was introduced in
PR #540 with the incorrect name.

## Testing

After this fix plus complytime-providers PR
[#41](https://github.com/complytime/complytime-providers/pull/41),
the full devcontainer E2E flow works:

```bash
complyctl get
complyctl generate --policy-id test-opa-bp
complyctl scan --policy-id test-opa-bp
```