### PR TITLE
fix: populate evaluation log metadata, result, and target fields

### DIFF
--- a/.gaze/baseline.json
+++ b/.gaze/baseline.json
@@ -74,49 +74,53 @@
       "line": 19,
       "complexity": 2,
       "line_coverage": 100,
-      "crap": 2,
-      "gaze_crap": 0
+      "crap": 2
     },
     {
       "package": "cli",
       "function": "(*registryVersionResolver).ResolveLatestVersion",
       "file": "cmd/complyctl/cli/doctor.go",
-      "line": 44,
+      "line": 50,
       "complexity": 1,
       "line_coverage": 0,
-      "crap": 2,
-      "gaze_crap": 0
+      "crap": 2
     },
     {
       "package": "cli",
       "function": "(*registryVersionResolver).ResolveVersion",
       "file": "cmd/complyctl/cli/doctor.go",
-      "line": 48,
+      "line": 54,
       "complexity": 1,
       "line_coverage": 0,
-      "crap": 2,
-      "gaze_crap": 0
+      "crap": 2
     },
     {
       "package": "cli",
       "function": "(*registryVersionResolver).resolve",
       "file": "cmd/complyctl/cli/doctor.go",
-      "line": 52,
+      "line": 58,
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
-      "fix_strategy": "add_tests",
-      "gaze_crap": 0
+      "fix_strategy": "add_tests"
     },
     {
       "package": "cli",
       "function": "runDoctor",
       "file": "cmd/complyctl/cli/doctor.go",
-      "line": 72,
-      "complexity": 11,
-      "line_coverage": 92.10526315789474,
-      "crap": 11.059538562472664,
-      "gaze_crap": 0
+      "line": 78,
+      "complexity": 4,
+      "line_coverage": 88.88888888888889,
+      "crap": 4.021947873799726
+    },
+    {
+      "package": "cli",
+      "function": "printDiagnostics",
+      "file": "cmd/complyctl/cli/doctor.go",
+      "line": 108,
+      "complexity": 8,
+      "line_coverage": 80.95238095238095,
+      "crap": 8.442284850448116
     },
     {
       "package": "cli",
@@ -125,8 +129,7 @@
       "line": 29,
       "complexity": 4,
       "line_coverage": 53.84615384615385,
-      "crap": 5.5730541647701415,
-      "gaze_crap": 0
+      "crap": 5.5730541647701415
     },
     {
       "package": "cli",
@@ -135,8 +138,7 @@
       "line": 60,
       "complexity": 3,
       "line_coverage": 0,
-      "crap": 12,
-      "gaze_crap": 0
+      "crap": 12
     },
     {
       "package": "cli",
@@ -145,8 +147,7 @@
       "line": 73,
       "complexity": 4,
       "line_coverage": 100,
-      "crap": 4,
-      "gaze_crap": 0
+      "crap": 4
     },
     {
       "package": "cli",
@@ -155,8 +156,7 @@
       "line": 95,
       "complexity": 4,
       "line_coverage": 29.41176470588235,
-      "crap": 9.627518827600243,
-      "gaze_crap": 0
+      "crap": 9.627518827600243
     },
     {
       "package": "cli",
@@ -165,38 +165,34 @@
       "line": 123,
       "complexity": 2,
       "line_coverage": 0,
-      "crap": 6,
-      "gaze_crap": 0
+      "crap": 6
     },
     {
       "package": "cli",
       "function": "buildExecutionPlan",
       "file": "cmd/complyctl/cli/generate.go",
-      "line": 136,
+      "line": 137,
       "complexity": 3,
       "line_coverage": 0,
-      "crap": 12,
-      "gaze_crap": 0
+      "crap": 12
     },
     {
       "package": "cli",
       "function": "providerStatus",
       "file": "cmd/complyctl/cli/generate.go",
-      "line": 154,
+      "line": 155,
       "complexity": 2,
       "line_coverage": 0,
-      "crap": 6,
-      "gaze_crap": 0
+      "crap": 6
     },
     {
       "package": "cli",
       "function": "saveGenerationAndPrint",
       "file": "cmd/complyctl/cli/generate.go",
-      "line": 161,
+      "line": 162,
       "complexity": 3,
       "line_coverage": 0,
-      "crap": 12,
-      "gaze_crap": 0
+      "crap": 12
     },
     {
       "package": "cli",
@@ -205,89 +201,118 @@
       "line": 25,
       "complexity": 3,
       "line_coverage": 44.44444444444444,
-      "crap": 4.54320987654321,
-      "gaze_crap": 0
+      "crap": 4.54320987654321
     },
     {
       "package": "cli",
       "function": "(*getOptions).validate",
       "file": "cmd/complyctl/cli/get.go",
-      "line": 50,
+      "line": 56,
       "complexity": 1,
       "line_coverage": 0,
-      "crap": 2,
-      "gaze_crap": 0
+      "crap": 2
     },
     {
       "package": "cli",
       "function": "(*getOptions).complete",
       "file": "cmd/complyctl/cli/get.go",
-      "line": 54,
+      "line": 60,
       "complexity": 2,
       "line_coverage": 0,
-      "crap": 6,
-      "gaze_crap": 0
+      "crap": 6
     },
     {
       "package": "cli",
       "function": "(*getOptions).run",
       "file": "cmd/complyctl/cli/get.go",
-      "line": 63,
+      "line": 69,
       "complexity": 3,
       "line_coverage": 100,
-      "crap": 3,
-      "gaze_crap": 0
+      "crap": 3
+    },
+    {
+      "package": "cli",
+      "function": "(*getOptions).syncAll",
+      "file": "cmd/complyctl/cli/get.go",
+      "line": 91,
+      "complexity": 2,
+      "line_coverage": 66.66666666666667,
+      "crap": 2.148148148148148
     },
     {
       "package": "cli",
       "function": "(*getOptions).syncPolicies",
       "file": "cmd/complyctl/cli/get.go",
-      "line": 80,
+      "line": 98,
       "complexity": 3,
       "line_coverage": 60,
-      "crap": 3.576,
-      "gaze_crap": 0
+      "crap": 3.576
+    },
+    {
+      "package": "cli",
+      "function": "(*getOptions).syncComplypacks",
+      "file": "cmd/complyctl/cli/get.go",
+      "line": 118,
+      "complexity": 4,
+      "line_coverage": 0,
+      "crap": 20,
+      "fix_strategy": "add_tests"
     },
     {
       "package": "cli",
       "function": "syncAllPolicies",
       "file": "cmd/complyctl/cli/get.go",
-      "line": 98,
+      "line": 138,
       "complexity": 3,
       "line_coverage": 62.5,
-      "crap": 3.474609375,
-      "gaze_crap": 0
+      "crap": 3.474609375
     },
     {
       "package": "cli",
       "function": "syncSinglePolicy",
       "file": "cmd/complyctl/cli/get.go",
-      "line": 113,
+      "line": 153,
       "complexity": 3,
       "line_coverage": 76.47058823529412,
-      "crap": 3.1172399755750053,
-      "gaze_crap": 0
+      "crap": 3.1172399755750053
     },
     {
       "package": "cli",
       "function": "resolveLatestVersion",
       "file": "cmd/complyctl/cli/get.go",
-      "line": 138,
+      "line": 178,
       "complexity": 2,
       "line_coverage": 0,
-      "crap": 6,
-      "gaze_crap": 0
+      "crap": 6
     },
     {
       "package": "cli",
       "function": "suggestCachedPolicyIDs",
       "file": "cmd/complyctl/cli/get.go",
-      "line": 150,
+      "line": 190,
       "complexity": 6,
       "line_coverage": 30,
       "crap": 18.348,
-      "fix_strategy": "add_tests",
-      "gaze_crap": 0
+      "fix_strategy": "add_tests"
+    },
+    {
+      "package": "cli",
+      "function": "syncAllComplypacks",
+      "file": "cmd/complyctl/cli/get.go",
+      "line": 207,
+      "complexity": 3,
+      "line_coverage": 0,
+      "crap": 12
+    },
+    {
+      "package": "cli",
+      "function": "syncSingleComplypack",
+      "file": "cmd/complyctl/cli/get.go",
+      "line": 222,
+      "complexity": 4,
+      "line_coverage": 0,
+      "crap": 20,
+      "fix_strategy": "add_tests"
     },
     {
       "package": "cli",
@@ -296,8 +321,7 @@
       "line": 19,
       "complexity": 1,
       "line_coverage": 75,
-      "crap": 1.015625,
-      "gaze_crap": 0
+      "crap": 1.015625
     },
     {
       "package": "cli",
@@ -306,8 +330,7 @@
       "line": 40,
       "complexity": 7,
       "line_coverage": 47.82608695652174,
-      "crap": 13.959151804060163,
-      "gaze_crap": 0
+      "crap": 13.959151804060163
     },
     {
       "package": "cli",
@@ -316,8 +339,7 @@
       "line": 106,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1,
-      "gaze_crap": 0
+      "crap": 1
     },
     {
       "package": "cli",
@@ -327,8 +349,7 @@
       "complexity": 7,
       "line_coverage": 35.714285714285715,
       "crap": 20.01785714285714,
-      "fix_strategy": "add_tests",
-      "gaze_crap": 0
+      "fix_strategy": "add_tests"
     },
     {
       "package": "cli",
@@ -338,8 +359,7 @@
       "complexity": 10,
       "line_coverage": 0,
       "crap": 110,
-      "fix_strategy": "add_tests",
-      "gaze_crap": 0
+      "fix_strategy": "add_tests"
     },
     {
       "package": "cli",
@@ -348,8 +368,7 @@
       "line": 26,
       "complexity": 4,
       "line_coverage": 41.666666666666664,
-      "crap": 7.175925925925927,
-      "gaze_crap": 0
+      "crap": 7.175925925925927
     },
     {
       "package": "cli",
@@ -358,8 +377,7 @@
       "line": 56,
       "complexity": 1,
       "line_coverage": 0,
-      "crap": 2,
-      "gaze_crap": 0
+      "crap": 2
     },
     {
       "package": "cli",
@@ -368,8 +386,7 @@
       "line": 60,
       "complexity": 2,
       "line_coverage": 0,
-      "crap": 6,
-      "gaze_crap": 0
+      "crap": 6
     },
     {
       "package": "cli",
@@ -378,8 +395,7 @@
       "line": 69,
       "complexity": 7,
       "line_coverage": 86.95652173913044,
-      "crap": 7.10873674693844,
-      "gaze_crap": 0
+      "crap": 7.10873674693844
     },
     {
       "package": "cli",
@@ -388,8 +404,7 @@
       "line": 108,
       "complexity": 1,
       "line_coverage": 80,
-      "crap": 1.008,
-      "gaze_crap": 0
+      "crap": 1.008
     },
     {
       "package": "cli",
@@ -398,8 +413,7 @@
       "line": 24,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1,
-      "gaze_crap": 2
+      "crap": 1
     },
     {
       "package": "cli",
@@ -408,28 +422,25 @@
       "line": 31,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1,
-      "gaze_crap": 1.125
+      "crap": 1
     },
     {
       "package": "cli",
       "function": "providersCmd",
       "file": "cmd/complyctl/cli/providers.go",
-      "line": 23,
+      "line": 25,
       "complexity": 2,
       "line_coverage": 50,
-      "crap": 2.5,
-      "gaze_crap": 0
+      "crap": 2.5
     },
     {
       "package": "cli",
       "function": "(*providersOptions).complete",
       "file": "cmd/complyctl/cli/providers.go",
-      "line": 42,
-      "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6,
-      "gaze_crap": 0
+      "line": 48,
+      "complexity": 4,
+      "line_coverage": 77.77777777777777,
+      "crap": 4.175582990397805
     },
     {
       "package": "cli",
@@ -437,29 +448,35 @@
       "file": "cmd/complyctl/cli/providers.go",
       "line": 63,
       "complexity": 4,
-      "line_coverage": 57.142857142857146,
-      "crap": 5.259475218658891,
-      "gaze_crap": 0
+      "line_coverage": 53.333333333333336,
+      "crap": 5.626074074074074
     },
     {
       "package": "cli",
       "function": "buildProviderRows",
       "file": "cmd/complyctl/cli/providers.go",
-      "line": 74,
+      "line": 87,
       "complexity": 3,
       "line_coverage": 0,
-      "crap": 12,
-      "gaze_crap": 0
+      "crap": 12
+    },
+    {
+      "package": "cli",
+      "function": "lookupComplypackVersion",
+      "file": "cmd/complyctl/cli/providers.go",
+      "line": 105,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4
     },
     {
       "package": "cli",
       "function": "describeProvider",
       "file": "cmd/complyctl/cli/providers.go",
-      "line": 87,
+      "line": 113,
       "complexity": 3,
       "line_coverage": 0,
-      "crap": 12,
-      "gaze_crap": 0
+      "crap": 12
     },
     {
       "package": "cli",
@@ -468,8 +485,7 @@
       "line": 33,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1,
-      "gaze_crap": 2
+      "crap": 1
     },
     {
       "package": "cli",
@@ -478,8 +494,7 @@
       "line": 38,
       "complexity": 2,
       "line_coverage": 100,
-      "crap": 2,
-      "gaze_crap": 6
+      "crap": 2
     },
     {
       "package": "cli",
@@ -488,8 +503,7 @@
       "line": 45,
       "complexity": 5,
       "line_coverage": 70.58823529411765,
-      "crap": 5.636067575819254,
-      "gaze_crap": 5
+      "crap": 5.636067575819254
     },
     {
       "package": "cli",
@@ -498,8 +512,7 @@
       "line": 70,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1,
-      "gaze_crap": 0
+      "crap": 1
     },
     {
       "package": "cli",
@@ -508,8 +521,7 @@
       "line": 76,
       "complexity": 1,
       "line_coverage": 0,
-      "crap": 2,
-      "gaze_crap": 0
+      "crap": 2
     },
     {
       "package": "cli",
@@ -518,8 +530,7 @@
       "line": 80,
       "complexity": 2,
       "line_coverage": 50,
-      "crap": 2.5,
-      "gaze_crap": 0
+      "crap": 2.5
     },
     {
       "package": "cli",
@@ -528,8 +539,7 @@
       "line": 86,
       "complexity": 2,
       "line_coverage": 92.3076923076923,
-      "crap": 2.0018206645425582,
-      "gaze_crap": 2
+      "crap": 2.0018206645425582
     },
     {
       "package": "cli",
@@ -538,8 +548,7 @@
       "line": 35,
       "complexity": 6,
       "line_coverage": 42.10526315789474,
-      "crap": 12.985857996792536,
-      "gaze_crap": 0
+      "crap": 12.985857996792536
     },
     {
       "package": "cli",
@@ -548,8 +557,7 @@
       "line": 101,
       "complexity": 5,
       "line_coverage": 91.66666666666667,
-      "crap": 5.014467592592593,
-      "gaze_crap": 0
+      "crap": 5.014467592592593
     },
     {
       "package": "cli",
@@ -558,8 +566,7 @@
       "line": 121,
       "complexity": 3,
       "line_coverage": 100,
-      "crap": 3,
-      "gaze_crap": 0
+      "crap": 3
     },
     {
       "package": "cli",
@@ -568,8 +575,7 @@
       "line": 133,
       "complexity": 3,
       "line_coverage": 0,
-      "crap": 12,
-      "gaze_crap": 0
+      "crap": 12
     },
     {
       "package": "cli",
@@ -578,8 +584,7 @@
       "line": 146,
       "complexity": 8,
       "line_coverage": 100,
-      "crap": 8,
-      "gaze_crap": 0
+      "crap": 8
     },
     {
       "package": "cli",
@@ -588,8 +593,7 @@
       "line": 188,
       "complexity": 4,
       "line_coverage": 100,
-      "crap": 4,
-      "gaze_crap": 0
+      "crap": 4
     },
     {
       "package": "cli",
@@ -598,8 +602,7 @@
       "line": 207,
       "complexity": 9,
       "line_coverage": 100,
-      "crap": 9,
-      "gaze_crap": 0
+      "crap": 9
     },
     {
       "package": "cli",
@@ -608,8 +611,7 @@
       "line": 237,
       "complexity": 2,
       "line_coverage": 100,
-      "crap": 2,
-      "gaze_crap": 0
+      "crap": 2
     },
     {
       "package": "cli",
@@ -619,8 +621,7 @@
       "complexity": 5,
       "line_coverage": 23.80952380952381,
       "crap": 16.057121261202894,
-      "fix_strategy": "add_tests",
-      "gaze_crap": 0
+      "fix_strategy": "add_tests"
     },
     {
       "package": "cli",
@@ -629,8 +630,7 @@
       "line": 285,
       "complexity": 2,
       "line_coverage": 0,
-      "crap": 6,
-      "gaze_crap": 0
+      "crap": 6
     },
     {
       "package": "cli",
@@ -639,8 +639,7 @@
       "line": 292,
       "complexity": 3,
       "line_coverage": 100,
-      "crap": 3,
-      "gaze_crap": 0
+      "crap": 3
     },
     {
       "package": "cli",
@@ -649,8 +648,7 @@
       "line": 305,
       "complexity": 3,
       "line_coverage": 60,
-      "crap": 3.576,
-      "gaze_crap": 0
+      "crap": 3.576
     },
     {
       "package": "cli",
@@ -660,8 +658,7 @@
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
-      "fix_strategy": "add_tests",
-      "gaze_crap": 0
+      "fix_strategy": "add_tests"
     },
     {
       "package": "cli",
@@ -670,8 +667,7 @@
       "line": 338,
       "complexity": 2,
       "line_coverage": 0,
-      "crap": 6,
-      "gaze_crap": 0
+      "crap": 6
     },
     {
       "package": "cli",
@@ -680,8 +676,7 @@
       "line": 346,
       "complexity": 2,
       "line_coverage": 0,
-      "crap": 6,
-      "gaze_crap": 0
+      "crap": 6
     },
     {
       "package": "cli",
@@ -690,342 +685,334 @@
       "line": 354,
       "complexity": 3,
       "line_coverage": 0,
-      "crap": 12,
-      "gaze_crap": 0
+      "crap": 12
     },
     {
       "package": "cli",
       "function": "runScanAndReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 368,
+      "line": 369,
       "complexity": 2,
       "line_coverage": 0,
-      "crap": 6,
-      "gaze_crap": 0
+      "crap": 6
     },
     {
       "package": "cli",
       "function": "processScanOutput",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 382,
-      "complexity": 2,
-      "line_coverage": 83.33333333333333,
-      "crap": 2.0185185185185186,
-      "gaze_crap": 0
+      "line": 386,
+      "complexity": 3,
+      "line_coverage": 87.5,
+      "crap": 3.017578125
     },
     {
       "package": "cli",
       "function": "reportOperationalWarnings",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 397,
+      "line": 404,
       "complexity": 2,
       "line_coverage": 100,
-      "crap": 2,
-      "gaze_crap": 0
+      "crap": 2
     },
     {
       "package": "cli",
       "function": "checkOperationalErrors",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 406,
+      "line": 413,
       "complexity": 3,
       "line_coverage": 100,
-      "crap": 3,
-      "gaze_crap": 0
+      "crap": 3
     },
     {
       "package": "cli",
-      "function": "buildEvaluator",
+      "function": "buildEvaluators",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 417,
+      "line": 424,
       "complexity": 4,
       "line_coverage": 100,
-      "crap": 4,
-      "gaze_crap": 0
+      "crap": 4
     },
     {
       "package": "cli",
       "function": "filterTargetByID",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 434,
+      "line": 443,
       "complexity": 3,
       "line_coverage": 100,
-      "crap": 3,
-      "gaze_crap": 0
+      "crap": 3
     },
     {
       "package": "cli",
       "function": "filterTargetsForPolicy",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 443,
+      "line": 452,
       "complexity": 3,
       "line_coverage": 100,
-      "crap": 3,
-      "gaze_crap": 0
+      "crap": 3
     },
     {
       "package": "cli",
       "function": "checkGenerationFreshness",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 453,
+      "line": 462,
       "complexity": 3,
       "line_coverage": 0,
-      "crap": 12,
-      "gaze_crap": 0
+      "crap": 12
     },
     {
       "package": "cli",
       "function": "needsRegeneration",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 468,
+      "line": 477,
       "complexity": 4,
       "line_coverage": 100,
-      "crap": 4,
-      "gaze_crap": 0
+      "crap": 4
     },
     {
       "package": "cli",
       "function": "evaluatorArtifactsExist",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 485,
+      "line": 494,
       "complexity": 6,
       "line_coverage": 100,
-      "crap": 6,
-      "gaze_crap": 0
+      "crap": 6
     },
     {
       "package": "cli",
       "function": "runGeneration",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 500,
+      "line": 509,
       "complexity": 3,
       "line_coverage": 0,
-      "crap": 12,
-      "gaze_crap": 0
+      "crap": 12
     },
     {
       "package": "cli",
       "function": "generateForAllTargets",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 516,
-      "complexity": 4,
-      "line_coverage": 0,
-      "crap": 20,
-      "fix_strategy": "add_tests",
-      "gaze_crap": 0
+      "line": 525,
+      "complexity": 5,
+      "line_coverage": 36.36363636363637,
+      "crap": 11.442524417731029
     },
     {
       "package": "cli",
       "function": "executeScan",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 527,
+      "line": 545,
       "complexity": 1,
       "line_coverage": 0,
-      "crap": 2,
-      "gaze_crap": 0
+      "crap": 2
     },
     {
       "package": "cli",
       "function": "scanAllTargets",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 535,
+      "line": 553,
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
-      "fix_strategy": "add_tests",
-      "gaze_crap": 0
+      "fix_strategy": "add_tests"
     },
     {
       "package": "cli",
       "function": "scanSingleTarget",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 561,
+      "line": 579,
       "complexity": 3,
       "line_coverage": 0,
-      "crap": 12,
-      "gaze_crap": 0
+      "crap": 12
     },
     {
       "package": "cli",
       "function": "writeScanReports",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 580,
+      "line": 598,
       "complexity": 3,
-      "line_coverage": 75,
-      "crap": 3.140625,
-      "gaze_crap": 0
+      "line_coverage": 71.42857142857143,
+      "crap": 3.2099125364431487
     },
     {
       "package": "cli",
       "function": "writeFormatReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 595,
+      "line": 612,
       "complexity": 4,
       "line_coverage": 40,
-      "crap": 7.4559999999999995,
-      "gaze_crap": 0
+      "crap": 7.4559999999999995
     },
     {
       "package": "cli",
       "function": "writePrettyReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 607,
+      "line": 624,
       "complexity": 2,
       "line_coverage": 0,
-      "crap": 6,
-      "gaze_crap": 0
+      "crap": 6
     },
     {
       "package": "cli",
       "function": "writeSARIFReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 618,
+      "line": 635,
       "complexity": 2,
       "line_coverage": 0,
-      "crap": 6,
-      "gaze_crap": 0
+      "crap": 6
     },
     {
       "package": "cli",
       "function": "writeOSCALReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 627,
+      "line": 644,
       "complexity": 2,
       "line_coverage": 0,
-      "crap": 6,
-      "gaze_crap": 0
+      "crap": 6
     },
     {
       "package": "cli",
       "function": "(*scanOptions).runExport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 638,
+      "line": 655,
       "complexity": 5,
       "line_coverage": 16.666666666666668,
       "crap": 19.467592592592588,
-      "fix_strategy": "add_tests",
-      "gaze_crap": 0
+      "fix_strategy": "add_tests"
     },
     {
       "package": "cli",
       "function": "authRequired",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 664,
+      "line": 681,
       "complexity": 2,
       "line_coverage": 100,
-      "crap": 2,
-      "gaze_crap": 0
+      "crap": 2
     },
     {
       "package": "cli",
       "function": "validateAuthCredentials",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 668,
+      "line": 685,
       "complexity": 3,
       "line_coverage": 100,
-      "crap": 3,
-      "gaze_crap": 0
+      "crap": 3
     },
     {
       "package": "cli",
       "function": "resolveCollectorAuth",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 675,
+      "line": 692,
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
-      "fix_strategy": "add_tests",
-      "gaze_crap": 0
+      "fix_strategy": "add_tests"
     },
     {
       "package": "cli",
       "function": "exportToProviders",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 690,
+      "line": 707,
       "complexity": 2,
       "line_coverage": 0,
-      "crap": 6,
-      "gaze_crap": 0
+      "crap": 6
     },
     {
       "package": "cli",
       "function": "exportSingleProvider",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 698,
+      "line": 715,
       "complexity": 3,
       "line_coverage": 0,
-      "crap": 12,
-      "gaze_crap": 0
+      "crap": 12
     },
     {
       "package": "cli",
       "function": "resolveOIDCToken",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 715,
+      "line": 732,
       "complexity": 2,
       "line_coverage": 0,
-      "crap": 6,
-      "gaze_crap": 0
+      "crap": 6
     },
     {
       "package": "cli",
       "function": "formatExportSummary",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 728,
+      "line": 745,
       "complexity": 4,
       "line_coverage": 100,
-      "crap": 4,
-      "gaze_crap": 0
+      "crap": 4
     },
     {
       "package": "cli",
       "function": "appendExportRow",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 748,
+      "line": 765,
       "complexity": 3,
       "line_coverage": 100,
-      "crap": 3,
-      "gaze_crap": 0
+      "crap": 3
     },
     {
       "package": "cli",
       "function": "appendResponseRow",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 762,
+      "line": 779,
       "complexity": 3,
       "line_coverage": 85.71428571428571,
-      "crap": 3.0262390670553936,
-      "gaze_crap": 0
+      "crap": 3.0262390670553936
     },
     {
       "package": "cli",
       "function": "exportResponseStatus",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 775,
+      "line": 792,
       "complexity": 4,
       "line_coverage": 100,
-      "crap": 4,
-      "gaze_crap": 0
+      "crap": 4
     },
     {
       "package": "cli",
       "function": "countExportFailures",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 797,
+      "line": 814,
       "complexity": 7,
       "line_coverage": 100,
-      "crap": 7,
-      "gaze_crap": 0
+      "crap": 7
+    },
+    {
+      "package": "cli",
+      "function": "injectWorkspaceIntoTargets",
+      "file": "cmd/complyctl/cli/scan.go",
+      "line": 835,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
     },
     {
       "package": "cli",
       "function": "extractReqToControlMap",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 816,
+      "line": 846,
       "complexity": 6,
       "line_coverage": 90,
-      "crap": 6.036,
-      "gaze_crap": 0
+      "crap": 6.036
+    },
+    {
+      "package": "cli",
+      "function": "extractPlanToReqMap",
+      "file": "cmd/complyctl/cli/scan.go",
+      "line": 867,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4
+    },
+    {
+      "package": "cli",
+      "function": "resolveAssessmentIDs",
+      "file": "cmd/complyctl/cli/scan.go",
+      "line": 882,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
     },
     {
       "package": "cli",
@@ -1034,8 +1021,7 @@
       "line": 12,
       "complexity": 1,
       "line_coverage": 50,
-      "crap": 1.125,
-      "gaze_crap": 0
+      "crap": 1.125
     },
     {
       "package": "main",
@@ -1050,7 +1036,7 @@
       "package": "main",
       "function": "main",
       "file": "cmd/mock-oci-registry/main.go",
-      "line": 44,
+      "line": 57,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -1059,7 +1045,7 @@
       "package": "main",
       "function": "registerOCIRoutes",
       "file": "cmd/mock-oci-registry/main.go",
-      "line": 70,
+      "line": 83,
       "complexity": 6,
       "line_coverage": 0,
       "crap": 42,
@@ -1069,7 +1055,7 @@
       "package": "main",
       "function": "serveCatalog",
       "file": "cmd/mock-oci-registry/main.go",
-      "line": 118,
+      "line": 131,
       "complexity": 1,
       "line_coverage": 0,
       "crap": 2
@@ -1078,7 +1064,7 @@
       "package": "main",
       "function": "serveTagsList",
       "file": "cmd/mock-oci-registry/main.go",
-      "line": 127,
+      "line": 140,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -1087,7 +1073,7 @@
       "package": "main",
       "function": "serveManifest",
       "file": "cmd/mock-oci-registry/main.go",
-      "line": 148,
+      "line": 161,
       "complexity": 6,
       "line_coverage": 0,
       "crap": 42,
@@ -1097,7 +1083,7 @@
       "package": "main",
       "function": "serveBlob",
       "file": "cmd/mock-oci-registry/main.go",
-      "line": 180,
+      "line": 193,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -1106,7 +1092,7 @@
       "package": "main",
       "function": "writeOCIError",
       "file": "cmd/mock-oci-registry/main.go",
-      "line": 226,
+      "line": 213,
       "complexity": 1,
       "line_coverage": 0,
       "crap": 2
@@ -1115,7 +1101,7 @@
       "package": "main",
       "function": "(*repository).resolve",
       "file": "cmd/mock-oci-registry/main.go",
-      "line": 280,
+      "line": 259,
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
@@ -1125,61 +1111,115 @@
       "package": "main",
       "function": "newContentStore",
       "file": "cmd/mock-oci-registry/main.go",
-      "line": 294,
+      "line": 272,
       "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
+      "line_coverage": 100,
+      "crap": 1
     },
     {
       "package": "main",
       "function": "(*contentStore).listRepositories",
       "file": "cmd/mock-oci-registry/main.go",
-      "line": 301,
+      "line": 278,
       "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
+      "line_coverage": 100,
+      "crap": 2
     },
     {
       "package": "main",
       "function": "(*contentStore).addArtifact",
       "file": "cmd/mock-oci-registry/main.go",
-      "line": 311,
+      "line": 293,
       "complexity": 3,
-      "line_coverage": 0,
-      "crap": 12
+      "line_coverage": 100,
+      "crap": 3
+    },
+    {
+      "package": "main",
+      "function": "(*contentStore).addComplypackArtifact",
+      "file": "cmd/mock-oci-registry/main.go",
+      "line": 351,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
     },
     {
       "package": "main",
       "function": "computeDigest",
       "file": "cmd/mock-oci-registry/main.go",
-      "line": 365,
+      "line": 405,
       "complexity": 1,
-      "line_coverage": 0,
-      "crap": 2
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "main",
+      "function": "buildDummyTarGz",
+      "file": "cmd/mock-oci-registry/main.go",
+      "line": 412,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "main",
+      "function": "buildTarGzFromFS",
+      "file": "cmd/mock-oci-registry/main.go",
+      "line": 432,
+      "complexity": 5,
+      "line_coverage": 82.3529411764706,
+      "crap": 5.137390596376959
     },
     {
       "package": "main",
       "function": "(*contentStore).seedPolicyFromFiles",
       "file": "cmd/mock-oci-registry/main.go",
-      "line": 449,
+      "line": 466,
       "complexity": 3,
-      "line_coverage": 0,
-      "crap": 12
+      "line_coverage": 71.42857142857143,
+      "crap": 3.2099125364431487
     },
     {
       "package": "main",
       "function": "(*contentStore).seedDefaults",
       "file": "cmd/mock-oci-registry/main.go",
-      "line": 466,
+      "line": 483,
       "complexity": 1,
-      "line_coverage": 0,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "main",
+      "function": "resolveContentDir",
+      "file": "cmd/mock-oci-registry/main.go",
+      "line": 522,
+      "complexity": 2,
+      "line_coverage": 100,
       "crap": 2
+    },
+    {
+      "package": "main",
+      "function": "(*contentStore).seedFromDirectory",
+      "file": "cmd/mock-oci-registry/main.go",
+      "line": 545,
+      "complexity": 8,
+      "line_coverage": 100,
+      "crap": 8
+    },
+    {
+      "package": "main",
+      "function": "readFileLimited",
+      "file": "cmd/mock-oci-registry/main.go",
+      "line": 586,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4
     },
     {
       "package": "main",
       "function": "(*testEvaluator).Describe",
       "file": "cmd/test-provider/main.go",
-      "line": 35,
+      "line": 37,
       "complexity": 1,
       "line_coverage": 0,
       "crap": 2
@@ -1188,7 +1228,16 @@
       "package": "main",
       "function": "(*testEvaluator).Generate",
       "file": "cmd/test-provider/main.go",
-      "line": 44,
+      "line": 46,
+      "complexity": 2,
+      "line_coverage": 0,
+      "crap": 6
+    },
+    {
+      "package": "main",
+      "function": "logComplypackPath",
+      "file": "cmd/test-provider/main.go",
+      "line": 60,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -1197,7 +1246,7 @@
       "package": "main",
       "function": "(*testEvaluator).Scan",
       "file": "cmd/test-provider/main.go",
-      "line": 52,
+      "line": 67,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -1206,7 +1255,7 @@
       "package": "main",
       "function": "(*testEvaluator).Export",
       "file": "cmd/test-provider/main.go",
-      "line": 71,
+      "line": 86,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -1215,7 +1264,7 @@
       "package": "main",
       "function": "main",
       "file": "cmd/test-provider/main.go",
-      "line": 83,
+      "line": 98,
       "complexity": 1,
       "line_coverage": 0,
       "crap": 2
@@ -1360,6 +1409,125 @@
     },
     {
       "package": "cache",
+      "function": "NewComplypackCache",
+      "file": "internal/cache/complypack.go",
+      "line": 38,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "cache",
+      "function": "ValidatePathComponent",
+      "file": "internal/cache/complypack.go",
+      "line": 48,
+      "complexity": 7,
+      "line_coverage": 81.81818181818181,
+      "crap": 7.294515401953419
+    },
+    {
+      "package": "cache",
+      "function": "(*ComplypackCache).complypackDir",
+      "file": "internal/cache/complypack.go",
+      "line": 69,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "cache",
+      "function": "(*ComplypackCache).Store",
+      "file": "internal/cache/complypack.go",
+      "line": 77,
+      "complexity": 13,
+      "line_coverage": 66.66666666666667,
+      "crap": 19.259259259259252,
+      "fix_strategy": "add_tests"
+    },
+    {
+      "package": "cache",
+      "function": "(*ComplypackCache).Lookup",
+      "file": "internal/cache/complypack.go",
+      "line": 149,
+      "complexity": 6,
+      "line_coverage": 75,
+      "crap": 6.5625
+    },
+    {
+      "package": "cache",
+      "function": "(*ComplypackCache).LookupByEvaluatorID",
+      "file": "internal/cache/complypack.go",
+      "line": 190,
+      "complexity": 10,
+      "line_coverage": 83.33333333333333,
+      "crap": 10.462962962962964
+    },
+    {
+      "package": "cache",
+      "function": "(*ComplypackCache).Dir",
+      "file": "internal/cache/complypack.go",
+      "line": 232,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "cache",
+      "function": "NewRegistryComplypackSource",
+      "file": "internal/cache/complypack_source.go",
+      "line": 42,
+      "complexity": 1,
+      "line_coverage": 0,
+      "crap": 2
+    },
+    {
+      "package": "cache",
+      "function": "(*RegistryComplypackSource).DefinitionVersion",
+      "file": "internal/cache/complypack_source.go",
+      "line": 46,
+      "complexity": 1,
+      "line_coverage": 0,
+      "crap": 2
+    },
+    {
+      "package": "cache",
+      "function": "(*RegistryComplypackSource).CopyComplypack",
+      "file": "internal/cache/complypack_source.go",
+      "line": 53,
+      "complexity": 3,
+      "line_coverage": 0,
+      "crap": 12
+    },
+    {
+      "package": "cache",
+      "function": "VerifyComplypackArtifactType",
+      "file": "internal/cache/complypack_source.go",
+      "line": 72,
+      "complexity": 5,
+      "line_coverage": 85.71428571428571,
+      "crap": 5.072886297376093
+    },
+    {
+      "package": "cache",
+      "function": "NewComplypackSync",
+      "file": "internal/cache/complypack_sync.go",
+      "line": 26,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "cache",
+      "function": "(*ComplypackSync).SyncComplypack",
+      "file": "internal/cache/complypack_sync.go",
+      "line": 42,
+      "complexity": 15,
+      "line_coverage": 85.29411764705883,
+      "crap": 15.715576022796661,
+      "fix_strategy": "decompose"
+    },
+    {
+      "package": "cache",
       "function": "NewRegistrySource",
       "file": "internal/cache/source.go",
       "line": 28,
@@ -1389,16 +1557,25 @@
       "package": "cache",
       "function": "LoadState",
       "file": "internal/cache/state.go",
-      "line": 28,
-      "complexity": 5,
+      "line": 32,
+      "complexity": 4,
+      "line_coverage": 81.81818181818181,
+      "crap": 4.096168294515402
+    },
+    {
+      "package": "cache",
+      "function": "initStateMaps",
+      "file": "internal/cache/state.go",
+      "line": 60,
+      "complexity": 3,
       "line_coverage": 75,
-      "crap": 5.390625
+      "crap": 3.140625
     },
     {
       "package": "cache",
       "function": "SaveState",
       "file": "internal/cache/state.go",
-      "line": 54,
+      "line": 70,
       "complexity": 4,
       "line_coverage": 66.66666666666667,
       "crap": 4.592592592592593
@@ -1407,7 +1584,7 @@
       "package": "cache",
       "function": "(*State).UpdatePolicyState",
       "file": "internal/cache/state.go",
-      "line": 73,
+      "line": 90,
       "complexity": 2,
       "line_coverage": 75,
       "crap": 2.0625
@@ -1416,7 +1593,25 @@
       "package": "cache",
       "function": "(*State).GetPolicyState",
       "file": "internal/cache/state.go",
-      "line": 85,
+      "line": 103,
+      "complexity": 2,
+      "line_coverage": 75,
+      "crap": 2.0625
+    },
+    {
+      "package": "cache",
+      "function": "(*State).UpdateComplypackState",
+      "file": "internal/cache/state.go",
+      "line": 113,
+      "complexity": 2,
+      "line_coverage": 75,
+      "crap": 2.0625
+    },
+    {
+      "package": "cache",
+      "function": "(*State).GetComplypackState",
+      "file": "internal/cache/state.go",
+      "line": 127,
       "complexity": 2,
       "line_coverage": 75,
       "crap": 2.0625
@@ -1446,159 +1641,160 @@
       "line": 23,
       "complexity": 6,
       "line_coverage": 100,
-      "crap": 6,
-      "gaze_crap": 0
+      "crap": 6
     },
     {
       "package": "complytime",
       "function": "(PolicyEntry).EffectiveID",
       "file": "internal/complytime/config.go",
-      "line": 83,
+      "line": 84,
       "complexity": 2,
       "line_coverage": 100,
-      "crap": 2,
-      "gaze_crap": 0
+      "crap": 2
     },
     {
       "package": "complytime",
       "function": "ParsePolicyRef",
       "file": "internal/complytime/config.go",
-      "line": 111,
+      "line": 112,
       "complexity": 8,
       "line_coverage": 100,
-      "crap": 8,
-      "gaze_crap": 0
+      "crap": 8
     },
     {
       "package": "complytime",
       "function": "FindPolicy",
       "file": "internal/complytime/config.go",
-      "line": 141,
+      "line": 142,
       "complexity": 3,
       "line_coverage": 100,
-      "crap": 3,
-      "gaze_crap": 0
+      "crap": 3
     },
     {
       "package": "complytime",
       "function": "PolicyIDs",
       "file": "internal/complytime/config.go",
-      "line": 154,
+      "line": 155,
       "complexity": 2,
       "line_coverage": 100,
-      "crap": 2,
-      "gaze_crap": 0
+      "crap": 2
     },
     {
       "package": "complytime",
       "function": "LoadFrom",
       "file": "internal/complytime/config.go",
-      "line": 164,
+      "line": 165,
       "complexity": 5,
       "line_coverage": 63.63636363636363,
-      "crap": 6.202103681442525,
-      "gaze_crap": 8.125
+      "crap": 6.202103681442525
     },
     {
       "package": "complytime",
       "function": "resolveEnvVars",
       "file": "internal/complytime/config.go",
-      "line": 194,
+      "line": 195,
       "complexity": 4,
       "line_coverage": 100,
-      "crap": 4,
-      "gaze_crap": 0
+      "crap": 4
     },
     {
       "package": "complytime",
       "function": "resolveCollectorEnvVars",
       "file": "internal/complytime/config.go",
-      "line": 207,
+      "line": 208,
       "complexity": 5,
       "line_coverage": 100,
-      "crap": 5,
-      "gaze_crap": 0
+      "crap": 5
     },
     {
       "package": "complytime",
       "function": "expandEnvRef",
       "file": "internal/complytime/config.go",
-      "line": 229,
+      "line": 230,
       "complexity": 3,
       "line_coverage": 100,
-      "crap": 3,
-      "gaze_crap": 0
+      "crap": 3
     },
     {
       "package": "complytime",
       "function": "SaveTo",
       "file": "internal/complytime/config.go",
-      "line": 246,
+      "line": 247,
       "complexity": 3,
       "line_coverage": 0,
-      "crap": 12,
-      "gaze_crap": 3
+      "crap": 12
     },
     {
       "package": "complytime",
       "function": "Validate",
       "file": "internal/complytime/config.go",
-      "line": 260,
-      "complexity": 15,
-      "line_coverage": 94.11764705882354,
-      "crap": 15.045796865458986,
-      "fix_strategy": "decompose",
-      "gaze_crap": 0
+      "line": 261,
+      "complexity": 13,
+      "line_coverage": 92.3076923076923,
+      "crap": 13.076923076923077
+    },
+    {
+      "package": "complytime",
+      "function": "validateEntries",
+      "file": "internal/complytime/config.go",
+      "line": 313,
+      "complexity": 6,
+      "line_coverage": 100,
+      "crap": 6
     },
     {
       "package": "complytime",
       "function": "ExportEnabled",
       "file": "internal/complytime/consts.go",
-      "line": 40,
+      "line": 41,
       "complexity": 3,
       "line_coverage": 0,
-      "crap": 12,
-      "gaze_crap": 0
+      "crap": 12
+    },
+    {
+      "package": "complytime",
+      "function": "WithWorkspaceVar",
+      "file": "internal/complytime/consts.go",
+      "line": 90,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
     },
     {
       "package": "complytime",
       "function": "FilenameSafe",
       "file": "internal/complytime/consts.go",
-      "line": 91,
+      "line": 109,
       "complexity": 1,
       "line_coverage": 0,
-      "crap": 2,
-      "gaze_crap": 0
+      "crap": 2
     },
     {
       "package": "complytime",
       "function": "ExpandPath",
       "file": "internal/complytime/consts.go",
-      "line": 96,
+      "line": 114,
       "complexity": 3,
       "line_coverage": 0,
-      "crap": 12,
-      "gaze_crap": 0
+      "crap": 12
     },
     {
       "package": "complytime",
       "function": "ResolveCacheDir",
       "file": "internal/complytime/consts.go",
-      "line": 108,
+      "line": 126,
       "complexity": 2,
       "line_coverage": 0,
-      "crap": 6,
-      "gaze_crap": 0
+      "crap": 6
     },
     {
       "package": "complytime",
       "function": "ResolveProviderDir",
       "file": "internal/complytime/consts.go",
-      "line": 117,
+      "line": 135,
       "complexity": 2,
       "line_coverage": 0,
-      "crap": 6,
-      "gaze_crap": 0
+      "crap": 6
     },
     {
       "package": "complytime",
@@ -1607,8 +1803,7 @@
       "line": 25,
       "complexity": 3,
       "line_coverage": 100,
-      "crap": 3,
-      "gaze_crap": 12
+      "crap": 3
     },
     {
       "package": "complytime",
@@ -1617,8 +1812,7 @@
       "line": 40,
       "complexity": 2,
       "line_coverage": 100,
-      "crap": 2,
-      "gaze_crap": 2.5
+      "crap": 2
     },
     {
       "package": "complytime",
@@ -1627,8 +1821,7 @@
       "line": 51,
       "complexity": 2,
       "line_coverage": 0,
-      "crap": 6,
-      "gaze_crap": 0
+      "crap": 6
     },
     {
       "package": "complytime",
@@ -1637,8 +1830,7 @@
       "line": 59,
       "complexity": 2,
       "line_coverage": 66.66666666666667,
-      "crap": 2.148148148148148,
-      "gaze_crap": 2
+      "crap": 2.148148148148148
     },
     {
       "package": "complytime",
@@ -1647,8 +1839,7 @@
       "line": 67,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1,
-      "gaze_crap": 1
+      "crap": 1
     },
     {
       "package": "complytime",
@@ -1657,8 +1848,7 @@
       "line": 72,
       "complexity": 1,
       "line_coverage": 0,
-      "crap": 2,
-      "gaze_crap": 0
+      "crap": 2
     },
     {
       "package": "complytime",
@@ -1667,8 +1857,7 @@
       "line": 77,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1,
-      "gaze_crap": 1
+      "crap": 1
     },
     {
       "package": "complytime",
@@ -1677,8 +1866,7 @@
       "line": 83,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1,
-      "gaze_crap": 1
+      "crap": 1
     },
     {
       "package": "complytime",
@@ -1687,8 +1875,7 @@
       "line": 88,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1,
-      "gaze_crap": 1
+      "crap": 1
     },
     {
       "package": "complytime",
@@ -1697,8 +1884,7 @@
       "line": 93,
       "complexity": 2,
       "line_coverage": 75,
-      "crap": 2.0625,
-      "gaze_crap": 6
+      "crap": 2.0625
     },
     {
       "package": "complytime",
@@ -1707,8 +1893,7 @@
       "line": 108,
       "complexity": 13,
       "line_coverage": 87.5,
-      "crap": 13.330078125,
-      "gaze_crap": 13
+      "crap": 13.330078125
     },
     {
       "package": "complytime",
@@ -1717,8 +1902,7 @@
       "line": 154,
       "complexity": 3,
       "line_coverage": 100,
-      "crap": 3,
-      "gaze_crap": 3
+      "crap": 3
     },
     {
       "package": "complytime",
@@ -1727,8 +1911,7 @@
       "line": 168,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1,
-      "gaze_crap": 0
+      "crap": 1
     },
     {
       "package": "doctor",
@@ -1743,17 +1926,16 @@
       "package": "doctor",
       "function": "CheckConfig",
       "file": "internal/doctor/doctor.go",
-      "line": 93,
+      "line": 94,
       "complexity": 4,
       "line_coverage": 25,
-      "crap": 10.75,
-      "gaze_crap": 4
+      "crap": 10.75
     },
     {
       "package": "doctor",
       "function": "CheckProviders",
       "file": "internal/doctor/doctor.go",
-      "line": 133,
+      "line": 134,
       "complexity": 8,
       "line_coverage": 0,
       "crap": 72,
@@ -1763,17 +1945,16 @@
       "package": "doctor",
       "function": "CheckPolicyVersions",
       "file": "internal/doctor/doctor.go",
-      "line": 218,
+      "line": 219,
       "complexity": 11,
       "line_coverage": 100,
-      "crap": 11,
-      "gaze_crap": 11
+      "crap": 11
     },
     {
       "package": "doctor",
       "function": "resolvePinnedFallback",
       "file": "internal/doctor/doctor.go",
-      "line": 293,
+      "line": 294,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -1782,38 +1963,35 @@
       "package": "doctor",
       "function": "CheckCache",
       "file": "internal/doctor/doctor.go",
-      "line": 321,
+      "line": 322,
       "complexity": 5,
       "line_coverage": 90.9090909090909,
-      "crap": 5.018782870022539,
-      "gaze_crap": 5
+      "crap": 5.018782870022539
     },
     {
       "package": "doctor",
       "function": "CheckVariables",
       "file": "internal/doctor/doctor.go",
-      "line": 376,
+      "line": 377,
       "complexity": 34,
-      "line_coverage": 87.65432098765432,
-      "crap": 36.17521794517172,
-      "gaze_crap": 34,
+      "line_coverage": 87.8048780487805,
+      "crap": 36.09660335746724,
       "fix_strategy": "decompose"
     },
     {
       "package": "doctor",
       "function": "CheckPolicyActivePeriod",
       "file": "internal/doctor/doctor.go",
-      "line": 542,
+      "line": 545,
       "complexity": 11,
       "line_coverage": 92.85714285714286,
-      "crap": 11.044096209912537,
-      "gaze_crap": 11
+      "crap": 11.044096209912537
     },
     {
       "package": "doctor",
       "function": "parseDatetime",
       "file": "internal/doctor/doctor.go",
-      "line": 615,
+      "line": 618,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -1822,7 +2000,7 @@
       "package": "doctor",
       "function": "evaluateTimeline",
       "file": "internal/doctor/doctor.go",
-      "line": 624,
+      "line": 627,
       "complexity": 7,
       "line_coverage": 86.66666666666667,
       "crap": 7.116148148148148
@@ -1831,7 +2009,7 @@
       "package": "doctor",
       "function": "countResolved",
       "file": "internal/doctor/doctor.go",
-      "line": 654,
+      "line": 657,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -1840,7 +2018,7 @@
       "package": "doctor",
       "function": "unmappedReason",
       "file": "internal/doctor/doctor.go",
-      "line": 664,
+      "line": 667,
       "complexity": 3,
       "line_coverage": 80,
       "crap": 3.072
@@ -1849,17 +2027,25 @@
       "package": "doctor",
       "function": "CheckCollector",
       "file": "internal/doctor/doctor.go",
-      "line": 677,
+      "line": 680,
       "complexity": 5,
       "line_coverage": 100,
-      "crap": 5,
-      "gaze_crap": 5
+      "crap": 5
+    },
+    {
+      "package": "doctor",
+      "function": "CheckComplypacks",
+      "file": "internal/doctor/doctor.go",
+      "line": 718,
+      "complexity": 12,
+      "line_coverage": 81.25,
+      "crap": 12.94921875
     },
     {
       "package": "doctor",
       "function": "checkExportEnabled",
       "file": "internal/doctor/doctor.go",
-      "line": 709,
+      "line": 789,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -1868,16 +2054,25 @@
       "package": "doctor",
       "function": "checkCollectorAuth",
       "file": "internal/doctor/doctor.go",
-      "line": 735,
+      "line": 815,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
     },
     {
       "package": "doctor",
+      "function": "effectiveGlobals",
+      "file": "internal/doctor/doctor.go",
+      "line": 840,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "doctor",
       "function": "joinNames",
       "file": "internal/doctor/doctor.go",
-      "line": 757,
+      "line": 849,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -1886,67 +2081,73 @@
       "package": "output",
       "function": "NewEvaluator",
       "file": "internal/output/evaluator.go",
-      "line": 29,
+      "line": 30,
       "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "output",
+      "function": "(*Evaluator).TargetID",
+      "file": "internal/output/evaluator.go",
+      "line": 43,
+      "complexity": 1,
       "line_coverage": 0,
-      "crap": 6
+      "crap": 2
     },
     {
       "package": "output",
       "function": "(*Evaluator).AddTarget",
       "file": "internal/output/evaluator.go",
-      "line": 42,
+      "line": 49,
       "complexity": 3,
-      "line_coverage": 0,
-      "crap": 12
+      "line_coverage": 100,
+      "crap": 3
     },
     {
       "package": "output",
       "function": "(*Evaluator).GemaraLog",
       "file": "internal/output/evaluator.go",
-      "line": 70,
-      "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
+      "line": 78,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
     },
     {
       "package": "output",
       "function": "(*Evaluator).Write",
       "file": "internal/output/evaluator.go",
-      "line": 92,
+      "line": 112,
       "complexity": 4,
-      "line_coverage": 0,
-      "crap": 20,
-      "fix_strategy": "add_tests"
+      "line_coverage": 72.72727272727273,
+      "crap": 4.324567993989482
     },
     {
       "package": "output",
       "function": "(*Evaluator).resolveControl",
       "file": "internal/output/evaluator.go",
-      "line": 114,
+      "line": 134,
       "complexity": 2,
-      "line_coverage": 0,
-      "crap": 6
+      "line_coverage": 66.66666666666667,
+      "crap": 2.148148148148148
     },
     {
       "package": "output",
       "function": "(*Evaluator).providerToGemaraAssessment",
       "file": "internal/output/evaluator.go",
-      "line": 121,
-      "complexity": 4,
-      "line_coverage": 0,
-      "crap": 20,
-      "fix_strategy": "add_tests"
+      "line": 141,
+      "complexity": 6,
+      "line_coverage": 100,
+      "crap": 6
     },
     {
       "package": "output",
       "function": "providerConfidenceToGemara",
       "file": "internal/output/evaluator.go",
-      "line": 146,
+      "line": 174,
       "complexity": 5,
-      "line_coverage": 0,
-      "crap": 30,
-      "fix_strategy": "add_tests"
+      "line_coverage": 33.333333333333336,
+      "crap": 12.407407407407405
     },
     {
       "package": "output",
@@ -2071,8 +2272,8 @@
       "file": "internal/output/scan_summary.go",
       "line": 44,
       "complexity": 4,
-      "line_coverage": 50,
-      "crap": 6
+      "line_coverage": 83.33333333333333,
+      "crap": 4.074074074074074
     },
     {
       "package": "output",
@@ -2241,7 +2442,7 @@
       "package": "policy",
       "function": "NewResolver",
       "file": "internal/policy/resolver.go",
-      "line": 72,
+      "line": 76,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1
@@ -2250,7 +2451,7 @@
       "package": "policy",
       "function": "(*Resolver).ResolveVersion",
       "file": "internal/policy/resolver.go",
-      "line": 80,
+      "line": 84,
       "complexity": 1,
       "line_coverage": 0,
       "crap": 2
@@ -2259,7 +2460,7 @@
       "package": "policy",
       "function": "(*Resolver).ResolvePolicyGraph",
       "file": "internal/policy/resolver.go",
-      "line": 87,
+      "line": 91,
       "complexity": 6,
       "line_coverage": 100,
       "crap": 6
@@ -2268,7 +2469,7 @@
       "package": "policy",
       "function": "(*Resolver).resolveBundleGraph",
       "file": "internal/policy/resolver.go",
-      "line": 112,
+      "line": 116,
       "complexity": 8,
       "line_coverage": 100,
       "crap": 8
@@ -2277,7 +2478,7 @@
       "package": "policy",
       "function": "(*Resolver).resolveSplitGraph",
       "file": "internal/policy/resolver.go",
-      "line": 168,
+      "line": 172,
       "complexity": 7,
       "line_coverage": 96.29629629629629,
       "crap": 7.002489457907839
@@ -2286,7 +2487,7 @@
       "package": "policy",
       "function": "parseControlCatalog",
       "file": "internal/policy/resolver.go",
-      "line": 220,
+      "line": 224,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -2295,7 +2496,7 @@
       "package": "policy",
       "function": "parseGuidanceCatalog",
       "file": "internal/policy/resolver.go",
-      "line": 228,
+      "line": 232,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -2304,7 +2505,7 @@
       "package": "policy",
       "function": "parsePolicyLayer",
       "file": "internal/policy/resolver.go",
-      "line": 244,
+      "line": 248,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -2313,7 +2514,7 @@
       "package": "policy",
       "function": "extractFromGemaraPolicy",
       "file": "internal/policy/resolver.go",
-      "line": 262,
+      "line": 266,
       "complexity": 9,
       "line_coverage": 100,
       "crap": 9
@@ -2702,7 +2903,7 @@
       "package": "provider",
       "function": "(*Client).Close",
       "file": "pkg/provider/client.go",
-      "line": 142,
+      "line": 143,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -2711,7 +2912,7 @@
       "package": "provider",
       "function": "(*Client).Describe",
       "file": "pkg/provider/client.go",
-      "line": 148,
+      "line": 149,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -2720,7 +2921,7 @@
       "package": "provider",
       "function": "(*Client).Generate",
       "file": "pkg/provider/client.go",
-      "line": 166,
+      "line": 167,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -2729,7 +2930,7 @@
       "package": "provider",
       "function": "(*Client).Scan",
       "file": "pkg/provider/client.go",
-      "line": 191,
+      "line": 193,
       "complexity": 5,
       "line_coverage": 0,
       "crap": 30,
@@ -2739,7 +2940,7 @@
       "package": "provider",
       "function": "(*Client).Export",
       "file": "pkg/provider/client.go",
-      "line": 231,
+      "line": 233,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -2748,7 +2949,7 @@
       "package": "provider",
       "function": "protoResultToInternal",
       "file": "pkg/provider/client.go",
-      "line": 250,
+      "line": 252,
       "complexity": 5,
       "line_coverage": 0,
       "crap": 30,
@@ -2758,7 +2959,7 @@
       "package": "provider",
       "function": "protoConfidenceToInternal",
       "file": "pkg/provider/client.go",
-      "line": 265,
+      "line": 267,
       "complexity": 5,
       "line_coverage": 0,
       "crap": 30,
@@ -2869,7 +3070,7 @@
       "package": "provider",
       "function": "(*Manager).RouteGenerate",
       "file": "pkg/provider/manager.go",
-      "line": 137,
+      "line": 139,
       "complexity": 8,
       "line_coverage": 85,
       "crap": 8.216
@@ -2878,7 +3079,7 @@
       "package": "provider",
       "function": "(*ScanResult).HasErrors",
       "file": "pkg/provider/manager.go",
-      "line": 190,
+      "line": 193,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1
@@ -2887,7 +3088,7 @@
       "package": "provider",
       "function": "(*Manager).RouteScan",
       "file": "pkg/provider/manager.go",
-      "line": 202,
+      "line": 205,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -2896,7 +3097,7 @@
       "package": "provider",
       "function": "(*Manager).RouteScanResult",
       "file": "pkg/provider/manager.go",
-      "line": 218,
+      "line": 221,
       "complexity": 6,
       "line_coverage": 100,
       "crap": 6
@@ -2905,7 +3106,7 @@
       "package": "provider",
       "function": "(*Manager).scanErrorMessage",
       "file": "pkg/provider/manager.go",
-      "line": 268,
+      "line": 271,
       "complexity": 2,
       "line_coverage": 75,
       "crap": 2.0625
@@ -2914,7 +3115,7 @@
       "package": "provider",
       "function": "(*Manager).RouteExport",
       "file": "pkg/provider/manager.go",
-      "line": 280,
+      "line": 283,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -2923,7 +3124,7 @@
       "package": "provider",
       "function": "(*Manager).resolveExporter",
       "file": "pkg/provider/manager.go",
-      "line": 293,
+      "line": 296,
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
@@ -2933,7 +3134,7 @@
       "package": "provider",
       "function": "errorAssessments",
       "file": "pkg/provider/manager.go",
-      "line": 308,
+      "line": 311,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1
@@ -2987,7 +3188,7 @@
       "package": "provider",
       "function": "(*grpcServer).Scan",
       "file": "pkg/provider/server.go",
-      "line": 60,
+      "line": 61,
       "complexity": 5,
       "line_coverage": 0,
       "crap": 30,
@@ -2997,7 +3198,7 @@
       "package": "provider",
       "function": "(*grpcServer).Export",
       "file": "pkg/provider/server.go",
-      "line": 100,
+      "line": 101,
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
@@ -3007,7 +3208,7 @@
       "package": "provider",
       "function": "internalResultToProto",
       "file": "pkg/provider/server.go",
-      "line": 132,
+      "line": 133,
       "complexity": 5,
       "line_coverage": 0,
       "crap": 30,
@@ -3017,7 +3218,7 @@
       "package": "provider",
       "function": "internalConfidenceToProto",
       "file": "pkg/provider/server.go",
-      "line": 147,
+      "line": 148,
       "complexity": 5,
       "line_coverage": 0,
       "crap": 30,
@@ -3267,14 +3468,14 @@
     }
   ],
   "summary": {
-    "total_functions": 345,
-    "avg_complexity": 3.4231884057971014,
-    "avg_line_coverage": 40.303555618271496,
-    "avg_crap": 10.902147936678759,
-    "crapload": 57,
+    "total_functions": 379,
+    "avg_complexity": 3.490765171503958,
+    "avg_line_coverage": 46.98979941439098,
+    "avg_crap": 10.106567370025402,
+    "crapload": 55,
     "crap_threshold": 15,
     "fix_strategy_counts": {
-      "add_tests": 54,
+      "add_tests": 52,
       "decompose": 2,
       "decompose_and_test": 1
     },
@@ -3288,16 +3489,6 @@
         "line_coverage": 0,
         "crap": 380,
         "fix_strategy": "decompose_and_test"
-      },
-      {
-        "package": "cachetest",
-        "function": "(*MockPolicySource).CopyPolicy",
-        "file": "internal/cache/cachetest/mock_source.go",
-        "line": 73,
-        "complexity": 10,
-        "line_coverage": 0,
-        "crap": 110,
-        "fix_strategy": "add_tests"
       },
       {
         "package": "cli",
@@ -3314,6 +3505,16 @@
         "function": "ShowPlainTable",
         "file": "internal/terminal/table.go",
         "line": 19,
+        "complexity": 10,
+        "line_coverage": 0,
+        "crap": 110,
+        "fix_strategy": "add_tests"
+      },
+      {
+        "package": "cachetest",
+        "function": "(*MockPolicySource).CopyPolicy",
+        "file": "internal/cache/cachetest/mock_source.go",
+        "line": 73,
         "complexity": 10,
         "line_coverage": 0,
         "crap": 110,
@@ -3332,10 +3533,10 @@
     ],
     "recommended_actions": [
       {
-        "function": "promptTargets",
-        "package": "cli",
-        "file": "cmd/complyctl/cli/init.go",
-        "line": 153,
+        "function": "ShowPlainTable",
+        "package": "terminal",
+        "file": "internal/terminal/table.go",
+        "line": 19,
         "fix_strategy": "add_tests",
         "crap": 110,
         "complexity": 10
@@ -3350,10 +3551,10 @@
         "complexity": 10
       },
       {
-        "function": "ShowPlainTable",
-        "package": "terminal",
-        "file": "internal/terminal/table.go",
-        "line": 19,
+        "function": "promptTargets",
+        "package": "cli",
+        "file": "cmd/complyctl/cli/init.go",
+        "line": 153,
         "fix_strategy": "add_tests",
         "crap": 110,
         "complexity": 10
@@ -3380,7 +3581,7 @@
         "function": "CheckProviders",
         "package": "doctor",
         "file": "internal/doctor/doctor.go",
-        "line": 133,
+        "line": 134,
         "fix_strategy": "add_tests",
         "crap": 72,
         "complexity": 8
@@ -3440,10 +3641,10 @@
         "complexity": 6
       },
       {
-        "function": "serveManifest",
+        "function": "registerOCIRoutes",
         "package": "main",
         "file": "cmd/mock-oci-registry/main.go",
-        "line": 148,
+        "line": 83,
         "fix_strategy": "add_tests",
         "crap": 42,
         "complexity": 6
@@ -3458,10 +3659,10 @@
         "complexity": 6
       },
       {
-        "function": "registerOCIRoutes",
+        "function": "serveManifest",
         "package": "main",
         "file": "cmd/mock-oci-registry/main.go",
-        "line": 70,
+        "line": 161,
         "fix_strategy": "add_tests",
         "crap": 42,
         "complexity": 6
@@ -3476,10 +3677,10 @@
         "complexity": 5
       },
       {
-        "function": "(*grpcServer).Scan",
-        "package": "provider",
-        "file": "pkg/provider/server.go",
-        "line": 60,
+        "function": "LogCredentialRedaction",
+        "package": "behavioral",
+        "file": "tests/behavioral/log_security.go",
+        "line": 16,
         "fix_strategy": "add_tests",
         "crap": 30,
         "complexity": 5
@@ -3503,10 +3704,10 @@
         "complexity": 5
       },
       {
-        "function": "LogCredentialRedaction",
+        "function": "EnvVarResolution",
         "package": "behavioral",
-        "file": "tests/behavioral/log_security.go",
-        "line": 16,
+        "file": "tests/behavioral/credential_protection.go",
+        "line": 54,
         "fix_strategy": "add_tests",
         "crap": 30,
         "complexity": 5
@@ -3514,6 +3715,7 @@
     ],
     "ssa_degraded_packages": [
       "github.com/complytime/complyctl/cmd/complyctl/cli",
+      "github.com/complytime/complyctl/cmd/mock-oci-registry",
       "github.com/complytime/complyctl/internal/cache",
       "github.com/complytime/complyctl/internal/complytime",
       "github.com/complytime/complyctl/internal/doctor",

--- a/cmd/complyctl/cli/scan.go
+++ b/cmd/complyctl/cli/scan.go
@@ -386,13 +386,16 @@ func runScanAndReport(ctx context.Context, format string, mgr *provider.Manager,
 func processScanOutput(format string, scanOut *scanOutput, repository string, reqToControl map[string]string, policyTargets []complytime.TargetConfig, eid string, targetIDs []string, baseDir string) error {
 	reportOperationalWarnings(scanOut.errors)
 
-	eval := buildEvaluator(repository, reqToControl, policyTargets, scanOut.assessments, scanOut.assessmentTargets)
+	evaluators := buildEvaluators(repository, reqToControl, policyTargets, scanOut.assessments, scanOut.assessmentTargets)
 
 	outDir := filepath.Join(baseDir, complytime.WorkspaceDir, complytime.ScanOutputDir)
-	if err := writeScanReports(format, eval, outDir, baseDir, repository, scanOut.assessments, scanOut.assessmentTargets, reqToControl, eid, targetIDs); err != nil {
-		return err
+	for _, eval := range evaluators {
+		if err := writeScanReports(format, eval, outDir, baseDir, repository); err != nil {
+			return err
+		}
 	}
 
+	fmt.Println(output.FormatScanSummary(scanOut.assessments, scanOut.assessmentTargets, reqToControl, eid, targetIDs))
 	return checkOperationalErrors(scanOut.errors)
 }
 
@@ -418,9 +421,10 @@ func checkOperationalErrors(errors []string) error {
 	return nil
 }
 
-func buildEvaluator(repository string, reqToControl map[string]string, policyTargets []complytime.TargetConfig, allAssessments []provider.AssessmentLog, assessmentTargets []string) *output.Evaluator {
-	eval := output.NewEvaluator(repository, reqToControl)
+func buildEvaluators(repository string, reqToControl map[string]string, policyTargets []complytime.TargetConfig, allAssessments []provider.AssessmentLog, assessmentTargets []string) []*output.Evaluator {
+	evaluators := make([]*output.Evaluator, 0, len(policyTargets))
 	for _, target := range policyTargets {
+		eval := output.NewEvaluator(repository, target.ID, reqToControl)
 		var targetAssessments []provider.AssessmentLog
 		for j, a := range allAssessments {
 			if assessmentTargets[j] == target.ID {
@@ -428,8 +432,9 @@ func buildEvaluator(repository string, reqToControl map[string]string, policyTar
 			}
 		}
 		eval.AddTarget(targetAssessments)
+		evaluators = append(evaluators, eval)
 	}
-	return eval
+	return evaluators
 }
 
 // filterTargetByID narrows a target slice to the single target matching the
@@ -590,18 +595,17 @@ func scanSingleTarget(ctx context.Context, mgr *provider.Manager, groups map[str
 	return results, operationalErrors, nil
 }
 
-func writeScanReports(format string, eval *output.Evaluator, outDir, reportDir, repository string, allAssessments []provider.AssessmentLog, assessmentTargets []string, reqToControl map[string]string, eid string, targetIDs []string) error {
+func writeScanReports(format string, eval *output.Evaluator, outDir, reportDir, repository string) error {
 	logPath, err := eval.Write(outDir)
 	if err != nil {
 		return fmt.Errorf("failed to write evaluation log: %w", err)
 	}
-	fmt.Printf("Evaluation log written: %s\n", logPath)
+	fmt.Printf("Evaluation log written: %s [target: %s]\n", logPath, eval.TargetID())
 
 	if err := writeFormatReport(format, eval, logPath, reportDir, repository); err != nil {
 		return err
 	}
 
-	fmt.Println(output.FormatScanSummary(allAssessments, assessmentTargets, reqToControl, eid, targetIDs))
 	return nil
 }
 

--- a/internal/output/evaluator.go
+++ b/internal/output/evaluator.go
@@ -15,26 +15,33 @@ import (
 	"github.com/complytime/complyctl/pkg/provider"
 )
 
-// Evaluator accumulates per-target provider assessments and produces a
-// gemara.EvaluationLog grouped by control.
+// Evaluator accumulates provider assessments for a single target and produces
+// a gemara.EvaluationLog grouped by control.
 type Evaluator struct {
 	policyID     string
+	targetID     string
 	reqToControl map[string]string
 	controlEvals map[string]*gemara.ControlEvaluation
 	controlOrder []string
 }
 
-// NewEvaluator creates an Evaluator. reqToControl maps requirement IDs to
-// control IDs; pass nil when the catalog is unavailable.
-func NewEvaluator(policyID string, reqToControl map[string]string) *Evaluator {
+// NewEvaluator creates an Evaluator scoped to a single target. reqToControl
+// maps requirement IDs to control IDs; pass nil when the catalog is unavailable.
+func NewEvaluator(policyID, targetID string, reqToControl map[string]string) *Evaluator {
 	if reqToControl == nil {
 		reqToControl = make(map[string]string)
 	}
 	return &Evaluator{
 		policyID:     policyID,
+		targetID:     targetID,
 		reqToControl: reqToControl,
 		controlEvals: make(map[string]*gemara.ControlEvaluation),
 	}
+}
+
+// TargetID returns the target identifier for this evaluator.
+func (e *Evaluator) TargetID() string {
+	return e.targetID
 }
 
 // AddTarget converts provider assessment results for one target into
@@ -66,17 +73,25 @@ func (e *Evaluator) AddTarget(assessments []provider.AssessmentLog) {
 	}
 }
 
-// GemaraLog returns the assembled gemara.EvaluationLog.
+// GemaraLog returns the assembled gemara.EvaluationLog with fully populated
+// metadata, aggregated result, and target resource.
 func (e *Evaluator) GemaraLog() *gemara.EvaluationLog {
 	evals := make([]*gemara.ControlEvaluation, 0, len(e.controlEvals))
 	for _, id := range e.controlOrder {
 		evals = append(evals, e.controlEvals[id])
 	}
 
+	result := gemara.NotRun
+	for _, ce := range evals {
+		result = gemara.UpdateAggregateResult(result, ce.Result)
+	}
+
 	return &gemara.EvaluationLog{
 		Evaluations: evals,
+		Result:      result,
 		Metadata: gemara.Metadata{
 			Id:          e.policyID,
+			Type:        gemara.EvaluationLogArtifact,
 			Description: "Compliance scan evaluation log",
 			Author: gemara.Actor{
 				Id:   "complytime",
@@ -84,6 +99,11 @@ func (e *Evaluator) GemaraLog() *gemara.EvaluationLog {
 				Type: gemara.Software,
 				Uri:  "https://github.com/complytime/complyctl",
 			},
+		},
+		Target: gemara.Resource{
+			Id:   e.targetID,
+			Name: e.targetID,
+			Type: gemara.Software,
 		},
 	}
 }
@@ -101,8 +121,8 @@ func (e *Evaluator) Write(outDir string) (string, error) {
 		return "", fmt.Errorf("failed to create output directory: %w", err)
 	}
 
-	filename := fmt.Sprintf("evaluation-log-%s-%s.yaml",
-		complytime.FilenameSafe(e.policyID), time.Now().Format("20060102-150405"))
+	filename := fmt.Sprintf("evaluation-log-%s-%s-%s.yaml",
+		complytime.FilenameSafe(e.policyID), complytime.FilenameSafe(e.targetID), time.Now().Format("20060102-150405"))
 	path := filepath.Join(outDir, filename)
 	if err := os.WriteFile(path, data, 0600); err != nil {
 		return "", fmt.Errorf("failed to write evaluation log: %w", err)
@@ -120,7 +140,15 @@ func (e *Evaluator) resolveControl(requirementID string) string {
 
 func (e *Evaluator) providerToGemaraAssessment(a *provider.AssessmentLog) *gemara.AssessmentLog {
 	result := aggregateResultFromSteps(a.Steps)
-	desc := a.Message
+
+	msg := a.Message
+	if result != gemara.Passed {
+		if stepMsg := matchingStepMessage(a.Steps, result); stepMsg != "" {
+			msg = stepMsg
+		}
+	}
+
+	desc := msg
 	if desc == "" && len(a.Steps) > 0 {
 		desc = a.Steps[0].Name
 	}
@@ -135,7 +163,7 @@ func (e *Evaluator) providerToGemaraAssessment(a *provider.AssessmentLog) *gemar
 		},
 		Description:     desc,
 		Result:          result,
-		Message:         a.Message,
+		Message:         msg,
 		Applicability:   []string{"default"},
 		Start:           gemara.Datetime(time.Now().Format(time.RFC3339)),
 		StepsExecuted:   int64(len(a.Steps)),

--- a/internal/output/evaluator_test.go
+++ b/internal/output/evaluator_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package output_test
+
+import (
+	"testing"
+
+	"github.com/gemaraproj/go-gemara"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/complytime/complyctl/internal/output"
+	"github.com/complytime/complyctl/pkg/provider"
+)
+
+func TestGemaraLog_MetadataType(t *testing.T) {
+	eval := output.NewEvaluator("test-policy", "target-1", nil)
+	eval.AddTarget([]provider.AssessmentLog{
+		{
+			RequirementID: "REQ-1",
+			Steps:         []provider.Step{{Result: provider.ResultPassed, Message: "ok"}},
+		},
+	})
+
+	log := eval.GemaraLog()
+	assert.Equal(t, gemara.EvaluationLogArtifact, log.Metadata.Type)
+}
+
+func TestGemaraLog_AggregatesResult(t *testing.T) {
+	tests := []struct {
+		name     string
+		steps    []provider.Step
+		expected gemara.Result
+	}{
+		{
+			name:     "all passing yields Passed",
+			steps:    []provider.Step{{Result: provider.ResultPassed, Message: "ok"}},
+			expected: gemara.Passed,
+		},
+		{
+			name:     "any failure yields Failed",
+			steps:    []provider.Step{{Result: provider.ResultFailed, Message: "bad"}},
+			expected: gemara.Failed,
+		},
+		{
+			name:     "no steps yields NotRun",
+			steps:    nil,
+			expected: gemara.NotRun,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eval := output.NewEvaluator("pol", "tgt", nil)
+			eval.AddTarget([]provider.AssessmentLog{
+				{RequirementID: "R1", Steps: tt.steps},
+			})
+			assert.Equal(t, tt.expected, eval.GemaraLog().Result)
+		})
+	}
+}
+
+func TestGemaraLog_PopulatesTarget(t *testing.T) {
+	eval := output.NewEvaluator("policy-id", "my-target", nil)
+	eval.AddTarget([]provider.AssessmentLog{
+		{RequirementID: "R1", Steps: []provider.Step{{Result: provider.ResultPassed, Message: "ok"}}},
+	})
+
+	log := eval.GemaraLog()
+	assert.Equal(t, "my-target", log.Target.Id)
+	assert.Equal(t, "my-target", log.Target.Name)
+	assert.Equal(t, gemara.Software, log.Target.Type)
+}
+
+func TestGemaraLog_AssessmentMessageUsesStepViolation(t *testing.T) {
+	eval := output.NewEvaluator("pol", "tgt", nil)
+	eval.AddTarget([]provider.AssessmentLog{
+		{
+			RequirementID: "REQ-1",
+			Steps: []provider.Step{
+				{Result: provider.ResultFailed, Message: "cert validity exceeds 397 days"},
+			},
+			Message: "0 of 1 targets passed",
+		},
+	})
+
+	log := eval.GemaraLog()
+	require.Len(t, log.Evaluations, 1)
+	require.Len(t, log.Evaluations[0].AssessmentLogs, 1)
+	assert.Equal(t, "cert validity exceeds 397 days", log.Evaluations[0].AssessmentLogs[0].Message)
+}
+
+func TestGemaraLog_PassingAssessmentKeepsProviderMessage(t *testing.T) {
+	eval := output.NewEvaluator("pol", "tgt", nil)
+	eval.AddTarget([]provider.AssessmentLog{
+		{
+			RequirementID: "REQ-1",
+			Steps: []provider.Step{
+				{Result: provider.ResultPassed, Message: "check ok"},
+			},
+			Message: "1 of 1 targets passed",
+		},
+	})
+
+	log := eval.GemaraLog()
+	require.Len(t, log.Evaluations, 1)
+	require.Len(t, log.Evaluations[0].AssessmentLogs, 1)
+	assert.Equal(t, "1 of 1 targets passed", log.Evaluations[0].AssessmentLogs[0].Message)
+}
+
+func TestEvaluator_Write(t *testing.T) {
+	outDir := t.TempDir()
+	eval := output.NewEvaluator("test-policy", "target-1", nil)
+	eval.AddTarget([]provider.AssessmentLog{
+		{RequirementID: "R1", Steps: []provider.Step{{Result: provider.ResultPassed, Message: "ok"}}},
+	})
+
+	path, err := eval.Write(outDir)
+	require.NoError(t, err)
+	assert.FileExists(t, path)
+	assert.Contains(t, path, "evaluation-log-test-policy-target-1-")
+}


### PR DESCRIPTION
## Summary

The evaluation log YAML emitted by `complyctl scan` had three defects:
1. metadata.type was "Invalid" (Go zero value for ArtifactType)
2. Top-level result was "Not Run" despite evaluations completing
3. target fields were empty

Root cause: GemaraLog() never assigned these fields.

Additionally, assessment-level messages showed generic "X of Y targets passed" instead of actual violation text from provider steps.

Changes:
- Make Evaluator target-scoped (one per scan target)
- GemaraLog() now sets Metadata.Type = EvaluationLog, aggregates Result from control evaluations, and populates Target from the target ID
- providerToGemaraAssessment uses matchingStepMessage for non-passing results, surfacing the real violation text in logs and reports
- buildEvaluators produces one evaluator per target, writing separate evaluation logs per target
- Evaluation log filename includes target ID for disambiguation

## Related Issues

Fixes: complytime/complyctl#552

## Devpod Validation

Validated in devcontainer using the OPA provider (`test-opa-bp` policy, `test-k8s-deployment` target):

```bash
cd ~/test-workspace
complyctl get          # synced 2 policies + 2 complypacks
complyctl generate --policy-id test-opa-bp
complyctl scan --policy-id test-opa-bp
```

Evaluation log output confirms all three fixed fields:

```yaml
metadata:
  id: policies/test-opa-policy
  type: EvaluationLog          # was: "Invalid"
  ...
result: Passed                 # was: always "Not Run"
evaluations:
- name: scan-status
  result: Passed
  ...
target:
  id: test-k8s-deployment      # was: empty
  name: test-k8s-deployment
  type: Software
```

CUE schema validation (`cue vet -c -d '#EvaluationLog' github.com/gemaraproj/gemara@latest`) fails on a pre-existing provider issue: the OPA provider returns empty `steps: []` but the Gemara schema requires at least one step per assessment. This is not introduced by this PR.