### PR TITLE
feat: populate assessment plan and step identity in evaluation logs

### DIFF
--- a/.gaze/baseline.json
+++ b/.gaze/baseline.json
@@ -273,33 +273,23 @@
       "file": "cmd/complyctl/cli/get.go",
       "line": 153,
       "complexity": 3,
-      "line_coverage": 76.47058823529412,
-      "crap": 3.1172399755750053
+      "line_coverage": 75,
+      "crap": 3.140625
     },
     {
       "package": "cli",
       "function": "resolveLatestVersion",
       "file": "cmd/complyctl/cli/get.go",
-      "line": 178,
+      "line": 177,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
     },
     {
       "package": "cli",
-      "function": "suggestCachedPolicyIDs",
-      "file": "cmd/complyctl/cli/get.go",
-      "line": 190,
-      "complexity": 6,
-      "line_coverage": 30,
-      "crap": 18.347999999999995,
-      "fix_strategy": "add_tests"
-    },
-    {
-      "package": "cli",
       "function": "syncAllComplypacks",
       "file": "cmd/complyctl/cli/get.go",
-      "line": 207,
+      "line": 189,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -308,7 +298,7 @@
       "package": "cli",
       "function": "syncSingleComplypack",
       "file": "cmd/complyctl/cli/get.go",
-      "line": 222,
+      "line": 204,
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
@@ -564,7 +554,7 @@
       "package": "cli",
       "function": "scanCmd",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 35,
+      "line": 45,
       "complexity": 6,
       "line_coverage": 42.10526315789474,
       "crap": 12.985857996792536
@@ -573,7 +563,7 @@
       "package": "cli",
       "function": "completeTargetIDs",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 101,
+      "line": 111,
       "complexity": 5,
       "line_coverage": 91.66666666666667,
       "crap": 5.014467592592593
@@ -582,7 +572,7 @@
       "package": "cli",
       "function": "(*scanOptions).validate",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 121,
+      "line": 131,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -591,7 +581,7 @@
       "package": "cli",
       "function": "(*scanOptions).complete",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 133,
+      "line": 143,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -600,7 +590,7 @@
       "package": "cli",
       "function": "(*scanOptions).run",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 146,
+      "line": 156,
       "complexity": 8,
       "line_coverage": 100,
       "crap": 8
@@ -609,7 +599,7 @@
       "package": "cli",
       "function": "resolveTarget",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 188,
+      "line": 198,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -618,7 +608,7 @@
       "package": "cli",
       "function": "resolvePolicy",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 207,
+      "line": 217,
       "complexity": 9,
       "line_coverage": 100,
       "crap": 9
@@ -627,7 +617,7 @@
       "package": "cli",
       "function": "loadWorkspaceConfig",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 237,
+      "line": 247,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -636,7 +626,7 @@
       "package": "cli",
       "function": "(*scanOptions).scanPolicy",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 245,
+      "line": 255,
       "complexity": 5,
       "line_coverage": 23.80952380952381,
       "crap": 16.05712126120289,
@@ -646,7 +636,7 @@
       "package": "cli",
       "function": "(*scanOptions).executeScanPhase",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 285,
+      "line": 295,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -655,7 +645,7 @@
       "package": "cli",
       "function": "(*scanOptions).maybeExport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 292,
+      "line": 303,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -664,7 +654,7 @@
       "package": "cli",
       "function": "resolveVersionAndGraph",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 305,
+      "line": 316,
       "complexity": 3,
       "line_coverage": 60,
       "crap": 3.576
@@ -673,7 +663,7 @@
       "package": "cli",
       "function": "loadProviders",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 322,
+      "line": 333,
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
@@ -683,7 +673,7 @@
       "package": "cli",
       "function": "evaluatorIDList",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 338,
+      "line": 349,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -692,7 +682,7 @@
       "package": "cli",
       "function": "targetIDList",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 346,
+      "line": 357,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -701,7 +691,7 @@
       "package": "cli",
       "function": "ensureGenerated",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 354,
+      "line": 365,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -710,7 +700,7 @@
       "package": "cli",
       "function": "runScanAndReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 369,
+      "line": 380,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -719,7 +709,7 @@
       "package": "cli",
       "function": "processScanOutput",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 388,
+      "line": 402,
       "complexity": 3,
       "line_coverage": 87.5,
       "crap": 3.017578125
@@ -728,7 +718,7 @@
       "package": "cli",
       "function": "reportOperationalWarnings",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 406,
+      "line": 420,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -737,7 +727,7 @@
       "package": "cli",
       "function": "checkOperationalErrors",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 415,
+      "line": 429,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -746,7 +736,7 @@
       "package": "cli",
       "function": "buildEvaluators",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 426,
+      "line": 440,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -755,7 +745,7 @@
       "package": "cli",
       "function": "filterTargetByID",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 445,
+      "line": 459,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -764,7 +754,7 @@
       "package": "cli",
       "function": "filterTargetsForPolicy",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 454,
+      "line": 468,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -773,7 +763,7 @@
       "package": "cli",
       "function": "checkGenerationFreshness",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 464,
+      "line": 478,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -782,7 +772,7 @@
       "package": "cli",
       "function": "needsRegeneration",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 479,
+      "line": 493,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -791,7 +781,7 @@
       "package": "cli",
       "function": "evaluatorArtifactsExist",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 496,
+      "line": 510,
       "complexity": 6,
       "line_coverage": 100,
       "crap": 6
@@ -800,7 +790,7 @@
       "package": "cli",
       "function": "runGeneration",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 511,
+      "line": 525,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -809,7 +799,7 @@
       "package": "cli",
       "function": "generateForAllTargets",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 527,
+      "line": 541,
       "complexity": 5,
       "line_coverage": 36.36363636363637,
       "crap": 11.442524417731029
@@ -818,7 +808,7 @@
       "package": "cli",
       "function": "executeScan",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 547,
+      "line": 561,
       "complexity": 1,
       "line_coverage": 0,
       "crap": 2
@@ -827,7 +817,7 @@
       "package": "cli",
       "function": "scanAllTargets",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 555,
+      "line": 569,
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
@@ -837,7 +827,7 @@
       "package": "cli",
       "function": "scanSingleTarget",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 581,
+      "line": 595,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -846,7 +836,7 @@
       "package": "cli",
       "function": "writeScanReports",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 600,
+      "line": 614,
       "complexity": 3,
       "line_coverage": 71.42857142857143,
       "crap": 3.2099125364431487
@@ -855,7 +845,7 @@
       "package": "cli",
       "function": "writeFormatReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 614,
+      "line": 628,
       "complexity": 4,
       "line_coverage": 40,
       "crap": 7.4559999999999995
@@ -864,7 +854,7 @@
       "package": "cli",
       "function": "writePrettyReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 626,
+      "line": 640,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -873,7 +863,7 @@
       "package": "cli",
       "function": "writeSARIFReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 637,
+      "line": 651,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -882,7 +872,7 @@
       "package": "cli",
       "function": "writeOSCALReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 646,
+      "line": 660,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -891,7 +881,7 @@
       "package": "cli",
       "function": "(*scanOptions).runExport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 657,
+      "line": 671,
       "complexity": 5,
       "line_coverage": 16.666666666666668,
       "crap": 19.467592592592588,
@@ -901,7 +891,7 @@
       "package": "cli",
       "function": "authRequired",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 683,
+      "line": 697,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -910,7 +900,7 @@
       "package": "cli",
       "function": "validateAuthCredentials",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 687,
+      "line": 701,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -919,7 +909,7 @@
       "package": "cli",
       "function": "resolveCollectorAuth",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 694,
+      "line": 708,
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
@@ -929,7 +919,7 @@
       "package": "cli",
       "function": "exportToProviders",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 709,
+      "line": 723,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -938,7 +928,7 @@
       "package": "cli",
       "function": "exportSingleProvider",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 717,
+      "line": 731,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -947,7 +937,7 @@
       "package": "cli",
       "function": "resolveOIDCToken",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 734,
+      "line": 748,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -956,7 +946,7 @@
       "package": "cli",
       "function": "formatExportSummary",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 747,
+      "line": 761,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -965,7 +955,7 @@
       "package": "cli",
       "function": "appendExportRow",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 767,
+      "line": 781,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -974,7 +964,7 @@
       "package": "cli",
       "function": "appendResponseRow",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 781,
+      "line": 795,
       "complexity": 3,
       "line_coverage": 85.71428571428571,
       "crap": 3.0262390670553936
@@ -983,7 +973,7 @@
       "package": "cli",
       "function": "exportResponseStatus",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 794,
+      "line": 808,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -992,7 +982,7 @@
       "package": "cli",
       "function": "countExportFailures",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 816,
+      "line": 830,
       "complexity": 7,
       "line_coverage": 100,
       "crap": 7
@@ -1001,7 +991,7 @@
       "package": "cli",
       "function": "injectWorkspaceIntoTargets",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 837,
+      "line": 851,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -1010,7 +1000,7 @@
       "package": "cli",
       "function": "extractReqToControlMap",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 848,
+      "line": 862,
       "complexity": 6,
       "line_coverage": 90,
       "crap": 6.036
@@ -1019,7 +1009,7 @@
       "package": "cli",
       "function": "extractPlanToReqMap",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 869,
+      "line": 883,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -1028,7 +1018,7 @@
       "package": "cli",
       "function": "resolveAssessmentIDs",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 884,
+      "line": 898,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -1037,20 +1027,28 @@
       "package": "cli",
       "function": "reverseMap",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 894,
+      "line": 908,
       "complexity": 3,
       "line_coverage": 83.33333333333333,
       "crap": 3.0416666666666665
     },
     {
       "package": "cli",
-      "function": "resolveComplypackRef",
+      "function": "buildComplypackRefs",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 912,
-      "complexity": 7,
-      "line_coverage": 18.181818181818183,
-      "crap": 33.83771600300525,
-      "fix_strategy": "add_tests"
+      "line": 923,
+      "complexity": 6,
+      "line_coverage": 63.63636363636363,
+      "crap": 7.7310293012772355
+    },
+    {
+      "package": "cli",
+      "function": "extractReqToEvaluator",
+      "file": "cmd/complyctl/cli/scan.go",
+      "line": 944,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
     },
     {
       "package": "cli",
@@ -1718,7 +1716,7 @@
       "package": "cache",
       "function": "NewSync",
       "file": "internal/cache/sync.go",
-      "line": 17,
+      "line": 20,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1,
@@ -1730,12 +1728,12 @@
       "package": "cache",
       "function": "(*Sync).SyncPolicy",
       "file": "internal/cache/sync.go",
-      "line": 28,
-      "complexity": 13,
-      "line_coverage": 86.95652173913044,
-      "crap": 13.375030821073395,
+      "line": 31,
+      "complexity": 14,
+      "line_coverage": 84,
+      "crap": 14.802816,
       "contract_coverage": 100,
-      "gaze_crap": 13,
+      "gaze_crap": 14,
       "quadrant": "Q1_Safe"
     },
     {
@@ -2065,7 +2063,7 @@
       "package": "doctor",
       "function": "Run",
       "file": "internal/doctor/doctor.go",
-      "line": 77,
+      "line": 79,
       "complexity": 1,
       "line_coverage": 0,
       "crap": 2
@@ -2074,7 +2072,7 @@
       "package": "doctor",
       "function": "CheckConfig",
       "file": "internal/doctor/doctor.go",
-      "line": 94,
+      "line": 96,
       "complexity": 4,
       "line_coverage": 25,
       "crap": 10.75,
@@ -2086,7 +2084,7 @@
       "package": "doctor",
       "function": "CheckProviders",
       "file": "internal/doctor/doctor.go",
-      "line": 134,
+      "line": 136,
       "complexity": 8,
       "line_coverage": 0,
       "crap": 72,
@@ -2096,28 +2094,29 @@
       "package": "doctor",
       "function": "CheckPolicyVersions",
       "file": "internal/doctor/doctor.go",
-      "line": 219,
-      "complexity": 11,
+      "line": 221,
+      "complexity": 15,
       "line_coverage": 100,
-      "crap": 11,
+      "crap": 15,
       "contract_coverage": 100,
-      "gaze_crap": 11,
-      "quadrant": "Q1_Safe"
+      "gaze_crap": 15,
+      "quadrant": "Q4_Dangerous",
+      "fix_strategy": "decompose"
     },
     {
       "package": "doctor",
       "function": "resolvePinnedFallback",
       "file": "internal/doctor/doctor.go",
-      "line": 294,
-      "complexity": 3,
+      "line": 317,
+      "complexity": 5,
       "line_coverage": 100,
-      "crap": 3
+      "crap": 5
     },
     {
       "package": "doctor",
       "function": "CheckCache",
       "file": "internal/doctor/doctor.go",
-      "line": 322,
+      "line": 359,
       "complexity": 5,
       "line_coverage": 90.9090909090909,
       "crap": 5.018782870022539,
@@ -2129,7 +2128,7 @@
       "package": "doctor",
       "function": "CheckVariables",
       "file": "internal/doctor/doctor.go",
-      "line": 377,
+      "line": 414,
       "complexity": 34,
       "line_coverage": 87.8048780487805,
       "crap": 36.09660335746724,
@@ -2142,7 +2141,7 @@
       "package": "doctor",
       "function": "CheckPolicyActivePeriod",
       "file": "internal/doctor/doctor.go",
-      "line": 545,
+      "line": 582,
       "complexity": 11,
       "line_coverage": 92.85714285714286,
       "crap": 11.044096209912537,
@@ -2154,7 +2153,7 @@
       "package": "doctor",
       "function": "parseDatetime",
       "file": "internal/doctor/doctor.go",
-      "line": 618,
+      "line": 655,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -2163,7 +2162,7 @@
       "package": "doctor",
       "function": "evaluateTimeline",
       "file": "internal/doctor/doctor.go",
-      "line": 627,
+      "line": 664,
       "complexity": 7,
       "line_coverage": 86.66666666666667,
       "crap": 7.116148148148148
@@ -2172,7 +2171,7 @@
       "package": "doctor",
       "function": "countResolved",
       "file": "internal/doctor/doctor.go",
-      "line": 657,
+      "line": 694,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -2181,7 +2180,7 @@
       "package": "doctor",
       "function": "unmappedReason",
       "file": "internal/doctor/doctor.go",
-      "line": 667,
+      "line": 704,
       "complexity": 3,
       "line_coverage": 80,
       "crap": 3.072
@@ -2190,19 +2189,19 @@
       "package": "doctor",
       "function": "CheckCollector",
       "file": "internal/doctor/doctor.go",
-      "line": 680,
-      "complexity": 5,
+      "line": 717,
+      "complexity": 6,
       "line_coverage": 100,
-      "crap": 5,
+      "crap": 6,
       "contract_coverage": 100,
-      "gaze_crap": 5,
+      "gaze_crap": 6,
       "quadrant": "Q1_Safe"
     },
     {
       "package": "doctor",
       "function": "CheckComplypacks",
       "file": "internal/doctor/doctor.go",
-      "line": 718,
+      "line": 758,
       "complexity": 12,
       "line_coverage": 81.25,
       "crap": 12.94921875,
@@ -2214,7 +2213,7 @@
       "package": "doctor",
       "function": "checkExportEnabled",
       "file": "internal/doctor/doctor.go",
-      "line": 789,
+      "line": 829,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -2223,7 +2222,7 @@
       "package": "doctor",
       "function": "checkCollectorAuth",
       "file": "internal/doctor/doctor.go",
-      "line": 815,
+      "line": 855,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -2232,7 +2231,7 @@
       "package": "doctor",
       "function": "effectiveGlobals",
       "file": "internal/doctor/doctor.go",
-      "line": 840,
+      "line": 880,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -2241,28 +2240,37 @@
       "package": "doctor",
       "function": "joinNames",
       "file": "internal/doctor/doctor.go",
-      "line": 849,
+      "line": 889,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
     },
     {
       "package": "output",
+      "function": "defaultMap",
+      "file": "internal/output/evaluator.go",
+      "line": 36,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "output",
       "function": "NewEvaluator",
       "file": "internal/output/evaluator.go",
-      "line": 39,
-      "complexity": 3,
+      "line": 51,
+      "complexity": 1,
       "line_coverage": 100,
-      "crap": 3,
+      "crap": 1,
       "contract_coverage": 0,
-      "gaze_crap": 12,
+      "gaze_crap": 2,
       "quadrant": "Q1_Safe"
     },
     {
       "package": "output",
       "function": "(*Evaluator).TargetID",
       "file": "internal/output/evaluator.go",
-      "line": 58,
+      "line": 65,
       "complexity": 1,
       "line_coverage": 0,
       "crap": 2
@@ -2271,7 +2279,7 @@
       "package": "output",
       "function": "(*Evaluator).AddTarget",
       "file": "internal/output/evaluator.go",
-      "line": 64,
+      "line": 71,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -2280,7 +2288,7 @@
       "package": "output",
       "function": "(*Evaluator).GemaraLog",
       "file": "internal/output/evaluator.go",
-      "line": 94,
+      "line": 101,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -2289,7 +2297,7 @@
       "package": "output",
       "function": "(*Evaluator).Write",
       "file": "internal/output/evaluator.go",
-      "line": 131,
+      "line": 138,
       "complexity": 4,
       "line_coverage": 75,
       "crap": 4.25
@@ -2298,16 +2306,16 @@
       "package": "output",
       "function": "(*Evaluator).resolveControl",
       "file": "internal/output/evaluator.go",
-      "line": 154,
+      "line": 161,
       "complexity": 2,
-      "line_coverage": 66.66666666666667,
-      "crap": 2.148148148148148
+      "line_coverage": 100,
+      "crap": 2
     },
     {
       "package": "output",
       "function": "(*Evaluator).providerToGemaraAssessment",
       "file": "internal/output/evaluator.go",
-      "line": 161,
+      "line": 168,
       "complexity": 8,
       "line_coverage": 100,
       "crap": 8
@@ -2316,7 +2324,7 @@
       "package": "output",
       "function": "providerStepToGemara",
       "file": "internal/output/evaluator.go",
-      "line": 215,
+      "line": 222,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1
@@ -2325,7 +2333,7 @@
       "package": "output",
       "function": "providerStepsToGemara",
       "file": "internal/output/evaluator.go",
-      "line": 225,
+      "line": 232,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -2334,7 +2342,7 @@
       "package": "output",
       "function": "providerConfidenceToGemara",
       "file": "internal/output/evaluator.go",
-      "line": 236,
+      "line": 243,
       "complexity": 5,
       "line_coverage": 83.33333333333333,
       "crap": 5.1157407407407405
@@ -2343,16 +2351,25 @@
       "package": "output",
       "function": "formatStepIdentity",
       "file": "internal/output/evaluator.go",
-      "line": 288,
+      "line": 295,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
     },
     {
       "package": "output",
+      "function": "(*Evaluator).resolveComplypackRef",
+      "file": "internal/output/evaluator.go",
+      "line": 306,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "output",
       "function": "(*Evaluator).toSerializable",
       "file": "internal/output/evaluator.go",
-      "line": 297,
+      "line": 316,
       "complexity": 5,
       "line_coverage": 100,
       "crap": 5
@@ -2791,7 +2808,7 @@
       "package": "registry",
       "function": "NewClient",
       "file": "internal/registry/client.go",
-      "line": 29,
+      "line": 35,
       "complexity": 1,
       "line_coverage": 0,
       "crap": 2
@@ -2800,7 +2817,7 @@
       "package": "registry",
       "function": "NewClientWithFetcher",
       "file": "internal/registry/client.go",
-      "line": 38,
+      "line": 44,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1
@@ -2809,16 +2826,16 @@
       "package": "registry",
       "function": "(*Client).DefinitionVersion",
       "file": "internal/registry/client.go",
-      "line": 47,
-      "complexity": 4,
-      "line_coverage": 44.44444444444444,
-      "crap": 6.743484224965707
+      "line": 53,
+      "complexity": 5,
+      "line_coverage": 36.36363636363637,
+      "crap": 11.442524417731029
     },
     {
       "package": "registry",
       "function": "(*Client).NewRemoteRepository",
       "file": "internal/registry/client.go",
-      "line": 67,
+      "line": 76,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -2827,7 +2844,7 @@
       "package": "registry",
       "function": "(*Client).registryHost",
       "file": "internal/registry/client.go",
-      "line": 76,
+      "line": 85,
       "complexity": 1,
       "line_coverage": 0,
       "crap": 2
@@ -2836,7 +2853,7 @@
       "package": "registry",
       "function": "buildRef",
       "file": "internal/registry/client.go",
-      "line": 86,
+      "line": 95,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -2845,7 +2862,7 @@
       "package": "registry",
       "function": "(*Client).newRepository",
       "file": "internal/registry/client.go",
-      "line": 94,
+      "line": 103,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -2854,10 +2871,10 @@
       "package": "registry",
       "function": "(*Client).fetchVersion",
       "file": "internal/registry/client.go",
-      "line": 109,
-      "complexity": 5,
+      "line": 118,
+      "complexity": 6,
       "line_coverage": 0,
-      "crap": 30,
+      "crap": 42,
       "fix_strategy": "add_tests"
     },
     {
@@ -3739,25 +3756,25 @@
     }
   ],
   "summary": {
-    "total_functions": 385,
-    "avg_complexity": 3.501298701298701,
-    "avg_line_coverage": 47.82577105673262,
-    "avg_crap": 10.056564107139334,
-    "crapload": 56,
+    "total_functions": 387,
+    "avg_complexity": 3.503875968992248,
+    "avg_line_coverage": 48.44754991621372,
+    "avg_crap": 9.967246916782646,
+    "crapload": 55,
     "crap_threshold": 15,
-    "gaze_crapload": 3,
+    "gaze_crapload": 4,
     "gaze_crap_threshold": 15,
-    "avg_gaze_crap": 5.57797619047619,
+    "avg_gaze_crap": 5.520833333333333,
     "avg_contract_coverage": 74.52380952380953,
     "quadrant_counts": {
-      "Q1_Safe": 66,
+      "Q1_Safe": 65,
       "Q2_ComplexButTested": 1,
       "Q3_SimpleButUnderspecified": 1,
-      "Q4_Dangerous": 2
+      "Q4_Dangerous": 3
     },
     "fix_strategy_counts": {
-      "add_tests": 53,
-      "decompose": 2,
+      "add_tests": 51,
+      "decompose": 3,
       "decompose_and_test": 1
     },
     "worst_crap": [
@@ -3770,16 +3787,6 @@
         "line_coverage": 0,
         "crap": 380,
         "fix_strategy": "decompose_and_test"
-      },
-      {
-        "package": "cachetest",
-        "function": "(*MockPolicySource).CopyPolicy",
-        "file": "internal/cache/cachetest/mock_source.go",
-        "line": 73,
-        "complexity": 10,
-        "line_coverage": 0,
-        "crap": 110,
-        "fix_strategy": "add_tests"
       },
       {
         "package": "cli",
@@ -3802,6 +3809,16 @@
         "fix_strategy": "add_tests"
       },
       {
+        "package": "cachetest",
+        "function": "(*MockPolicySource).CopyPolicy",
+        "file": "internal/cache/cachetest/mock_source.go",
+        "line": 73,
+        "complexity": 10,
+        "line_coverage": 0,
+        "crap": 110,
+        "fix_strategy": "add_tests"
+      },
+      {
         "package": "main",
         "function": "main",
         "file": "cmd/behavioral-report/main.go",
@@ -3817,7 +3834,7 @@
         "package": "doctor",
         "function": "CheckVariables",
         "file": "internal/doctor/doctor.go",
-        "line": 377,
+        "line": 414,
         "complexity": 34,
         "line_coverage": 87.8048780487805,
         "crap": 36.09660335746724,
@@ -3839,6 +3856,19 @@
         "quadrant": "Q3_SimpleButUnderspecified"
       },
       {
+        "package": "doctor",
+        "function": "CheckPolicyVersions",
+        "file": "internal/doctor/doctor.go",
+        "line": 221,
+        "complexity": 15,
+        "line_coverage": 100,
+        "crap": 15,
+        "contract_coverage": 100,
+        "gaze_crap": 15,
+        "quadrant": "Q4_Dangerous",
+        "fix_strategy": "decompose"
+      },
+      {
         "package": "cache",
         "function": "(*ComplypackSync).SyncComplypack",
         "file": "internal/cache/complypack_sync.go",
@@ -3852,40 +3882,19 @@
         "fix_strategy": "decompose"
       },
       {
-        "package": "complytime",
-        "function": "ResolveWorkspaceDir",
-        "file": "internal/complytime/workspace.go",
-        "line": 108,
-        "complexity": 13,
-        "line_coverage": 87.5,
-        "crap": 13.330078125,
-        "contract_coverage": 100,
-        "gaze_crap": 13,
-        "quadrant": "Q1_Safe"
-      },
-      {
         "package": "cache",
         "function": "(*Sync).SyncPolicy",
         "file": "internal/cache/sync.go",
-        "line": 28,
-        "complexity": 13,
-        "line_coverage": 86.95652173913044,
-        "crap": 13.375030821073395,
+        "line": 31,
+        "complexity": 14,
+        "line_coverage": 84,
+        "crap": 14.802816,
         "contract_coverage": 100,
-        "gaze_crap": 13,
+        "gaze_crap": 14,
         "quadrant": "Q1_Safe"
       }
     ],
     "recommended_actions": [
-      {
-        "function": "(*MockPolicySource).CopyPolicy",
-        "package": "cachetest",
-        "file": "/Users/hbraswel/github/complytime/complyctl/internal/cache/cachetest/mock_source.go",
-        "line": 73,
-        "fix_strategy": "add_tests",
-        "crap": 110,
-        "complexity": 10
-      },
       {
         "function": "ShowPlainTable",
         "package": "terminal",
@@ -3900,6 +3909,15 @@
         "package": "cli",
         "file": "/Users/hbraswel/github/complytime/complyctl/cmd/complyctl/cli/init.go",
         "line": 153,
+        "fix_strategy": "add_tests",
+        "crap": 110,
+        "complexity": 10
+      },
+      {
+        "function": "(*MockPolicySource).CopyPolicy",
+        "package": "cachetest",
+        "file": "/Users/hbraswel/github/complytime/complyctl/internal/cache/cachetest/mock_source.go",
+        "line": 73,
         "fix_strategy": "add_tests",
         "crap": 110,
         "complexity": 10
@@ -3926,34 +3944,16 @@
         "function": "CheckProviders",
         "package": "doctor",
         "file": "/Users/hbraswel/github/complytime/complyctl/internal/doctor/doctor.go",
-        "line": 134,
+        "line": 136,
         "fix_strategy": "add_tests",
         "crap": 72,
         "complexity": 8
       },
       {
-        "function": "InstallTestPlugin",
-        "package": "behavioral",
-        "file": "/Users/hbraswel/github/complytime/complyctl/tests/behavioral/reusable_steps.go",
-        "line": 57,
-        "fix_strategy": "add_tests",
-        "crap": 56,
-        "complexity": 7
-      },
-      {
-        "function": "OSCALResultProduced",
-        "package": "behavioral",
-        "file": "/Users/hbraswel/github/complytime/complyctl/tests/behavioral/audit.go",
-        "line": 48,
-        "fix_strategy": "add_tests",
-        "crap": 56,
-        "complexity": 7
-      },
-      {
-        "function": "PluginBinaryIntegrityCheck",
-        "package": "behavioral",
-        "file": "/Users/hbraswel/github/complytime/complyctl/tests/behavioral/plugin_security.go",
-        "line": 67,
+        "function": "(*Cache).ListPolicies",
+        "package": "cache",
+        "file": "/Users/hbraswel/github/complytime/complyctl/internal/cache/cache.go",
+        "line": 50,
         "fix_strategy": "add_tests",
         "crap": 56,
         "complexity": 7
@@ -3968,10 +3968,28 @@
         "complexity": 7
       },
       {
-        "function": "(*Cache).ListPolicies",
-        "package": "cache",
-        "file": "/Users/hbraswel/github/complytime/complyctl/internal/cache/cache.go",
-        "line": 50,
+        "function": "InstallTestPlugin",
+        "package": "behavioral",
+        "file": "/Users/hbraswel/github/complytime/complyctl/tests/behavioral/reusable_steps.go",
+        "line": 57,
+        "fix_strategy": "add_tests",
+        "crap": 56,
+        "complexity": 7
+      },
+      {
+        "function": "PluginBinaryIntegrityCheck",
+        "package": "behavioral",
+        "file": "/Users/hbraswel/github/complytime/complyctl/tests/behavioral/plugin_security.go",
+        "line": 67,
+        "fix_strategy": "add_tests",
+        "crap": 56,
+        "complexity": 7
+      },
+      {
+        "function": "OSCALResultProduced",
+        "package": "behavioral",
+        "file": "/Users/hbraswel/github/complytime/complyctl/tests/behavioral/audit.go",
+        "line": 48,
         "fix_strategy": "add_tests",
         "crap": 56,
         "complexity": 7
@@ -3986,19 +4004,28 @@
         "complexity": 6
       },
       {
-        "function": "registerOCIRoutes",
-        "package": "main",
-        "file": "/Users/hbraswel/github/complytime/complyctl/cmd/mock-oci-registry/main.go",
-        "line": 83,
+        "function": "HTTPSchemeRejected",
+        "package": "behavioral",
+        "file": "/Users/hbraswel/github/complytime/complyctl/tests/behavioral/transport_security.go",
+        "line": 17,
         "fix_strategy": "add_tests",
         "crap": 42,
         "complexity": 6
       },
       {
-        "function": "HTTPSchemeRejected",
-        "package": "behavioral",
-        "file": "/Users/hbraswel/github/complytime/complyctl/tests/behavioral/transport_security.go",
-        "line": 17,
+        "function": "(*Client).fetchVersion",
+        "package": "registry",
+        "file": "/Users/hbraswel/github/complytime/complyctl/internal/registry/client.go",
+        "line": 118,
+        "fix_strategy": "add_tests",
+        "crap": 42,
+        "complexity": 6
+      },
+      {
+        "function": "registerOCIRoutes",
+        "package": "main",
+        "file": "/Users/hbraswel/github/complytime/complyctl/cmd/mock-oci-registry/main.go",
+        "line": 83,
         "fix_strategy": "add_tests",
         "crap": 42,
         "complexity": 6
@@ -4013,15 +4040,6 @@
         "complexity": 6
       },
       {
-        "function": "resolveComplypackRef",
-        "package": "cli",
-        "file": "/Users/hbraswel/github/complytime/complyctl/cmd/complyctl/cli/scan.go",
-        "line": 912,
-        "fix_strategy": "add_tests",
-        "crap": 33.83771600300525,
-        "complexity": 7
-      },
-      {
         "function": "UnsetEnvVarFails",
         "package": "behavioral",
         "file": "/Users/hbraswel/github/complytime/complyctl/tests/behavioral/credential_protection.go",
@@ -4031,28 +4049,28 @@
         "complexity": 5
       },
       {
-        "function": "(*grpcServer).Scan",
-        "package": "provider",
-        "file": "/Users/hbraswel/github/complytime/complyctl/pkg/provider/server.go",
-        "line": 61,
-        "fix_strategy": "add_tests",
-        "crap": 30,
-        "complexity": 5
-      },
-      {
-        "function": "HTTPSSchemeNoPlainHTTP",
-        "package": "behavioral",
-        "file": "/Users/hbraswel/github/complytime/complyctl/tests/behavioral/transport_security.go",
-        "line": 48,
-        "fix_strategy": "add_tests",
-        "crap": 30,
-        "complexity": 5
-      },
-      {
         "function": "EvaluatorMismatchRejected",
         "package": "behavioral",
         "file": "/Users/hbraswel/github/complytime/complyctl/tests/behavioral/plugin_security.go",
         "line": 36,
+        "fix_strategy": "add_tests",
+        "crap": 30,
+        "complexity": 5
+      },
+      {
+        "function": "LogCredentialRedaction",
+        "package": "behavioral",
+        "file": "/Users/hbraswel/github/complytime/complyctl/tests/behavioral/log_security.go",
+        "line": 16,
+        "fix_strategy": "add_tests",
+        "crap": 30,
+        "complexity": 5
+      },
+      {
+        "function": "EnvVarResolution",
+        "package": "behavioral",
+        "file": "/Users/hbraswel/github/complytime/complyctl/tests/behavioral/credential_protection.go",
+        "line": 54,
         "fix_strategy": "add_tests",
         "crap": 30,
         "complexity": 5

--- a/.gaze/baseline.json
+++ b/.gaze/baseline.json
@@ -14,7 +14,7 @@
       "package": "main",
       "function": "runEvaluations",
       "file": "cmd/behavioral-report/main.go",
-      "line": 103,
+      "line": 104,
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
@@ -24,7 +24,7 @@
       "package": "main",
       "function": "writeEvaluationLog",
       "file": "cmd/behavioral-report/main.go",
-      "line": 155,
+      "line": 156,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -33,7 +33,7 @@
       "package": "main",
       "function": "writeSARIF",
       "file": "cmd/behavioral-report/main.go",
-      "line": 168,
+      "line": 169,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -42,7 +42,7 @@
       "package": "main",
       "function": "printSummary",
       "file": "cmd/behavioral-report/main.go",
-      "line": 181,
+      "line": 182,
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
@@ -52,7 +52,7 @@
       "package": "main",
       "function": "sortedKeys",
       "file": "cmd/behavioral-report/main.go",
-      "line": 199,
+      "line": 200,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -61,7 +61,7 @@
       "package": "main",
       "function": "toFileURI",
       "file": "cmd/behavioral-report/main.go",
-      "line": 208,
+      "line": 209,
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
@@ -292,7 +292,7 @@
       "line": 190,
       "complexity": 6,
       "line_coverage": 30,
-      "crap": 18.348,
+      "crap": 18.347999999999995,
       "fix_strategy": "add_tests"
     },
     {
@@ -368,7 +368,7 @@
       "line": 26,
       "complexity": 4,
       "line_coverage": 41.666666666666664,
-      "crap": 7.175925925925927
+      "crap": 7.1759259259259265
     },
     {
       "package": "cli",
@@ -413,7 +413,11 @@
       "line": 24,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "no_effects_detected"
     },
     {
       "package": "cli",
@@ -422,7 +426,10 @@
       "line": 31,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 50,
+      "gaze_crap": 1.125,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cli",
@@ -440,7 +447,7 @@
       "line": 48,
       "complexity": 4,
       "line_coverage": 77.77777777777777,
-      "crap": 4.175582990397805
+      "crap": 4.175582990397806
     },
     {
       "package": "cli",
@@ -485,7 +492,10 @@
       "line": 33,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cli",
@@ -494,7 +504,10 @@
       "line": 38,
       "complexity": 2,
       "line_coverage": 100,
-      "crap": 2
+      "crap": 2,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cli",
@@ -503,7 +516,10 @@
       "line": 45,
       "complexity": 5,
       "line_coverage": 70.58823529411765,
-      "crap": 5.636067575819254
+      "crap": 5.636067575819255,
+      "contract_coverage": 100,
+      "gaze_crap": 5,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cli",
@@ -539,7 +555,10 @@
       "line": 86,
       "complexity": 2,
       "line_coverage": 92.3076923076923,
-      "crap": 2.0018206645425582
+      "crap": 2.0018206645425582,
+      "contract_coverage": 100,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cli",
@@ -620,7 +639,7 @@
       "line": 245,
       "complexity": 5,
       "line_coverage": 23.80952380952381,
-      "crap": 16.057121261202894,
+      "crap": 16.05712126120289,
       "fix_strategy": "add_tests"
     },
     {
@@ -700,7 +719,7 @@
       "package": "cli",
       "function": "processScanOutput",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 386,
+      "line": 388,
       "complexity": 3,
       "line_coverage": 87.5,
       "crap": 3.017578125
@@ -709,7 +728,7 @@
       "package": "cli",
       "function": "reportOperationalWarnings",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 404,
+      "line": 406,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -718,7 +737,7 @@
       "package": "cli",
       "function": "checkOperationalErrors",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 413,
+      "line": 415,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -727,7 +746,7 @@
       "package": "cli",
       "function": "buildEvaluators",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 424,
+      "line": 426,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -736,7 +755,7 @@
       "package": "cli",
       "function": "filterTargetByID",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 443,
+      "line": 445,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -745,7 +764,7 @@
       "package": "cli",
       "function": "filterTargetsForPolicy",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 452,
+      "line": 454,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -754,7 +773,7 @@
       "package": "cli",
       "function": "checkGenerationFreshness",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 462,
+      "line": 464,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -763,7 +782,7 @@
       "package": "cli",
       "function": "needsRegeneration",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 477,
+      "line": 479,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -772,7 +791,7 @@
       "package": "cli",
       "function": "evaluatorArtifactsExist",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 494,
+      "line": 496,
       "complexity": 6,
       "line_coverage": 100,
       "crap": 6
@@ -781,7 +800,7 @@
       "package": "cli",
       "function": "runGeneration",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 509,
+      "line": 511,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -790,7 +809,7 @@
       "package": "cli",
       "function": "generateForAllTargets",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 525,
+      "line": 527,
       "complexity": 5,
       "line_coverage": 36.36363636363637,
       "crap": 11.442524417731029
@@ -799,7 +818,7 @@
       "package": "cli",
       "function": "executeScan",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 545,
+      "line": 547,
       "complexity": 1,
       "line_coverage": 0,
       "crap": 2
@@ -808,7 +827,7 @@
       "package": "cli",
       "function": "scanAllTargets",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 553,
+      "line": 555,
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
@@ -818,7 +837,7 @@
       "package": "cli",
       "function": "scanSingleTarget",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 579,
+      "line": 581,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -827,7 +846,7 @@
       "package": "cli",
       "function": "writeScanReports",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 598,
+      "line": 600,
       "complexity": 3,
       "line_coverage": 71.42857142857143,
       "crap": 3.2099125364431487
@@ -836,7 +855,7 @@
       "package": "cli",
       "function": "writeFormatReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 612,
+      "line": 614,
       "complexity": 4,
       "line_coverage": 40,
       "crap": 7.4559999999999995
@@ -845,7 +864,7 @@
       "package": "cli",
       "function": "writePrettyReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 624,
+      "line": 626,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -854,7 +873,7 @@
       "package": "cli",
       "function": "writeSARIFReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 635,
+      "line": 637,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -863,7 +882,7 @@
       "package": "cli",
       "function": "writeOSCALReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 644,
+      "line": 646,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -872,7 +891,7 @@
       "package": "cli",
       "function": "(*scanOptions).runExport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 655,
+      "line": 657,
       "complexity": 5,
       "line_coverage": 16.666666666666668,
       "crap": 19.467592592592588,
@@ -882,7 +901,7 @@
       "package": "cli",
       "function": "authRequired",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 681,
+      "line": 683,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -891,7 +910,7 @@
       "package": "cli",
       "function": "validateAuthCredentials",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 685,
+      "line": 687,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -900,7 +919,7 @@
       "package": "cli",
       "function": "resolveCollectorAuth",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 692,
+      "line": 694,
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
@@ -910,7 +929,7 @@
       "package": "cli",
       "function": "exportToProviders",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 707,
+      "line": 709,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -919,7 +938,7 @@
       "package": "cli",
       "function": "exportSingleProvider",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 715,
+      "line": 717,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -928,7 +947,7 @@
       "package": "cli",
       "function": "resolveOIDCToken",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 732,
+      "line": 734,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -937,7 +956,7 @@
       "package": "cli",
       "function": "formatExportSummary",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 745,
+      "line": 747,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -946,7 +965,7 @@
       "package": "cli",
       "function": "appendExportRow",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 765,
+      "line": 767,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -955,7 +974,7 @@
       "package": "cli",
       "function": "appendResponseRow",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 779,
+      "line": 781,
       "complexity": 3,
       "line_coverage": 85.71428571428571,
       "crap": 3.0262390670553936
@@ -964,7 +983,7 @@
       "package": "cli",
       "function": "exportResponseStatus",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 792,
+      "line": 794,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -973,7 +992,7 @@
       "package": "cli",
       "function": "countExportFailures",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 814,
+      "line": 816,
       "complexity": 7,
       "line_coverage": 100,
       "crap": 7
@@ -982,7 +1001,7 @@
       "package": "cli",
       "function": "injectWorkspaceIntoTargets",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 835,
+      "line": 837,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -991,7 +1010,7 @@
       "package": "cli",
       "function": "extractReqToControlMap",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 846,
+      "line": 848,
       "complexity": 6,
       "line_coverage": 90,
       "crap": 6.036
@@ -1000,7 +1019,7 @@
       "package": "cli",
       "function": "extractPlanToReqMap",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 867,
+      "line": 869,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -1009,10 +1028,29 @@
       "package": "cli",
       "function": "resolveAssessmentIDs",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 882,
+      "line": 884,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
+    },
+    {
+      "package": "cli",
+      "function": "reverseMap",
+      "file": "cmd/complyctl/cli/scan.go",
+      "line": 894,
+      "complexity": 3,
+      "line_coverage": 83.33333333333333,
+      "crap": 3.0416666666666665
+    },
+    {
+      "package": "cli",
+      "function": "resolveComplypackRef",
+      "file": "cmd/complyctl/cli/scan.go",
+      "line": 912,
+      "complexity": 7,
+      "line_coverage": 18.181818181818183,
+      "crap": 33.83771600300525,
+      "fix_strategy": "add_tests"
     },
     {
       "package": "cli",
@@ -1276,7 +1314,10 @@
       "line": 19,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
@@ -1285,7 +1326,10 @@
       "line": 25,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
@@ -1294,7 +1338,10 @@
       "line": 30,
       "complexity": 3,
       "line_coverage": 71.42857142857143,
-      "crap": 3.2099125364431487
+      "crap": 3.2099125364431487,
+      "contract_coverage": 50,
+      "gaze_crap": 4.125,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
@@ -1303,7 +1350,10 @@
       "line": 44,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
@@ -1322,7 +1372,10 @@
       "line": 77,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cachetest",
@@ -1414,7 +1467,10 @@
       "line": 38,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
@@ -1423,7 +1479,10 @@
       "line": 48,
       "complexity": 7,
       "line_coverage": 81.81818181818181,
-      "crap": 7.294515401953419
+      "crap": 7.294515401953419,
+      "contract_coverage": 100,
+      "gaze_crap": 7,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
@@ -1441,7 +1500,10 @@
       "line": 77,
       "complexity": 13,
       "line_coverage": 66.66666666666667,
-      "crap": 19.259259259259252,
+      "crap": 19.259259259259256,
+      "contract_coverage": 100,
+      "gaze_crap": 13,
+      "quadrant": "Q2_ComplexButTested",
       "fix_strategy": "add_tests"
     },
     {
@@ -1451,7 +1513,10 @@
       "line": 149,
       "complexity": 6,
       "line_coverage": 75,
-      "crap": 6.5625
+      "crap": 6.5625,
+      "contract_coverage": 100,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
@@ -1460,7 +1525,10 @@
       "line": 190,
       "complexity": 10,
       "line_coverage": 83.33333333333333,
-      "crap": 10.462962962962964
+      "crap": 10.462962962962964,
+      "contract_coverage": 100,
+      "gaze_crap": 10,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
@@ -1469,7 +1537,10 @@
       "line": 232,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
@@ -1505,7 +1576,10 @@
       "line": 72,
       "complexity": 5,
       "line_coverage": 85.71428571428571,
-      "crap": 5.072886297376093
+      "crap": 5.072886297376093,
+      "contract_coverage": 100,
+      "gaze_crap": 5,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
@@ -1514,7 +1588,10 @@
       "line": 26,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
@@ -1524,6 +1601,9 @@
       "complexity": 15,
       "line_coverage": 85.29411764705883,
       "crap": 15.715576022796661,
+      "contract_coverage": 100,
+      "gaze_crap": 15,
+      "quadrant": "Q4_Dangerous",
       "fix_strategy": "decompose"
     },
     {
@@ -1557,16 +1637,19 @@
       "package": "cache",
       "function": "LoadState",
       "file": "internal/cache/state.go",
-      "line": 32,
+      "line": 33,
       "complexity": 4,
       "line_coverage": 81.81818181818181,
-      "crap": 4.096168294515402
+      "crap": 4.096168294515402,
+      "contract_coverage": 100,
+      "gaze_crap": 4,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
       "function": "initStateMaps",
       "file": "internal/cache/state.go",
-      "line": 60,
+      "line": 61,
       "complexity": 3,
       "line_coverage": 75,
       "crap": 3.140625
@@ -1575,46 +1658,61 @@
       "package": "cache",
       "function": "SaveState",
       "file": "internal/cache/state.go",
-      "line": 70,
+      "line": 71,
       "complexity": 4,
       "line_coverage": 66.66666666666667,
-      "crap": 4.592592592592593
+      "crap": 4.592592592592593,
+      "contract_coverage": 100,
+      "gaze_crap": 4,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
       "function": "(*State).UpdatePolicyState",
       "file": "internal/cache/state.go",
-      "line": 90,
+      "line": 91,
       "complexity": 2,
       "line_coverage": 75,
-      "crap": 2.0625
+      "crap": 2.0625,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
       "function": "(*State).GetPolicyState",
       "file": "internal/cache/state.go",
-      "line": 103,
+      "line": 104,
       "complexity": 2,
       "line_coverage": 75,
-      "crap": 2.0625
+      "crap": 2.0625,
+      "contract_coverage": 100,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
       "function": "(*State).UpdateComplypackState",
       "file": "internal/cache/state.go",
-      "line": 113,
+      "line": 115,
       "complexity": 2,
       "line_coverage": 75,
-      "crap": 2.0625
+      "crap": 2.0625,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
       "function": "(*State).GetComplypackState",
       "file": "internal/cache/state.go",
-      "line": 127,
+      "line": 130,
       "complexity": 2,
       "line_coverage": 75,
-      "crap": 2.0625
+      "crap": 2.0625,
+      "contract_coverage": 100,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
@@ -1623,16 +1721,22 @@
       "line": 17,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
       "function": "(*Sync).SyncPolicy",
       "file": "internal/cache/sync.go",
-      "line": 31,
-      "complexity": 14,
-      "line_coverage": 84,
-      "crap": 14.802816
+      "line": 28,
+      "complexity": 13,
+      "line_coverage": 86.95652173913044,
+      "crap": 13.375030821073395,
+      "contract_coverage": 100,
+      "gaze_crap": 13,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "complytime",
@@ -1686,7 +1790,10 @@
       "line": 165,
       "complexity": 5,
       "line_coverage": 63.63636363636363,
-      "crap": 6.202103681442525
+      "crap": 6.202103681442525,
+      "contract_coverage": 50,
+      "gaze_crap": 8.125,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "complytime",
@@ -1722,7 +1829,10 @@
       "line": 247,
       "complexity": 3,
       "line_coverage": 0,
-      "crap": 12
+      "crap": 12,
+      "contract_coverage": 100,
+      "gaze_crap": 3,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "complytime",
@@ -1758,7 +1868,10 @@
       "line": 90,
       "complexity": 2,
       "line_coverage": 100,
-      "crap": 2
+      "crap": 2,
+      "contract_coverage": 100,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "complytime",
@@ -1803,7 +1916,15 @@
       "line": 25,
       "complexity": 3,
       "line_coverage": 100,
-      "crap": 3
+      "crap": 3,
+      "contract_coverage": 0,
+      "gaze_crap": 12,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        69,
+        69
+      ]
     },
     {
       "package": "complytime",
@@ -1812,7 +1933,10 @@
       "line": 40,
       "complexity": 2,
       "line_coverage": 100,
-      "crap": 2
+      "crap": 2,
+      "contract_coverage": 50,
+      "gaze_crap": 2.5,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "complytime",
@@ -1830,7 +1954,10 @@
       "line": 59,
       "complexity": 2,
       "line_coverage": 66.66666666666667,
-      "crap": 2.148148148148148
+      "crap": 2.148148148148148,
+      "contract_coverage": 100,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "complytime",
@@ -1839,7 +1966,10 @@
       "line": 67,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "complytime",
@@ -1857,7 +1987,10 @@
       "line": 77,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "complytime",
@@ -1866,7 +1999,10 @@
       "line": 83,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "complytime",
@@ -1875,7 +2011,10 @@
       "line": 88,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "complytime",
@@ -1884,7 +2023,10 @@
       "line": 93,
       "complexity": 2,
       "line_coverage": 75,
-      "crap": 2.0625
+      "crap": 2.0625,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "complytime",
@@ -1893,7 +2035,10 @@
       "line": 108,
       "complexity": 13,
       "line_coverage": 87.5,
-      "crap": 13.330078125
+      "crap": 13.330078125,
+      "contract_coverage": 100,
+      "gaze_crap": 13,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "complytime",
@@ -1902,7 +2047,10 @@
       "line": 154,
       "complexity": 3,
       "line_coverage": 100,
-      "crap": 3
+      "crap": 3,
+      "contract_coverage": 100,
+      "gaze_crap": 3,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "complytime",
@@ -1929,7 +2077,10 @@
       "line": 94,
       "complexity": 4,
       "line_coverage": 25,
-      "crap": 10.75
+      "crap": 10.75,
+      "contract_coverage": 100,
+      "gaze_crap": 4,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "doctor",
@@ -1945,19 +2096,22 @@
       "package": "doctor",
       "function": "CheckPolicyVersions",
       "file": "internal/doctor/doctor.go",
-      "line": 221,
-      "complexity": 15,
+      "line": 219,
+      "complexity": 11,
       "line_coverage": 100,
-      "crap": 15
+      "crap": 11,
+      "contract_coverage": 100,
+      "gaze_crap": 11,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "doctor",
       "function": "resolvePinnedFallback",
       "file": "internal/doctor/doctor.go",
-      "line": 317,
-      "complexity": 5,
-      "line_coverage": 90,
-      "crap": 5.025
+      "line": 294,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
     },
     {
       "package": "doctor",
@@ -1966,7 +2120,10 @@
       "line": 322,
       "complexity": 5,
       "line_coverage": 90.9090909090909,
-      "crap": 5.018782870022539
+      "crap": 5.018782870022539,
+      "contract_coverage": 100,
+      "gaze_crap": 5,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "doctor",
@@ -1976,6 +2133,9 @@
       "complexity": 34,
       "line_coverage": 87.8048780487805,
       "crap": 36.09660335746724,
+      "contract_coverage": 100,
+      "gaze_crap": 34,
+      "quadrant": "Q4_Dangerous",
       "fix_strategy": "decompose"
     },
     {
@@ -1985,7 +2145,10 @@
       "line": 545,
       "complexity": 11,
       "line_coverage": 92.85714285714286,
-      "crap": 11.044096209912537
+      "crap": 11.044096209912537,
+      "contract_coverage": 100,
+      "gaze_crap": 11,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "doctor",
@@ -2027,10 +2190,13 @@
       "package": "doctor",
       "function": "CheckCollector",
       "file": "internal/doctor/doctor.go",
-      "line": 717,
-      "complexity": 6,
+      "line": 680,
+      "complexity": 5,
       "line_coverage": 100,
-      "crap": 6
+      "crap": 5,
+      "contract_coverage": 100,
+      "gaze_crap": 5,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "doctor",
@@ -2039,7 +2205,10 @@
       "line": 718,
       "complexity": 12,
       "line_coverage": 81.25,
-      "crap": 12.94921875
+      "crap": 12.94921875,
+      "contract_coverage": 100,
+      "gaze_crap": 12,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "doctor",
@@ -2081,16 +2250,19 @@
       "package": "output",
       "function": "NewEvaluator",
       "file": "internal/output/evaluator.go",
-      "line": 30,
-      "complexity": 2,
+      "line": 39,
+      "complexity": 3,
       "line_coverage": 100,
-      "crap": 2
+      "crap": 3,
+      "contract_coverage": 0,
+      "gaze_crap": 12,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "output",
       "function": "(*Evaluator).TargetID",
       "file": "internal/output/evaluator.go",
-      "line": 43,
+      "line": 58,
       "complexity": 1,
       "line_coverage": 0,
       "crap": 2
@@ -2099,7 +2271,7 @@
       "package": "output",
       "function": "(*Evaluator).AddTarget",
       "file": "internal/output/evaluator.go",
-      "line": 49,
+      "line": 64,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -2108,7 +2280,7 @@
       "package": "output",
       "function": "(*Evaluator).GemaraLog",
       "file": "internal/output/evaluator.go",
-      "line": 78,
+      "line": 94,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -2117,16 +2289,16 @@
       "package": "output",
       "function": "(*Evaluator).Write",
       "file": "internal/output/evaluator.go",
-      "line": 112,
+      "line": 131,
       "complexity": 4,
-      "line_coverage": 72.72727272727273,
-      "crap": 4.324567993989482
+      "line_coverage": 75,
+      "crap": 4.25
     },
     {
       "package": "output",
       "function": "(*Evaluator).resolveControl",
       "file": "internal/output/evaluator.go",
-      "line": 134,
+      "line": 154,
       "complexity": 2,
       "line_coverage": 66.66666666666667,
       "crap": 2.148148148148148
@@ -2135,19 +2307,55 @@
       "package": "output",
       "function": "(*Evaluator).providerToGemaraAssessment",
       "file": "internal/output/evaluator.go",
-      "line": 141,
-      "complexity": 6,
+      "line": 161,
+      "complexity": 8,
       "line_coverage": 100,
-      "crap": 6
+      "crap": 8
+    },
+    {
+      "package": "output",
+      "function": "providerStepToGemara",
+      "file": "internal/output/evaluator.go",
+      "line": 215,
+      "complexity": 1,
+      "line_coverage": 100,
+      "crap": 1
+    },
+    {
+      "package": "output",
+      "function": "providerStepsToGemara",
+      "file": "internal/output/evaluator.go",
+      "line": 225,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
     },
     {
       "package": "output",
       "function": "providerConfidenceToGemara",
       "file": "internal/output/evaluator.go",
-      "line": 174,
+      "line": 236,
       "complexity": 5,
-      "line_coverage": 33.333333333333336,
-      "crap": 12.407407407407405
+      "line_coverage": 83.33333333333333,
+      "crap": 5.1157407407407405
+    },
+    {
+      "package": "output",
+      "function": "formatStepIdentity",
+      "file": "internal/output/evaluator.go",
+      "line": 288,
+      "complexity": 3,
+      "line_coverage": 100,
+      "crap": 3
+    },
+    {
+      "package": "output",
+      "function": "(*Evaluator).toSerializable",
+      "file": "internal/output/evaluator.go",
+      "line": 297,
+      "complexity": 5,
+      "line_coverage": 100,
+      "crap": 5
     },
     {
       "package": "output",
@@ -2245,8 +2453,8 @@
       "file": "internal/output/sarif.go",
       "line": 42,
       "complexity": 5,
-      "line_coverage": 50,
-      "crap": 8.125
+      "line_coverage": 100,
+      "crap": 5
     },
     {
       "package": "output",
@@ -2282,7 +2490,10 @@
       "line": 59,
       "complexity": 9,
       "line_coverage": 88.88888888888889,
-      "crap": 9.11111111111111
+      "crap": 9.11111111111111,
+      "contract_coverage": 100,
+      "gaze_crap": 9,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "output",
@@ -2291,7 +2502,10 @@
       "line": 144,
       "complexity": 4,
       "line_coverage": 100,
-      "crap": 4
+      "crap": 4,
+      "contract_coverage": 100,
+      "gaze_crap": 4,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
@@ -2300,7 +2514,10 @@
       "line": 19,
       "complexity": 2,
       "line_coverage": 100,
-      "crap": 2
+      "crap": 2,
+      "contract_coverage": 100,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
@@ -2309,7 +2526,10 @@
       "line": 36,
       "complexity": 3,
       "line_coverage": 100,
-      "crap": 3
+      "crap": 3,
+      "contract_coverage": 50,
+      "gaze_crap": 4.125,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
@@ -2318,7 +2538,10 @@
       "line": 29,
       "complexity": 4,
       "line_coverage": 70,
-      "crap": 4.432
+      "crap": 4.432,
+      "contract_coverage": 100,
+      "gaze_crap": 4,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
@@ -2327,7 +2550,10 @@
       "line": 49,
       "complexity": 4,
       "line_coverage": 90,
-      "crap": 4.016
+      "crap": 4.016,
+      "contract_coverage": 100,
+      "gaze_crap": 4,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
@@ -2336,7 +2562,10 @@
       "line": 68,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
@@ -2345,7 +2574,10 @@
       "line": 73,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
@@ -2354,7 +2586,10 @@
       "line": 24,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
@@ -2363,7 +2598,10 @@
       "line": 33,
       "complexity": 5,
       "line_coverage": 81.81818181818181,
-      "crap": 5.150262960180315
+      "crap": 5.150262960180315,
+      "contract_coverage": 50,
+      "gaze_crap": 8.125,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
@@ -2372,7 +2610,10 @@
       "line": 59,
       "complexity": 10,
       "line_coverage": 87.5,
-      "crap": 10.1953125
+      "crap": 10.1953125,
+      "contract_coverage": 100,
+      "gaze_crap": 10,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
@@ -2390,7 +2631,10 @@
       "line": 113,
       "complexity": 12,
       "line_coverage": 74.07407407407408,
-      "crap": 14.509373571101964
+      "crap": 14.509373571101964,
+      "contract_coverage": 50,
+      "gaze_crap": 30,
+      "quadrant": "Q3_SimpleButUnderspecified"
     },
     {
       "package": "policy",
@@ -2399,7 +2643,10 @@
       "line": 162,
       "complexity": 5,
       "line_coverage": 77.77777777777777,
-      "crap": 5.274348422496571
+      "crap": 5.274348422496571,
+      "contract_coverage": 100,
+      "gaze_crap": 5,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
@@ -2417,7 +2664,10 @@
       "line": 205,
       "complexity": 4,
       "line_coverage": 87.5,
-      "crap": 4.03125
+      "crap": 4.03125,
+      "contract_coverage": 100,
+      "gaze_crap": 4,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
@@ -2426,7 +2676,10 @@
       "line": 221,
       "complexity": 4,
       "line_coverage": 84.61538461538461,
-      "crap": 4.058261265361857
+      "crap": 4.058261265361857,
+      "contract_coverage": 100,
+      "gaze_crap": 4,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
@@ -2445,7 +2698,10 @@
       "line": 76,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
@@ -2463,7 +2719,10 @@
       "line": 91,
       "complexity": 6,
       "line_coverage": 100,
-      "crap": 6
+      "crap": 6,
+      "contract_coverage": 100,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
@@ -2551,9 +2810,9 @@
       "function": "(*Client).DefinitionVersion",
       "file": "internal/registry/client.go",
       "line": 47,
-      "complexity": 6,
-      "line_coverage": 0,
-      "crap": 11.442524417731029
+      "complexity": 4,
+      "line_coverage": 44.44444444444444,
+      "crap": 6.743484224965707
     },
     {
       "package": "registry",
@@ -2595,10 +2854,10 @@
       "package": "registry",
       "function": "(*Client).fetchVersion",
       "file": "internal/registry/client.go",
-      "line": 115,
-      "complexity": 6,
+      "line": 109,
+      "complexity": 5,
       "line_coverage": 0,
-      "crap": 42,
+      "crap": 30,
       "fix_strategy": "add_tests"
     },
     {
@@ -2644,7 +2903,10 @@
       "line": 49,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "terminal",
@@ -2690,7 +2952,10 @@
       "line": 40,
       "complexity": 4,
       "line_coverage": 90,
-      "crap": 4.016
+      "crap": 4.016,
+      "contract_coverage": 100,
+      "gaze_crap": 4,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "log",
@@ -2972,7 +3237,10 @@
       "line": 26,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "provider",
@@ -2981,7 +3249,10 @@
       "line": 35,
       "complexity": 6,
       "line_coverage": 73.33333333333333,
-      "crap": 6.682666666666667
+      "crap": 6.682666666666667,
+      "contract_coverage": 66.66666666666667,
+      "gaze_crap": 7.333333333333332,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "provider",
@@ -3468,14 +3739,24 @@
     }
   ],
   "summary": {
-    "total_functions": 379,
-    "avg_complexity": 3.490765171503958,
-    "avg_line_coverage": 46.98979941439098,
-    "avg_crap": 10.106567370025402,
-    "crapload": 55,
+    "total_functions": 385,
+    "avg_complexity": 3.501298701298701,
+    "avg_line_coverage": 47.82577105673262,
+    "avg_crap": 10.056564107139334,
+    "crapload": 56,
     "crap_threshold": 15,
+    "gaze_crapload": 3,
+    "gaze_crap_threshold": 15,
+    "avg_gaze_crap": 5.57797619047619,
+    "avg_contract_coverage": 74.52380952380953,
+    "quadrant_counts": {
+      "Q1_Safe": 66,
+      "Q2_ComplexButTested": 1,
+      "Q3_SimpleButUnderspecified": 1,
+      "Q4_Dangerous": 2
+    },
     "fix_strategy_counts": {
-      "add_tests": 52,
+      "add_tests": 53,
       "decompose": 2,
       "decompose_and_test": 1
     },
@@ -3489,6 +3770,16 @@
         "line_coverage": 0,
         "crap": 380,
         "fix_strategy": "decompose_and_test"
+      },
+      {
+        "package": "cachetest",
+        "function": "(*MockPolicySource).CopyPolicy",
+        "file": "internal/cache/cachetest/mock_source.go",
+        "line": 73,
+        "complexity": 10,
+        "line_coverage": 0,
+        "crap": 110,
+        "fix_strategy": "add_tests"
       },
       {
         "package": "cli",
@@ -3505,16 +3796,6 @@
         "function": "ShowPlainTable",
         "file": "internal/terminal/table.go",
         "line": 19,
-        "complexity": 10,
-        "line_coverage": 0,
-        "crap": 110,
-        "fix_strategy": "add_tests"
-      },
-      {
-        "package": "cachetest",
-        "function": "(*MockPolicySource).CopyPolicy",
-        "file": "internal/cache/cachetest/mock_source.go",
-        "line": 73,
         "complexity": 10,
         "line_coverage": 0,
         "crap": 110,
@@ -3531,21 +3812,85 @@
         "fix_strategy": "add_tests"
       }
     ],
+    "worst_gaze_crap": [
+      {
+        "package": "doctor",
+        "function": "CheckVariables",
+        "file": "internal/doctor/doctor.go",
+        "line": 377,
+        "complexity": 34,
+        "line_coverage": 87.8048780487805,
+        "crap": 36.09660335746724,
+        "contract_coverage": 100,
+        "gaze_crap": 34,
+        "quadrant": "Q4_Dangerous",
+        "fix_strategy": "decompose"
+      },
+      {
+        "package": "policy",
+        "function": "(*Loader).LoadBundleFiles",
+        "file": "internal/policy/loader.go",
+        "line": 113,
+        "complexity": 12,
+        "line_coverage": 74.07407407407408,
+        "crap": 14.509373571101964,
+        "contract_coverage": 50,
+        "gaze_crap": 30,
+        "quadrant": "Q3_SimpleButUnderspecified"
+      },
+      {
+        "package": "cache",
+        "function": "(*ComplypackSync).SyncComplypack",
+        "file": "internal/cache/complypack_sync.go",
+        "line": 42,
+        "complexity": 15,
+        "line_coverage": 85.29411764705883,
+        "crap": 15.715576022796661,
+        "contract_coverage": 100,
+        "gaze_crap": 15,
+        "quadrant": "Q4_Dangerous",
+        "fix_strategy": "decompose"
+      },
+      {
+        "package": "complytime",
+        "function": "ResolveWorkspaceDir",
+        "file": "internal/complytime/workspace.go",
+        "line": 108,
+        "complexity": 13,
+        "line_coverage": 87.5,
+        "crap": 13.330078125,
+        "contract_coverage": 100,
+        "gaze_crap": 13,
+        "quadrant": "Q1_Safe"
+      },
+      {
+        "package": "cache",
+        "function": "(*Sync).SyncPolicy",
+        "file": "internal/cache/sync.go",
+        "line": 28,
+        "complexity": 13,
+        "line_coverage": 86.95652173913044,
+        "crap": 13.375030821073395,
+        "contract_coverage": 100,
+        "gaze_crap": 13,
+        "quadrant": "Q1_Safe"
+      }
+    ],
     "recommended_actions": [
       {
-        "function": "ShowPlainTable",
-        "package": "terminal",
-        "file": "internal/terminal/table.go",
-        "line": 19,
+        "function": "(*MockPolicySource).CopyPolicy",
+        "package": "cachetest",
+        "file": "/Users/hbraswel/github/complytime/complyctl/internal/cache/cachetest/mock_source.go",
+        "line": 73,
         "fix_strategy": "add_tests",
         "crap": 110,
         "complexity": 10
       },
       {
-        "function": "(*MockPolicySource).CopyPolicy",
-        "package": "cachetest",
-        "file": "internal/cache/cachetest/mock_source.go",
-        "line": 73,
+        "function": "ShowPlainTable",
+        "package": "terminal",
+        "file": "/Users/hbraswel/github/complytime/complyctl/internal/terminal/table.go",
+        "line": 19,
         "fix_strategy": "add_tests",
         "crap": 110,
         "complexity": 10
@@ -3553,7 +3898,7 @@
       {
         "function": "promptTargets",
         "package": "cli",
-        "file": "cmd/complyctl/cli/init.go",
+        "file": "/Users/hbraswel/github/complytime/complyctl/cmd/complyctl/cli/init.go",
         "line": 153,
         "fix_strategy": "add_tests",
         "crap": 110,
@@ -3562,7 +3907,7 @@
       {
         "function": "main",
         "package": "main",
-        "file": "cmd/behavioral-report/main.go",
+        "file": "/Users/hbraswel/github/complytime/complyctl/cmd/behavioral-report/main.go",
         "line": 28,
         "fix_strategy": "add_tests",
         "crap": 90,
@@ -3571,7 +3916,7 @@
       {
         "function": "DigestRecordedInState",
         "package": "behavioral",
-        "file": "tests/behavioral/supply_chain.go",
+        "file": "/Users/hbraswel/github/complytime/complyctl/tests/behavioral/supply_chain.go",
         "line": 50,
         "fix_strategy": "add_tests",
         "crap": 72,
@@ -3580,17 +3925,17 @@
       {
         "function": "CheckProviders",
         "package": "doctor",
-        "file": "internal/doctor/doctor.go",
+        "file": "/Users/hbraswel/github/complytime/complyctl/internal/doctor/doctor.go",
         "line": 134,
         "fix_strategy": "add_tests",
         "crap": 72,
         "complexity": 8
       },
       {
-        "function": "SignatureVerified",
+        "function": "InstallTestPlugin",
         "package": "behavioral",
-        "file": "tests/behavioral/supply_chain.go",
-        "line": 19,
+        "file": "/Users/hbraswel/github/complytime/complyctl/tests/behavioral/reusable_steps.go",
+        "line": 57,
         "fix_strategy": "add_tests",
         "crap": 56,
         "complexity": 7
@@ -3598,7 +3943,7 @@
       {
         "function": "OSCALResultProduced",
         "package": "behavioral",
-        "file": "tests/behavioral/audit.go",
+        "file": "/Users/hbraswel/github/complytime/complyctl/tests/behavioral/audit.go",
         "line": 48,
         "fix_strategy": "add_tests",
         "crap": 56,
@@ -3607,17 +3952,17 @@
       {
         "function": "PluginBinaryIntegrityCheck",
         "package": "behavioral",
-        "file": "tests/behavioral/plugin_security.go",
+        "file": "/Users/hbraswel/github/complytime/complyctl/tests/behavioral/plugin_security.go",
         "line": 67,
         "fix_strategy": "add_tests",
         "crap": 56,
         "complexity": 7
       },
       {
-        "function": "InstallTestPlugin",
+        "function": "SignatureVerified",
         "package": "behavioral",
-        "file": "tests/behavioral/reusable_steps.go",
-        "line": 57,
+        "file": "/Users/hbraswel/github/complytime/complyctl/tests/behavioral/supply_chain.go",
+        "line": 19,
         "fix_strategy": "add_tests",
         "crap": 56,
         "complexity": 7
@@ -3625,7 +3970,7 @@
       {
         "function": "(*Cache).ListPolicies",
         "package": "cache",
-        "file": "internal/cache/cache.go",
+        "file": "/Users/hbraswel/github/complytime/complyctl/internal/cache/cache.go",
         "line": 50,
         "fix_strategy": "add_tests",
         "crap": 56,
@@ -3634,7 +3979,7 @@
       {
         "function": "EvaluationLogProduced",
         "package": "behavioral",
-        "file": "tests/behavioral/audit.go",
+        "file": "/Users/hbraswel/github/complytime/complyctl/tests/behavioral/audit.go",
         "line": 17,
         "fix_strategy": "add_tests",
         "crap": 42,
@@ -3643,7 +3988,7 @@
       {
         "function": "registerOCIRoutes",
         "package": "main",
-        "file": "cmd/mock-oci-registry/main.go",
+        "file": "/Users/hbraswel/github/complytime/complyctl/cmd/mock-oci-registry/main.go",
         "line": 83,
         "fix_strategy": "add_tests",
         "crap": 42,
@@ -3652,7 +3997,7 @@
       {
         "function": "HTTPSchemeRejected",
         "package": "behavioral",
-        "file": "tests/behavioral/transport_security.go",
+        "file": "/Users/hbraswel/github/complytime/complyctl/tests/behavioral/transport_security.go",
         "line": 17,
         "fix_strategy": "add_tests",
         "crap": 42,
@@ -3661,26 +4006,35 @@
       {
         "function": "serveManifest",
         "package": "main",
-        "file": "cmd/mock-oci-registry/main.go",
+        "file": "/Users/hbraswel/github/complytime/complyctl/cmd/mock-oci-registry/main.go",
         "line": 161,
         "fix_strategy": "add_tests",
         "crap": 42,
         "complexity": 6
       },
       {
-        "function": "(*Loader).ListCachedPolicies",
-        "package": "policy",
-        "file": "internal/policy/loader.go",
-        "line": 245,
+        "function": "resolveComplypackRef",
+        "package": "cli",
+        "file": "/Users/hbraswel/github/complytime/complyctl/cmd/complyctl/cli/scan.go",
+        "line": 912,
+        "fix_strategy": "add_tests",
+        "crap": 33.83771600300525,
+        "complexity": 7
+      },
+      {
+        "function": "UnsetEnvVarFails",
+        "package": "behavioral",
+        "file": "/Users/hbraswel/github/complytime/complyctl/tests/behavioral/credential_protection.go",
+        "line": 17,
         "fix_strategy": "add_tests",
         "crap": 30,
         "complexity": 5
       },
       {
-        "function": "LogCredentialRedaction",
-        "package": "behavioral",
-        "file": "tests/behavioral/log_security.go",
-        "line": 16,
+        "function": "(*grpcServer).Scan",
+        "package": "provider",
+        "file": "/Users/hbraswel/github/complytime/complyctl/pkg/provider/server.go",
+        "line": 61,
         "fix_strategy": "add_tests",
         "crap": 30,
         "complexity": 5
@@ -3688,7 +4042,7 @@
       {
         "function": "HTTPSSchemeNoPlainHTTP",
         "package": "behavioral",
-        "file": "tests/behavioral/transport_security.go",
+        "file": "/Users/hbraswel/github/complytime/complyctl/tests/behavioral/transport_security.go",
         "line": 48,
         "fix_strategy": "add_tests",
         "crap": 30,
@@ -3697,35 +4051,12 @@
       {
         "function": "EvaluatorMismatchRejected",
         "package": "behavioral",
-        "file": "tests/behavioral/plugin_security.go",
+        "file": "/Users/hbraswel/github/complytime/complyctl/tests/behavioral/plugin_security.go",
         "line": 36,
         "fix_strategy": "add_tests",
         "crap": 30,
         "complexity": 5
-      },
-      {
-        "function": "EnvVarResolution",
-        "package": "behavioral",
-        "file": "tests/behavioral/credential_protection.go",
-        "line": 54,
-        "fix_strategy": "add_tests",
-        "crap": 30,
-        "complexity": 5
       }
-    ],
-    "ssa_degraded_packages": [
-      "github.com/complytime/complyctl/cmd/complyctl/cli",
-      "github.com/complytime/complyctl/cmd/mock-oci-registry",
-      "github.com/complytime/complyctl/internal/cache",
-      "github.com/complytime/complyctl/internal/complytime",
-      "github.com/complytime/complyctl/internal/doctor",
-      "github.com/complytime/complyctl/internal/output",
-      "github.com/complytime/complyctl/internal/policy",
-      "github.com/complytime/complyctl/internal/registry",
-      "github.com/complytime/complyctl/internal/terminal",
-      "github.com/complytime/complyctl/internal/version",
-      "github.com/complytime/complyctl/pkg/log",
-      "github.com/complytime/complyctl/pkg/provider"
     ]
   }
 }

--- a/cmd/behavioral-report/main.go
+++ b/cmd/behavioral-report/main.go
@@ -70,8 +70,9 @@ func main() {
 	evalLog := gemara.EvaluationLog{
 		Evaluations: controlEvals,
 		Metadata: gemara.Metadata{
-			Id:          policyID,
-			Description: "Behavioral test evaluation of CT.COMPLYCTL control catalog",
+			Id:            policyID,
+			GemaraVersion: gemara.SchemaVersion,
+			Description:   "Behavioral test evaluation of CT.COMPLYCTL control catalog",
 			Author: gemara.Actor{
 				Id:      toolName,
 				Name:    toolName,

--- a/cmd/complyctl/cli/cli_test.go
+++ b/cmd/complyctl/cli/cli_test.go
@@ -890,9 +890,11 @@ func TestProcessScanOutput_NoErrors_ReturnsNil(t *testing.T) {
 		errors:            nil,
 	}
 	policyTargets := []complytime.TargetConfig{{ID: "target-1"}}
-	reqToControl := map[string]string{"req-1": "ctrl-1"}
+	mappings := &resolvedMappings{
+		reqToControl: map[string]string{"req-1": "ctrl-1"},
+	}
 
-	err = processScanOutput("", scanOut, "test-repo", reqToControl, nil, nil, nil, policyTargets, "test-policy", []string{"target-1"}, tmpDir)
+	err = processScanOutput("", scanOut, "test-repo", mappings, policyTargets, "test-policy", []string{"target-1"}, tmpDir)
 	assert.NoError(t, err)
 }
 
@@ -919,9 +921,11 @@ func TestProcessScanOutput_WithErrors_ReturnsError(t *testing.T) {
 		errors:            []string{"target 'staging': clone failed"},
 	}
 	policyTargets := []complytime.TargetConfig{{ID: "target-1"}}
-	reqToControl := map[string]string{"req-1": "ctrl-1"}
+	mappings := &resolvedMappings{
+		reqToControl: map[string]string{"req-1": "ctrl-1"},
+	}
 
-	err = processScanOutput("", scanOut, "test-repo", reqToControl, nil, nil, nil, policyTargets, "test-policy", []string{"target-1"}, tmpDir)
+	err = processScanOutput("", scanOut, "test-repo", mappings, policyTargets, "test-policy", []string{"target-1"}, tmpDir)
 	w.Close()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "1 operational error")

--- a/cmd/complyctl/cli/cli_test.go
+++ b/cmd/complyctl/cli/cli_test.go
@@ -892,7 +892,7 @@ func TestProcessScanOutput_NoErrors_ReturnsNil(t *testing.T) {
 	policyTargets := []complytime.TargetConfig{{ID: "target-1"}}
 	reqToControl := map[string]string{"req-1": "ctrl-1"}
 
-	err = processScanOutput("", scanOut, "test-repo", reqToControl, nil, "", policyTargets, "test-policy", []string{"target-1"}, tmpDir)
+	err = processScanOutput("", scanOut, "test-repo", reqToControl, nil, nil, nil, policyTargets, "test-policy", []string{"target-1"}, tmpDir)
 	assert.NoError(t, err)
 }
 
@@ -921,7 +921,7 @@ func TestProcessScanOutput_WithErrors_ReturnsError(t *testing.T) {
 	policyTargets := []complytime.TargetConfig{{ID: "target-1"}}
 	reqToControl := map[string]string{"req-1": "ctrl-1"}
 
-	err = processScanOutput("", scanOut, "test-repo", reqToControl, nil, "", policyTargets, "test-policy", []string{"target-1"}, tmpDir)
+	err = processScanOutput("", scanOut, "test-repo", reqToControl, nil, nil, nil, policyTargets, "test-policy", []string{"target-1"}, tmpDir)
 	w.Close()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "1 operational error")
@@ -1511,11 +1511,58 @@ func TestReverseMap_Nil(t *testing.T) {
 	assert.Empty(t, r)
 }
 
-// --- resolveComplypackRef tests ---
+// --- buildComplypackRefs tests ---
 
-func TestResolveComplypackRef_NoCacheDir(t *testing.T) {
-	ref := resolveComplypackRef(t.TempDir(), map[string]policy.EvaluatorGroup{
-		"opa": {EvaluatorID: "opa"},
-	}, nil)
-	assert.Equal(t, "", ref)
+func TestBuildComplypackRefs_NoComplypacks(t *testing.T) {
+	refs := buildComplypackRefs(t.TempDir(), nil)
+	assert.Empty(t, refs)
+}
+
+func TestBuildComplypackRefs_NoCacheState(t *testing.T) {
+	refs := buildComplypackRefs(t.TempDir(), []complytime.PolicyEntry{
+		{URL: "registry.example.com/complypacks/opa@v1"},
+	})
+	assert.Empty(t, refs)
+}
+
+// --- extractReqToEvaluator tests ---
+
+func TestExtractReqToEvaluator_SingleGroup(t *testing.T) {
+	groups := map[string]policy.EvaluatorGroup{
+		"opa": {
+			EvaluatorID: "opa",
+			Configs: []provider.AssessmentConfiguration{
+				{RequirementID: "req-1"},
+				{RequirementID: "req-2"},
+			},
+		},
+	}
+	m := extractReqToEvaluator(groups)
+	assert.Equal(t, "opa", m["req-1"])
+	assert.Equal(t, "opa", m["req-2"])
+}
+
+func TestExtractReqToEvaluator_MultipleGroups(t *testing.T) {
+	groups := map[string]policy.EvaluatorGroup{
+		"opa": {
+			EvaluatorID: "opa",
+			Configs: []provider.AssessmentConfiguration{
+				{RequirementID: "req-1"},
+			},
+		},
+		"openscap": {
+			EvaluatorID: "openscap",
+			Configs: []provider.AssessmentConfiguration{
+				{RequirementID: "req-2"},
+			},
+		},
+	}
+	m := extractReqToEvaluator(groups)
+	assert.Equal(t, "opa", m["req-1"])
+	assert.Equal(t, "openscap", m["req-2"])
+}
+
+func TestExtractReqToEvaluator_EmptyGroups(t *testing.T) {
+	m := extractReqToEvaluator(map[string]policy.EvaluatorGroup{})
+	assert.Empty(t, m)
 }

--- a/cmd/complyctl/cli/cli_test.go
+++ b/cmd/complyctl/cli/cli_test.go
@@ -892,7 +892,7 @@ func TestProcessScanOutput_NoErrors_ReturnsNil(t *testing.T) {
 	policyTargets := []complytime.TargetConfig{{ID: "target-1"}}
 	reqToControl := map[string]string{"req-1": "ctrl-1"}
 
-	err = processScanOutput("", scanOut, "test-repo", reqToControl, policyTargets, "test-policy", []string{"target-1"}, tmpDir)
+	err = processScanOutput("", scanOut, "test-repo", reqToControl, nil, "", policyTargets, "test-policy", []string{"target-1"}, tmpDir)
 	assert.NoError(t, err)
 }
 
@@ -921,7 +921,7 @@ func TestProcessScanOutput_WithErrors_ReturnsError(t *testing.T) {
 	policyTargets := []complytime.TargetConfig{{ID: "target-1"}}
 	reqToControl := map[string]string{"req-1": "ctrl-1"}
 
-	err = processScanOutput("", scanOut, "test-repo", reqToControl, policyTargets, "test-policy", []string{"target-1"}, tmpDir)
+	err = processScanOutput("", scanOut, "test-repo", reqToControl, nil, "", policyTargets, "test-policy", []string{"target-1"}, tmpDir)
 	w.Close()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "1 operational error")
@@ -1489,4 +1489,33 @@ func TestCompleteTargetIDs_WithWorkspaceConfig(t *testing.T) {
 	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
 	assert.Contains(t, ids, "prod")
 	assert.Contains(t, ids, "staging")
+}
+
+// --- reverseMap tests ---
+
+func TestReverseMap_Basic(t *testing.T) {
+	m := map[string]string{"ap-1": "req-1", "ap-2": "req-2"}
+	r := reverseMap(m)
+	assert.Equal(t, "ap-1", r["req-1"])
+	assert.Equal(t, "ap-2", r["req-2"])
+	assert.Len(t, r, 2)
+}
+
+func TestReverseMap_Empty(t *testing.T) {
+	r := reverseMap(map[string]string{})
+	assert.Empty(t, r)
+}
+
+func TestReverseMap_Nil(t *testing.T) {
+	r := reverseMap(nil)
+	assert.Empty(t, r)
+}
+
+// --- resolveComplypackRef tests ---
+
+func TestResolveComplypackRef_NoCacheDir(t *testing.T) {
+	ref := resolveComplypackRef(t.TempDir(), map[string]policy.EvaluatorGroup{
+		"opa": {EvaluatorID: "opa"},
+	}, nil)
+	assert.Equal(t, "", ref)
 }

--- a/cmd/complyctl/cli/cli_test.go
+++ b/cmd/complyctl/cli/cli_test.go
@@ -1515,23 +1515,40 @@ func TestReverseMap_Nil(t *testing.T) {
 	assert.Empty(t, r)
 }
 
-// --- buildComplypackRefs tests ---
+// --- buildReqToComplypackRef tests ---
 
-func TestBuildComplypackRefs_NoComplypacks(t *testing.T) {
-	refs := buildComplypackRefs(t.TempDir(), nil)
-	assert.Empty(t, refs)
+func TestBuildReqToComplypackRef_EmptyGroups(t *testing.T) {
+	m := buildReqToComplypackRef(t.TempDir(), map[string]policy.EvaluatorGroup{})
+	assert.Empty(t, m)
 }
 
-func TestBuildComplypackRefs_NoCacheState(t *testing.T) {
-	refs := buildComplypackRefs(t.TempDir(), []complytime.PolicyEntry{
-		{URL: "registry.example.com/complypacks/opa@v1"},
-	})
-	assert.Empty(t, refs)
+func TestBuildReqToComplypackRef_NoCacheState(t *testing.T) {
+	groups := map[string]policy.EvaluatorGroup{
+		"opa": {
+			EvaluatorID: "opa",
+			Configs:     []provider.AssessmentConfiguration{{RequirementID: "req-1"}},
+		},
+	}
+	m := buildReqToComplypackRef(t.TempDir(), groups)
+	assert.Empty(t, m)
 }
 
-// --- extractReqToEvaluator tests ---
+func TestBuildReqToComplypackRef_ResolvesRequirements(t *testing.T) {
+	cacheDir := t.TempDir()
+	state := &cache.State{
+		Complypacks: map[string]cache.PolicyState{
+			"registry.example.com/complypacks/opa": {
+				Digest:      "sha256:abc123",
+				EvaluatorID: "opa",
+			},
+			"registry.example.com/complypacks/kyverno": {
+				Digest:      "sha256:def456",
+				EvaluatorID: "kyverno",
+			},
+		},
+	}
+	require.NoError(t, cache.SaveState(state, cacheDir))
 
-func TestExtractReqToEvaluator_SingleGroup(t *testing.T) {
 	groups := map[string]policy.EvaluatorGroup{
 		"opa": {
 			EvaluatorID: "opa",
@@ -1540,33 +1557,37 @@ func TestExtractReqToEvaluator_SingleGroup(t *testing.T) {
 				{RequirementID: "req-2"},
 			},
 		},
+		"kyverno": {
+			EvaluatorID: "kyverno",
+			Configs: []provider.AssessmentConfiguration{
+				{RequirementID: "req-3"},
+			},
+		},
 	}
-	m := extractReqToEvaluator(groups)
-	assert.Equal(t, "opa", m["req-1"])
-	assert.Equal(t, "opa", m["req-2"])
+	m := buildReqToComplypackRef(cacheDir, groups)
+	assert.Equal(t, "registry.example.com/complypacks/opa@sha256:abc123", m["req-1"])
+	assert.Equal(t, "registry.example.com/complypacks/opa@sha256:abc123", m["req-2"])
+	assert.Equal(t, "registry.example.com/complypacks/kyverno@sha256:def456", m["req-3"])
 }
 
-func TestExtractReqToEvaluator_MultipleGroups(t *testing.T) {
+func TestBuildReqToComplypackRef_SkipsMissingDigest(t *testing.T) {
+	cacheDir := t.TempDir()
+	state := &cache.State{
+		Complypacks: map[string]cache.PolicyState{
+			"registry.example.com/complypacks/opa": {
+				Digest:      "",
+				EvaluatorID: "opa",
+			},
+		},
+	}
+	require.NoError(t, cache.SaveState(state, cacheDir))
+
 	groups := map[string]policy.EvaluatorGroup{
 		"opa": {
 			EvaluatorID: "opa",
-			Configs: []provider.AssessmentConfiguration{
-				{RequirementID: "req-1"},
-			},
-		},
-		"openscap": {
-			EvaluatorID: "openscap",
-			Configs: []provider.AssessmentConfiguration{
-				{RequirementID: "req-2"},
-			},
+			Configs:     []provider.AssessmentConfiguration{{RequirementID: "req-1"}},
 		},
 	}
-	m := extractReqToEvaluator(groups)
-	assert.Equal(t, "opa", m["req-1"])
-	assert.Equal(t, "openscap", m["req-2"])
-}
-
-func TestExtractReqToEvaluator_EmptyGroups(t *testing.T) {
-	m := extractReqToEvaluator(map[string]policy.EvaluatorGroup{})
+	m := buildReqToComplypackRef(cacheDir, groups)
 	assert.Empty(t, m)
 }

--- a/cmd/complyctl/cli/scan.go
+++ b/cmd/complyctl/cli/scan.go
@@ -32,6 +32,16 @@ type scanOptions struct {
 	providerDir string
 }
 
+// resolvedMappings groups the ID-resolution maps built during scan setup.
+// Bundling them into a struct prevents parameter-transposition bugs across
+// the four identically-typed map[string]string arguments.
+type resolvedMappings struct {
+	reqToControl   map[string]string
+	reqToPlan      map[string]string
+	complypackRefs map[string]string
+	reqToEvaluator map[string]string
+}
+
 func scanCmd(common *Common) *cobra.Command {
 	o := &scanOptions{
 		Common: common,
@@ -368,10 +378,13 @@ func ensureGenerated(ctx context.Context, cacheDir, baseDir string, mgr *provide
 // combined output (reports + error checking). It delegates post-scan handling
 // to processScanOutput.
 func runScanAndReport(ctx context.Context, format string, mgr *provider.Manager, groups map[string]policy.EvaluatorGroup, complypackRefs map[string]string, policyTargets []complytime.TargetConfig, repository, eid string, graph *policy.DependencyGraph, targetIDs []string, baseDir string) error {
-	reqToControl := extractReqToControlMap(graph)
 	planToReq := extractPlanToReqMap(graph)
-	reqToPlan := reverseMap(planToReq)
-	reqToEvaluator := extractReqToEvaluator(groups)
+	mappings := resolvedMappings{
+		reqToControl:   extractReqToControlMap(graph),
+		reqToPlan:      reverseMap(planToReq),
+		complypackRefs: complypackRefs,
+		reqToEvaluator: extractReqToEvaluator(groups),
+	}
 	targetsWithWorkspace := injectWorkspaceIntoTargets(policyTargets, baseDir)
 	scanOut, err := executeScan(ctx, mgr, groups, targetsWithWorkspace)
 	if err != nil {
@@ -379,17 +392,17 @@ func runScanAndReport(ctx context.Context, format string, mgr *provider.Manager,
 	}
 
 	resolveAssessmentIDs(scanOut.assessments, planToReq)
-	return processScanOutput(format, scanOut, repository, reqToControl, reqToPlan, complypackRefs, reqToEvaluator, policyTargets, eid, targetIDs, baseDir)
+	return processScanOutput(format, scanOut, repository, &mappings, policyTargets, eid, targetIDs, baseDir)
 }
 
 // processScanOutput handles post-scan output: prints operational warnings to
 // stderr, writes evaluation reports, and returns an error when operational
 // failures are present (triggering non-zero exit). Reports are always written
 // before the error return so partial results remain available.
-func processScanOutput(format string, scanOut *scanOutput, repository string, reqToControl, reqToPlan, complypackRefs, reqToEvaluator map[string]string, policyTargets []complytime.TargetConfig, eid string, targetIDs []string, baseDir string) error {
+func processScanOutput(format string, scanOut *scanOutput, repository string, mappings *resolvedMappings, policyTargets []complytime.TargetConfig, eid string, targetIDs []string, baseDir string) error {
 	reportOperationalWarnings(scanOut.errors)
 
-	evaluators := buildEvaluators(repository, reqToControl, reqToPlan, complypackRefs, reqToEvaluator, policyTargets, scanOut.assessments, scanOut.assessmentTargets)
+	evaluators := buildEvaluators(repository, mappings, policyTargets, scanOut.assessments, scanOut.assessmentTargets)
 
 	outDir := filepath.Join(baseDir, complytime.WorkspaceDir, complytime.ScanOutputDir)
 	for _, eval := range evaluators {
@@ -398,7 +411,7 @@ func processScanOutput(format string, scanOut *scanOutput, repository string, re
 		}
 	}
 
-	fmt.Println(output.FormatScanSummary(scanOut.assessments, scanOut.assessmentTargets, reqToControl, eid, targetIDs))
+	fmt.Println(output.FormatScanSummary(scanOut.assessments, scanOut.assessmentTargets, mappings.reqToControl, eid, targetIDs))
 	return checkOperationalErrors(scanOut.errors)
 }
 
@@ -424,10 +437,10 @@ func checkOperationalErrors(errors []string) error {
 	return nil
 }
 
-func buildEvaluators(repository string, reqToControl, reqToPlan, complypackRefs, reqToEvaluator map[string]string, policyTargets []complytime.TargetConfig, allAssessments []provider.AssessmentLog, assessmentTargets []string) []*output.Evaluator {
+func buildEvaluators(repository string, mappings *resolvedMappings, policyTargets []complytime.TargetConfig, allAssessments []provider.AssessmentLog, assessmentTargets []string) []*output.Evaluator {
 	evaluators := make([]*output.Evaluator, 0, len(policyTargets))
 	for _, target := range policyTargets {
-		eval := output.NewEvaluator(repository, target.ID, reqToControl, reqToPlan, complypackRefs, reqToEvaluator)
+		eval := output.NewEvaluator(repository, target.ID, mappings.reqToControl, mappings.reqToPlan, mappings.complypackRefs, mappings.reqToEvaluator)
 		var targetAssessments []provider.AssessmentLog
 		for j, a := range allAssessments {
 			if assessmentTargets[j] == target.ID {
@@ -897,7 +910,7 @@ func reverseMap(m map[string]string) map[string]string {
 	for k, v := range m {
 		if existing, ok := r[v]; ok {
 			logger.Warn("multiple keys map to same value in reverse map",
-				"value", v, "kept", existing, "dropped", k)
+				"value", v, "kept", k, "dropped", existing)
 		}
 		r[v] = k
 	}

--- a/cmd/complyctl/cli/scan.go
+++ b/cmd/complyctl/cli/scan.go
@@ -283,7 +283,7 @@ func (o *scanOptions) scanPolicy(ctx context.Context, cfg *complytime.WorkspaceC
 }
 
 func (o *scanOptions) executeScanPhase(ctx context.Context, cfg *complytime.WorkspaceConfig, mgr *provider.Manager, groups map[string]policy.EvaluatorGroup, policyTargets []complytime.TargetConfig, repository, eid string, graph *policy.DependencyGraph, targetIDs []string, baseDir string) error {
-	if err := runScanAndReport(ctx, o.format, mgr, groups, policyTargets, repository, eid, graph, targetIDs, baseDir); err != nil {
+	if err := runScanAndReport(ctx, o.format, o.cacheDir, mgr, groups, cfg.Complypacks, policyTargets, repository, eid, graph, targetIDs, baseDir); err != nil {
 		return err
 	}
 	return o.maybeExport(ctx, cfg, mgr, groups)
@@ -366,9 +366,11 @@ func ensureGenerated(ctx context.Context, cacheDir, baseDir string, mgr *provide
 // runScanAndReport executes the scan across all targets and processes the
 // combined output (reports + error checking). It delegates post-scan handling
 // to processScanOutput.
-func runScanAndReport(ctx context.Context, format string, mgr *provider.Manager, groups map[string]policy.EvaluatorGroup, policyTargets []complytime.TargetConfig, repository, eid string, graph *policy.DependencyGraph, targetIDs []string, baseDir string) error {
+func runScanAndReport(ctx context.Context, format string, cacheDir string, mgr *provider.Manager, groups map[string]policy.EvaluatorGroup, complypacks []complytime.PolicyEntry, policyTargets []complytime.TargetConfig, repository, eid string, graph *policy.DependencyGraph, targetIDs []string, baseDir string) error {
 	reqToControl := extractReqToControlMap(graph)
 	planToReq := extractPlanToReqMap(graph)
+	reqToPlan := reverseMap(planToReq)
+	complypackRef := resolveComplypackRef(cacheDir, groups, complypacks)
 	targetsWithWorkspace := injectWorkspaceIntoTargets(policyTargets, baseDir)
 	scanOut, err := executeScan(ctx, mgr, groups, targetsWithWorkspace)
 	if err != nil {
@@ -376,17 +378,17 @@ func runScanAndReport(ctx context.Context, format string, mgr *provider.Manager,
 	}
 
 	resolveAssessmentIDs(scanOut.assessments, planToReq)
-	return processScanOutput(format, scanOut, repository, reqToControl, policyTargets, eid, targetIDs, baseDir)
+	return processScanOutput(format, scanOut, repository, reqToControl, reqToPlan, complypackRef, policyTargets, eid, targetIDs, baseDir)
 }
 
 // processScanOutput handles post-scan output: prints operational warnings to
 // stderr, writes evaluation reports, and returns an error when operational
 // failures are present (triggering non-zero exit). Reports are always written
 // before the error return so partial results remain available.
-func processScanOutput(format string, scanOut *scanOutput, repository string, reqToControl map[string]string, policyTargets []complytime.TargetConfig, eid string, targetIDs []string, baseDir string) error {
+func processScanOutput(format string, scanOut *scanOutput, repository string, reqToControl, reqToPlan map[string]string, complypackRef string, policyTargets []complytime.TargetConfig, eid string, targetIDs []string, baseDir string) error {
 	reportOperationalWarnings(scanOut.errors)
 
-	evaluators := buildEvaluators(repository, reqToControl, policyTargets, scanOut.assessments, scanOut.assessmentTargets)
+	evaluators := buildEvaluators(repository, reqToControl, reqToPlan, complypackRef, policyTargets, scanOut.assessments, scanOut.assessmentTargets)
 
 	outDir := filepath.Join(baseDir, complytime.WorkspaceDir, complytime.ScanOutputDir)
 	for _, eval := range evaluators {
@@ -421,10 +423,10 @@ func checkOperationalErrors(errors []string) error {
 	return nil
 }
 
-func buildEvaluators(repository string, reqToControl map[string]string, policyTargets []complytime.TargetConfig, allAssessments []provider.AssessmentLog, assessmentTargets []string) []*output.Evaluator {
+func buildEvaluators(repository string, reqToControl, reqToPlan map[string]string, complypackRef string, policyTargets []complytime.TargetConfig, allAssessments []provider.AssessmentLog, assessmentTargets []string) []*output.Evaluator {
 	evaluators := make([]*output.Evaluator, 0, len(policyTargets))
 	for _, target := range policyTargets {
-		eval := output.NewEvaluator(repository, target.ID, reqToControl)
+		eval := output.NewEvaluator(repository, target.ID, reqToControl, reqToPlan, complypackRef)
 		var targetAssessments []provider.AssessmentLog
 		for j, a := range allAssessments {
 			if assessmentTargets[j] == target.ID {
@@ -885,4 +887,43 @@ func resolveAssessmentIDs(assessments []provider.AssessmentLog, planToReq map[st
 			assessments[i].RequirementID = reqID
 		}
 	}
+}
+
+// reverseMap inverts a string-to-string map. If multiple keys map to the same
+// value, only one mapping is preserved (last-write-wins) and a warning is logged.
+func reverseMap(m map[string]string) map[string]string {
+	r := make(map[string]string, len(m))
+	for k, v := range m {
+		if existing, ok := r[v]; ok {
+			logger.Warn("multiple keys map to same value in reverse map",
+				"value", v, "kept", existing, "dropped", k)
+		}
+		r[v] = k
+	}
+	return r
+}
+
+// resolveComplypackRef builds a complypack OCI reference string
+// (repository@digest) for the evaluator groups in this scan. Returns ""
+// if no complypack is cached for any evaluator in the groups.
+//
+// State.Complypacks entries include an EvaluatorID field (set during
+// complypack sync) which directly maps repositories to evaluator-ids.
+func resolveComplypackRef(cacheDir string, groups map[string]policy.EvaluatorGroup, complypacks []complytime.PolicyEntry) string {
+	if len(complypacks) == 0 {
+		return ""
+	}
+	state, err := cache.LoadState(cacheDir)
+	if err != nil {
+		logger.Debug("failed to load cache state for complypack ref resolution", "error", err)
+		return ""
+	}
+	for evalID := range groups {
+		for repo, ps := range state.Complypacks {
+			if ps.Digest != "" && ps.EvaluatorID == evalID {
+				return repo + "@" + ps.Digest
+			}
+		}
+	}
+	return ""
 }

--- a/cmd/complyctl/cli/scan.go
+++ b/cmd/complyctl/cli/scan.go
@@ -283,7 +283,8 @@ func (o *scanOptions) scanPolicy(ctx context.Context, cfg *complytime.WorkspaceC
 }
 
 func (o *scanOptions) executeScanPhase(ctx context.Context, cfg *complytime.WorkspaceConfig, mgr *provider.Manager, groups map[string]policy.EvaluatorGroup, policyTargets []complytime.TargetConfig, repository, eid string, graph *policy.DependencyGraph, targetIDs []string, baseDir string) error {
-	if err := runScanAndReport(ctx, o.format, o.cacheDir, mgr, groups, cfg.Complypacks, policyTargets, repository, eid, graph, targetIDs, baseDir); err != nil {
+	complypackRefs := buildComplypackRefs(o.cacheDir, cfg.Complypacks)
+	if err := runScanAndReport(ctx, o.format, mgr, groups, complypackRefs, policyTargets, repository, eid, graph, targetIDs, baseDir); err != nil {
 		return err
 	}
 	return o.maybeExport(ctx, cfg, mgr, groups)
@@ -366,11 +367,11 @@ func ensureGenerated(ctx context.Context, cacheDir, baseDir string, mgr *provide
 // runScanAndReport executes the scan across all targets and processes the
 // combined output (reports + error checking). It delegates post-scan handling
 // to processScanOutput.
-func runScanAndReport(ctx context.Context, format string, cacheDir string, mgr *provider.Manager, groups map[string]policy.EvaluatorGroup, complypacks []complytime.PolicyEntry, policyTargets []complytime.TargetConfig, repository, eid string, graph *policy.DependencyGraph, targetIDs []string, baseDir string) error {
+func runScanAndReport(ctx context.Context, format string, mgr *provider.Manager, groups map[string]policy.EvaluatorGroup, complypackRefs map[string]string, policyTargets []complytime.TargetConfig, repository, eid string, graph *policy.DependencyGraph, targetIDs []string, baseDir string) error {
 	reqToControl := extractReqToControlMap(graph)
 	planToReq := extractPlanToReqMap(graph)
 	reqToPlan := reverseMap(planToReq)
-	complypackRef := resolveComplypackRef(cacheDir, groups, complypacks)
+	reqToEvaluator := extractReqToEvaluator(groups)
 	targetsWithWorkspace := injectWorkspaceIntoTargets(policyTargets, baseDir)
 	scanOut, err := executeScan(ctx, mgr, groups, targetsWithWorkspace)
 	if err != nil {
@@ -378,17 +379,17 @@ func runScanAndReport(ctx context.Context, format string, cacheDir string, mgr *
 	}
 
 	resolveAssessmentIDs(scanOut.assessments, planToReq)
-	return processScanOutput(format, scanOut, repository, reqToControl, reqToPlan, complypackRef, policyTargets, eid, targetIDs, baseDir)
+	return processScanOutput(format, scanOut, repository, reqToControl, reqToPlan, complypackRefs, reqToEvaluator, policyTargets, eid, targetIDs, baseDir)
 }
 
 // processScanOutput handles post-scan output: prints operational warnings to
 // stderr, writes evaluation reports, and returns an error when operational
 // failures are present (triggering non-zero exit). Reports are always written
 // before the error return so partial results remain available.
-func processScanOutput(format string, scanOut *scanOutput, repository string, reqToControl, reqToPlan map[string]string, complypackRef string, policyTargets []complytime.TargetConfig, eid string, targetIDs []string, baseDir string) error {
+func processScanOutput(format string, scanOut *scanOutput, repository string, reqToControl, reqToPlan, complypackRefs, reqToEvaluator map[string]string, policyTargets []complytime.TargetConfig, eid string, targetIDs []string, baseDir string) error {
 	reportOperationalWarnings(scanOut.errors)
 
-	evaluators := buildEvaluators(repository, reqToControl, reqToPlan, complypackRef, policyTargets, scanOut.assessments, scanOut.assessmentTargets)
+	evaluators := buildEvaluators(repository, reqToControl, reqToPlan, complypackRefs, reqToEvaluator, policyTargets, scanOut.assessments, scanOut.assessmentTargets)
 
 	outDir := filepath.Join(baseDir, complytime.WorkspaceDir, complytime.ScanOutputDir)
 	for _, eval := range evaluators {
@@ -423,10 +424,10 @@ func checkOperationalErrors(errors []string) error {
 	return nil
 }
 
-func buildEvaluators(repository string, reqToControl, reqToPlan map[string]string, complypackRef string, policyTargets []complytime.TargetConfig, allAssessments []provider.AssessmentLog, assessmentTargets []string) []*output.Evaluator {
+func buildEvaluators(repository string, reqToControl, reqToPlan, complypackRefs, reqToEvaluator map[string]string, policyTargets []complytime.TargetConfig, allAssessments []provider.AssessmentLog, assessmentTargets []string) []*output.Evaluator {
 	evaluators := make([]*output.Evaluator, 0, len(policyTargets))
 	for _, target := range policyTargets {
-		eval := output.NewEvaluator(repository, target.ID, reqToControl, reqToPlan, complypackRef)
+		eval := output.NewEvaluator(repository, target.ID, reqToControl, reqToPlan, complypackRefs, reqToEvaluator)
 		var targetAssessments []provider.AssessmentLog
 		for j, a := range allAssessments {
 			if assessmentTargets[j] == target.ID {
@@ -903,27 +904,36 @@ func reverseMap(m map[string]string) map[string]string {
 	return r
 }
 
-// resolveComplypackRef builds a complypack OCI reference string
-// (repository@digest) for the evaluator groups in this scan. Returns ""
-// if no complypack is cached for any evaluator in the groups.
-//
-// State.Complypacks entries include an EvaluatorID field (set during
-// complypack sync) which directly maps repositories to evaluator-ids.
-func resolveComplypackRef(cacheDir string, groups map[string]policy.EvaluatorGroup, complypacks []complytime.PolicyEntry) string {
+// buildComplypackRefs builds a map of evaluator-id → OCI reference
+// (repository@digest) from the complypacks configuration and cached state.
+// Returns an empty map when no complypacks are configured or state is unavailable.
+func buildComplypackRefs(cacheDir string, complypacks []complytime.PolicyEntry) map[string]string {
+	refs := make(map[string]string)
 	if len(complypacks) == 0 {
-		return ""
+		return refs
 	}
 	state, err := cache.LoadState(cacheDir)
 	if err != nil {
 		logger.Debug("failed to load cache state for complypack ref resolution", "error", err)
-		return ""
+		return refs
 	}
-	for evalID := range groups {
-		for repo, ps := range state.Complypacks {
-			if ps.Digest != "" && ps.EvaluatorID == evalID {
-				return repo + "@" + ps.Digest
-			}
+	for repo, ps := range state.Complypacks {
+		if ps.Digest != "" && ps.EvaluatorID != "" {
+			refs[ps.EvaluatorID] = repo + "@" + ps.Digest
 		}
 	}
-	return ""
+	return refs
+}
+
+// extractReqToEvaluator builds a requirement-ID → evaluator-ID mapping from
+// the evaluator groups. This allows resolving which complypack reference
+// applies to each assessment result.
+func extractReqToEvaluator(groups map[string]policy.EvaluatorGroup) map[string]string {
+	m := make(map[string]string)
+	for evalID, group := range groups {
+		for _, cfg := range group.Configs {
+			m[cfg.RequirementID] = evalID
+		}
+	}
+	return m
 }

--- a/cmd/complyctl/cli/scan.go
+++ b/cmd/complyctl/cli/scan.go
@@ -34,12 +34,11 @@ type scanOptions struct {
 
 // resolvedMappings groups the ID-resolution maps built during scan setup.
 // Bundling them into a struct prevents parameter-transposition bugs across
-// the four identically-typed map[string]string arguments.
+// the identically-typed map[string]string arguments.
 type resolvedMappings struct {
-	reqToControl   map[string]string
-	reqToPlan      map[string]string
-	complypackRefs map[string]string
-	reqToEvaluator map[string]string
+	reqToControl       map[string]string
+	reqToPlan          map[string]string
+	reqToComplypackRef map[string]string
 }
 
 func scanCmd(common *Common) *cobra.Command {
@@ -293,8 +292,8 @@ func (o *scanOptions) scanPolicy(ctx context.Context, cfg *complytime.WorkspaceC
 }
 
 func (o *scanOptions) executeScanPhase(ctx context.Context, cfg *complytime.WorkspaceConfig, mgr *provider.Manager, groups map[string]policy.EvaluatorGroup, policyTargets []complytime.TargetConfig, repository, eid string, graph *policy.DependencyGraph, targetIDs []string, baseDir string) error {
-	complypackRefs := buildComplypackRefs(o.cacheDir, cfg.Complypacks)
-	if err := runScanAndReport(ctx, o.format, mgr, groups, complypackRefs, policyTargets, repository, eid, graph, targetIDs, baseDir); err != nil {
+	reqToComplypackRef := buildReqToComplypackRef(o.cacheDir, groups)
+	if err := runScanAndReport(ctx, o.format, mgr, groups, reqToComplypackRef, policyTargets, repository, eid, graph, targetIDs, baseDir); err != nil {
 		return err
 	}
 	return o.maybeExport(ctx, cfg, mgr, groups)
@@ -377,13 +376,12 @@ func ensureGenerated(ctx context.Context, cacheDir, baseDir string, mgr *provide
 // runScanAndReport executes the scan across all targets and processes the
 // combined output (reports + error checking). It delegates post-scan handling
 // to processScanOutput.
-func runScanAndReport(ctx context.Context, format string, mgr *provider.Manager, groups map[string]policy.EvaluatorGroup, complypackRefs map[string]string, policyTargets []complytime.TargetConfig, repository, eid string, graph *policy.DependencyGraph, targetIDs []string, baseDir string) error {
+func runScanAndReport(ctx context.Context, format string, mgr *provider.Manager, groups map[string]policy.EvaluatorGroup, reqToComplypackRef map[string]string, policyTargets []complytime.TargetConfig, repository, eid string, graph *policy.DependencyGraph, targetIDs []string, baseDir string) error {
 	planToReq := extractPlanToReqMap(graph)
 	mappings := resolvedMappings{
-		reqToControl:   extractReqToControlMap(graph),
-		reqToPlan:      reverseMap(planToReq),
-		complypackRefs: complypackRefs,
-		reqToEvaluator: extractReqToEvaluator(groups),
+		reqToControl:       extractReqToControlMap(graph),
+		reqToPlan:          reverseMap(planToReq),
+		reqToComplypackRef: reqToComplypackRef,
 	}
 	targetsWithWorkspace := injectWorkspaceIntoTargets(policyTargets, baseDir)
 	scanOut, err := executeScan(ctx, mgr, groups, targetsWithWorkspace)
@@ -440,7 +438,7 @@ func checkOperationalErrors(errors []string) error {
 func buildEvaluators(repository string, mappings *resolvedMappings, policyTargets []complytime.TargetConfig, allAssessments []provider.AssessmentLog, assessmentTargets []string) []*output.Evaluator {
 	evaluators := make([]*output.Evaluator, 0, len(policyTargets))
 	for _, target := range policyTargets {
-		eval := output.NewEvaluator(repository, target.ID, mappings.reqToControl, mappings.reqToPlan, mappings.complypackRefs, mappings.reqToEvaluator)
+		eval := output.NewEvaluator(repository, target.ID, mappings.reqToControl, mappings.reqToPlan, mappings.reqToComplypackRef)
 		var targetAssessments []provider.AssessmentLog
 		for j, a := range allAssessments {
 			if assessmentTargets[j] == target.ID {
@@ -917,35 +915,48 @@ func reverseMap(m map[string]string) map[string]string {
 	return r
 }
 
-// buildComplypackRefs builds a map of evaluator-id → OCI reference
-// (repository@digest) from the complypacks configuration and cached state.
-// Returns an empty map when no complypacks are configured or state is unavailable.
-func buildComplypackRefs(cacheDir string, complypacks []complytime.PolicyEntry) map[string]string {
-	refs := make(map[string]string)
-	if len(complypacks) == 0 {
-		return refs
+// buildReqToComplypackRef produces a pre-resolved requirement-ID →
+// OCI reference (repository@digest) map by composing two lookups:
+//
+//  1. state.Complypacks: evaluator-ID → repository@digest
+//  2. evaluator groups:  requirement-ID → evaluator-ID
+//
+// Resolving the chain here keeps the Evaluator free of evaluator-ID
+// routing concerns and makes it easier to change selection logic later
+// (e.g., per-requirement complypack selection).
+func buildReqToComplypackRef(cacheDir string, groups map[string]policy.EvaluatorGroup) map[string]string {
+	m := make(map[string]string)
+	if len(groups) == 0 {
+		return m
 	}
 	state, err := cache.LoadState(cacheDir)
 	if err != nil {
 		logger.Debug("failed to load cache state for complypack ref resolution", "error", err)
-		return refs
+		return m
 	}
-	for repo, ps := range state.Complypacks {
-		if ps.Digest != "" && ps.EvaluatorID != "" {
-			refs[ps.EvaluatorID] = repo + "@" + ps.Digest
-		}
-	}
-	return refs
-}
 
-// extractReqToEvaluator builds a requirement-ID → evaluator-ID mapping from
-// the evaluator groups. This allows resolving which complypack reference
-// applies to each assessment result.
-func extractReqToEvaluator(groups map[string]policy.EvaluatorGroup) map[string]string {
-	m := make(map[string]string)
+	evalToRef := make(map[string]string)
+	for repo, ps := range state.Complypacks {
+		if ps.Digest == "" || ps.EvaluatorID == "" {
+			continue
+		}
+		if existing, ok := evalToRef[ps.EvaluatorID]; ok {
+			logger.Warn("multiple complypacks cached for same evaluator",
+				"evaluator", ps.EvaluatorID, "kept", existing, "dropped", repo+"@"+ps.Digest)
+		}
+		evalToRef[ps.EvaluatorID] = repo + "@" + ps.Digest
+	}
+	if len(evalToRef) == 0 {
+		return m
+	}
+
 	for evalID, group := range groups {
+		ref, ok := evalToRef[evalID]
+		if !ok {
+			continue
+		}
 		for _, cfg := range group.Configs {
-			m[cfg.RequirementID] = evalID
+			m[cfg.RequirementID] = ref
 		}
 	}
 	return m

--- a/internal/cache/complypack_sync.go
+++ b/internal/cache/complypack_sync.go
@@ -111,7 +111,7 @@ func (s *ComplypackSync) SyncComplypack(ctx context.Context, repository, version
 		return false, fmt.Errorf("failed to store complypack %s@%s: %w", repository, version, err)
 	}
 
-	s.state.UpdateComplypackState(repository, version, remoteDigest)
+	s.state.UpdateComplypackState(repository, version, remoteDigest, result.Config.EvaluatorID)
 	if err := SaveState(s.state, s.complypackCache.Dir()); err != nil {
 		return false, fmt.Errorf("failed to save state after complypack sync: %w (complypack blobs are valid)", err)
 	}

--- a/internal/cache/complypack_test.go
+++ b/internal/cache/complypack_test.go
@@ -233,8 +233,8 @@ func TestState_ComplypackRoundTrip(t *testing.T) {
 	state, err := cache.LoadState(stateDir)
 	require.NoError(t, err)
 
-	state.UpdateComplypackState("io.complytime.opa", "1.0.0", "sha256:abc123")
-	state.UpdateComplypackState("io.complytime.kyverno", "2.0.0", "sha256:def456")
+	state.UpdateComplypackState("io.complytime.opa", "1.0.0", "sha256:abc123", "opa")
+	state.UpdateComplypackState("io.complytime.kyverno", "2.0.0", "sha256:def456", "kyverno")
 
 	err = cache.SaveState(state, stateDir)
 	require.NoError(t, err)

--- a/internal/cache/state.go
+++ b/internal/cache/state.go
@@ -24,6 +24,7 @@ type State struct {
 type PolicyState struct {
 	Version     string    `json:"version"`
 	Digest      string    `json:"digest"`
+	EvaluatorID string    `json:"evaluator_id,omitempty"`
 	LastUpdated time.Time `json:"last_updated"`
 }
 
@@ -108,15 +109,17 @@ func (s *State) GetPolicyState(policyID string) (PolicyState, bool) {
 	return state, exists
 }
 
-// UpdateComplypackState records the version, digest, and current timestamp for
-// a cached complypack, keyed by repository (e.g., "example.com/complypacks/opa-bundle").
-func (s *State) UpdateComplypackState(evaluatorID, version, digest string) {
+// UpdateComplypackState records the version, digest, evaluator-id, and current
+// timestamp for a cached complypack, keyed by repository
+// (e.g., "example.com/complypacks/opa-bundle").
+func (s *State) UpdateComplypackState(repository, version, digest, evaluatorID string) {
 	if s.Complypacks == nil {
 		s.Complypacks = make(map[string]PolicyState)
 	}
-	s.Complypacks[evaluatorID] = PolicyState{
+	s.Complypacks[repository] = PolicyState{
 		Version:     version,
 		Digest:      digest,
+		EvaluatorID: evaluatorID,
 		LastUpdated: time.Now(),
 	}
 	s.LastSync = time.Now()

--- a/internal/cache/state.go
+++ b/internal/cache/state.go
@@ -127,10 +127,10 @@ func (s *State) UpdateComplypackState(repository, version, digest, evaluatorID s
 
 // GetComplypackState returns the cached state for a complypack, keyed by
 // repository (e.g., "example.com/complypacks/opa-bundle").
-func (s *State) GetComplypackState(evaluatorID string) (PolicyState, bool) {
+func (s *State) GetComplypackState(repository string) (PolicyState, bool) {
 	if s.Complypacks == nil {
 		return PolicyState{}, false
 	}
-	state, exists := s.Complypacks[evaluatorID]
+	state, exists := s.Complypacks[repository]
 	return state, exists
 }

--- a/internal/output/evaluator.go
+++ b/internal/output/evaluator.go
@@ -18,14 +18,13 @@ import (
 // Evaluator accumulates provider assessments for a single target and produces
 // a gemara.EvaluationLog grouped by control.
 type Evaluator struct {
-	policyID       string
-	targetID       string
-	reqToControl   map[string]string
-	reqToPlan      map[string]string
-	complypackRefs map[string]string
-	reqToEvaluator map[string]string
-	controlEvals   map[string]*gemara.ControlEvaluation
-	controlOrder   []string
+	policyID           string
+	targetID           string
+	reqToControl       map[string]string
+	reqToPlan          map[string]string
+	reqToComplypackRef map[string]string
+	controlEvals       map[string]*gemara.ControlEvaluation
+	controlOrder       []string
 	// controlStepNames tracks step name strings parallel to each control's
 	// AssessmentLogs slice. Keyed by control ID, each value is a slice of
 	// step name slices (one per assessment log under that control).
@@ -43,21 +42,18 @@ func defaultMap(m map[string]string) map[string]string {
 // NewEvaluator creates an Evaluator scoped to a single target. reqToControl
 // maps requirement IDs to control IDs; pass nil when the catalog is unavailable.
 // reqToPlan maps requirement IDs to assessment plan IDs for populating the Plan
-// field; pass nil when unavailable. complypackRefs maps evaluator IDs to OCI
-// references (repository@digest) for step identity; pass nil when no complypacks
-// are configured. reqToEvaluator maps requirement IDs to evaluator IDs for
-// resolving which complypack reference applies to each assessment; pass nil
-// when unavailable.
-func NewEvaluator(policyID, targetID string, reqToControl, reqToPlan, complypackRefs, reqToEvaluator map[string]string) *Evaluator {
+// field; pass nil when unavailable. reqToComplypackRef maps requirement IDs
+// directly to OCI references (repository@digest) for step identity; pass nil
+// when no complypacks are configured.
+func NewEvaluator(policyID, targetID string, reqToControl, reqToPlan, reqToComplypackRef map[string]string) *Evaluator {
 	return &Evaluator{
-		policyID:         policyID,
-		targetID:         targetID,
-		reqToControl:     defaultMap(reqToControl),
-		reqToPlan:        defaultMap(reqToPlan),
-		complypackRefs:   defaultMap(complypackRefs),
-		reqToEvaluator:   defaultMap(reqToEvaluator),
-		controlEvals:     make(map[string]*gemara.ControlEvaluation),
-		controlStepNames: make(map[string][][]string),
+		policyID:           policyID,
+		targetID:           targetID,
+		reqToControl:       defaultMap(reqToControl),
+		reqToPlan:          defaultMap(reqToPlan),
+		reqToComplypackRef: defaultMap(reqToComplypackRef),
+		controlEvals:       make(map[string]*gemara.ControlEvaluation),
+		controlStepNames:   make(map[string][][]string),
 	}
 }
 
@@ -299,16 +295,10 @@ func formatStepIdentity(complypackRef, stepName string) string {
 	return stepName
 }
 
-// resolveComplypackRef returns the OCI reference for the complypack associated
-// with the given requirement ID. It looks up the evaluator that owns the
-// requirement, then resolves the complypack reference for that evaluator.
-// Returns "" when no complypack is configured for the requirement's evaluator.
+// resolveComplypackRef returns the pre-resolved OCI reference for the
+// complypack associated with the given requirement ID.
 func (e *Evaluator) resolveComplypackRef(requirementID string) string {
-	evalID, ok := e.reqToEvaluator[requirementID]
-	if !ok {
-		return ""
-	}
-	return e.complypackRefs[evalID]
+	return e.reqToComplypackRef[requirementID]
 }
 
 // toSerializable converts a gemara.EvaluationLog into the shadow struct,

--- a/internal/output/evaluator.go
+++ b/internal/output/evaluator.go
@@ -90,9 +90,10 @@ func (e *Evaluator) GemaraLog() *gemara.EvaluationLog {
 		Evaluations: evals,
 		Result:      result,
 		Metadata: gemara.Metadata{
-			Id:          e.policyID,
-			Type:        gemara.EvaluationLogArtifact,
-			Description: "Compliance scan evaluation log",
+			Id:            e.policyID,
+			Type:          gemara.EvaluationLogArtifact,
+			GemaraVersion: gemara.SchemaVersion,
+			Description:   "Compliance scan evaluation log",
 			Author: gemara.Actor{
 				Id:   "complytime",
 				Name: "complytime",
@@ -165,10 +166,35 @@ func (e *Evaluator) providerToGemaraAssessment(a *provider.AssessmentLog) *gemar
 		Result:          result,
 		Message:         msg,
 		Applicability:   []string{"default"},
+		Steps:           providerStepsToGemara(a.Steps, a.Confidence),
 		Start:           gemara.Datetime(time.Now().Format(time.RFC3339)),
 		StepsExecuted:   int64(len(a.Steps)),
 		ConfidenceLevel: providerConfidenceToGemara(a.Confidence),
 	}
+}
+
+// providerStepToGemara wraps a provider.Step into a gemara.AssessmentStep closure.
+// The closure ignores its payload argument and returns the step's pre-computed
+// result, message, and the assessment-level confidence.
+func providerStepToGemara(step provider.Step, confidence provider.ConfidenceLevel) gemara.AssessmentStep {
+	result := providerResultToGemara(step.Result)
+	conf := providerConfidenceToGemara(confidence)
+	return func(_ interface{}) (gemara.Result, string, gemara.ConfidenceLevel) {
+		return result, step.Message, conf
+	}
+}
+
+// providerStepsToGemara converts a slice of provider steps into gemara AssessmentStep closures.
+// Returns nil when the input slice is empty.
+func providerStepsToGemara(steps []provider.Step, confidence provider.ConfidenceLevel) []gemara.AssessmentStep {
+	if len(steps) == 0 {
+		return nil
+	}
+	gemaraSteps := make([]gemara.AssessmentStep, len(steps))
+	for i, s := range steps {
+		gemaraSteps[i] = providerStepToGemara(s, confidence)
+	}
+	return gemaraSteps
 }
 
 func providerConfidenceToGemara(c provider.ConfidenceLevel) gemara.ConfidenceLevel {

--- a/internal/output/evaluator.go
+++ b/internal/output/evaluator.go
@@ -18,24 +18,39 @@ import (
 // Evaluator accumulates provider assessments for a single target and produces
 // a gemara.EvaluationLog grouped by control.
 type Evaluator struct {
-	policyID     string
-	targetID     string
-	reqToControl map[string]string
-	controlEvals map[string]*gemara.ControlEvaluation
-	controlOrder []string
+	policyID      string
+	targetID      string
+	reqToControl  map[string]string
+	reqToPlan     map[string]string
+	complypackRef string
+	controlEvals  map[string]*gemara.ControlEvaluation
+	controlOrder  []string
+	// controlStepNames tracks step name strings parallel to each control's
+	// AssessmentLogs slice. Keyed by control ID, each value is a slice of
+	// step name slices (one per assessment log under that control).
+	controlStepNames map[string][][]string
 }
 
 // NewEvaluator creates an Evaluator scoped to a single target. reqToControl
 // maps requirement IDs to control IDs; pass nil when the catalog is unavailable.
-func NewEvaluator(policyID, targetID string, reqToControl map[string]string) *Evaluator {
+// reqToPlan maps requirement IDs to assessment plan IDs for populating the Plan
+// field; pass nil when unavailable. complypackRef is the OCI reference
+// (repository@digest) for step identity; pass "" when no complypack is configured.
+func NewEvaluator(policyID, targetID string, reqToControl, reqToPlan map[string]string, complypackRef string) *Evaluator {
 	if reqToControl == nil {
 		reqToControl = make(map[string]string)
 	}
+	if reqToPlan == nil {
+		reqToPlan = make(map[string]string)
+	}
 	return &Evaluator{
-		policyID:     policyID,
-		targetID:     targetID,
-		reqToControl: reqToControl,
-		controlEvals: make(map[string]*gemara.ControlEvaluation),
+		policyID:         policyID,
+		targetID:         targetID,
+		reqToControl:     reqToControl,
+		reqToPlan:        reqToPlan,
+		complypackRef:    complypackRef,
+		controlEvals:     make(map[string]*gemara.ControlEvaluation),
+		controlStepNames: make(map[string][][]string),
 	}
 }
 
@@ -51,7 +66,7 @@ func (e *Evaluator) AddTarget(assessments []provider.AssessmentLog) {
 		a := &assessments[i]
 		controlID := e.resolveControl(a.RequirementID)
 
-		gemaraAssessment := e.providerToGemaraAssessment(a)
+		gemaraAssessment, stepNames := e.providerToGemaraAssessment(a)
 
 		ce, exists := e.controlEvals[controlID]
 		if !exists {
@@ -68,6 +83,7 @@ func (e *Evaluator) AddTarget(assessments []provider.AssessmentLog) {
 		}
 
 		ce.AssessmentLogs = append(ce.AssessmentLogs, gemaraAssessment)
+		e.controlStepNames[controlID] = append(e.controlStepNames[controlID], stepNames)
 		ce.Result = gemara.UpdateAggregateResult(ce.Result, gemaraAssessment.Result)
 		ce.Message = gemaraAssessment.Message
 	}
@@ -110,10 +126,13 @@ func (e *Evaluator) GemaraLog() *gemara.EvaluationLog {
 }
 
 // Write serializes the evaluation log as YAML to outDir and returns the path.
+// It uses a shadow struct to replace gemara.AssessmentStep function closures
+// with human-readable step identity strings.
 func (e *Evaluator) Write(outDir string) (string, error) {
 	evalLog := e.GemaraLog()
+	serializable := e.toSerializable(evalLog)
 
-	data, err := yaml.Marshal(evalLog)
+	data, err := yaml.Marshal(serializable)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal evaluation log: %w", err)
 	}
@@ -139,7 +158,7 @@ func (e *Evaluator) resolveControl(requirementID string) string {
 	return requirementID
 }
 
-func (e *Evaluator) providerToGemaraAssessment(a *provider.AssessmentLog) *gemara.AssessmentLog {
+func (e *Evaluator) providerToGemaraAssessment(a *provider.AssessmentLog) (*gemara.AssessmentLog, []string) {
 	result := aggregateResultFromSteps(a.Steps)
 
 	msg := a.Message
@@ -157,7 +176,7 @@ func (e *Evaluator) providerToGemaraAssessment(a *provider.AssessmentLog) *gemar
 		desc = a.RequirementID
 	}
 
-	return &gemara.AssessmentLog{
+	gemaraLog := &gemara.AssessmentLog{
 		Requirement: gemara.EntryMapping{
 			ReferenceId: e.policyID,
 			EntryId:     a.RequirementID,
@@ -171,6 +190,23 @@ func (e *Evaluator) providerToGemaraAssessment(a *provider.AssessmentLog) *gemar
 		StepsExecuted:   int64(len(a.Steps)),
 		ConfidenceLevel: providerConfidenceToGemara(a.Confidence),
 	}
+
+	// Populate the Plan field when a plan ID mapping exists for this requirement.
+	if planID, ok := e.reqToPlan[a.RequirementID]; ok {
+		gemaraLog.Plan = &gemara.EntryMapping{
+			ReferenceId: e.policyID,
+			EntryId:     planID,
+		}
+	}
+
+	// Collect step names so the shadow struct serialization can produce
+	// human-readable step identity strings instead of function pointer names.
+	names := make([]string, len(a.Steps))
+	for i, s := range a.Steps {
+		names[i] = s.Name
+	}
+
+	return gemaraLog, names
 }
 
 // providerStepToGemara wraps a provider.Step into a gemara.AssessmentStep closure.
@@ -210,5 +246,96 @@ func providerConfidenceToGemara(c provider.ConfidenceLevel) gemara.ConfidenceLev
 	default:
 		// Unknown provider values map to Undetermined as the most conservative confidence level.
 		return gemara.Undetermined
+	}
+}
+
+// Shadow struct types mirror gemara types but replace Steps []AssessmentStep
+// (function type) with Steps []string (identity strings) for YAML serialization.
+
+type serializableEvaluationLog struct {
+	Metadata    gemara.Metadata                  `yaml:"metadata"`
+	Result      gemara.Result                    `yaml:"result"`
+	Evaluations []*serializableControlEvaluation `yaml:"evaluations"`
+	Target      gemara.Resource                  `yaml:"target"`
+}
+
+type serializableControlEvaluation struct {
+	Name           string                       `yaml:"name"`
+	Result         gemara.Result                `yaml:"result"`
+	Message        string                       `yaml:"message"`
+	Control        gemara.EntryMapping          `yaml:"control"`
+	AssessmentLogs []*serializableAssessmentLog `yaml:"assessment-logs"`
+}
+
+type serializableAssessmentLog struct {
+	Requirement     gemara.EntryMapping    `yaml:"requirement"`
+	Plan            *gemara.EntryMapping   `yaml:"plan,omitempty"`
+	Description     string                 `yaml:"description"`
+	Result          gemara.Result          `yaml:"result"`
+	Message         string                 `yaml:"message"`
+	Applicability   []string               `yaml:"applicability"`
+	Steps           []string               `yaml:"steps"`
+	StepsExecuted   int64                  `yaml:"steps-executed,omitempty"`
+	Start           gemara.Datetime        `yaml:"start"`
+	End             gemara.Datetime        `yaml:"end,omitempty"`
+	Recommendation  string                 `yaml:"recommendation,omitempty"`
+	ConfidenceLevel gemara.ConfidenceLevel `yaml:"confidence-level,omitempty"`
+}
+
+// formatStepIdentity produces a step identity string. When complypackRef is
+// non-empty, the format is "{complypackRef}#{stepName}". Otherwise, the bare
+// stepName is returned.
+func formatStepIdentity(complypackRef, stepName string) string {
+	if complypackRef != "" && stepName != "" {
+		return complypackRef + "#" + stepName
+	}
+	return stepName
+}
+
+// toSerializable converts a gemara.EvaluationLog into the shadow struct,
+// replacing AssessmentStep closures with formatted step identity strings.
+func (e *Evaluator) toSerializable(log *gemara.EvaluationLog) *serializableEvaluationLog {
+	sEvals := make([]*serializableControlEvaluation, len(log.Evaluations))
+	for i, ce := range log.Evaluations {
+		controlID := ce.Control.EntryId
+		controlNames := e.controlStepNames[controlID]
+		sLogs := make([]*serializableAssessmentLog, len(ce.AssessmentLogs))
+		for j, al := range ce.AssessmentLogs {
+			var names []string
+			if j < len(controlNames) {
+				names = controlNames[j]
+			}
+			steps := make([]string, len(names))
+			for k, name := range names {
+				steps[k] = formatStepIdentity(e.complypackRef, name)
+			}
+			sLogs[j] = &serializableAssessmentLog{
+				Requirement:     al.Requirement,
+				Plan:            al.Plan,
+				Description:     al.Description,
+				Result:          al.Result,
+				Message:         al.Message,
+				Applicability:   al.Applicability,
+				Steps:           steps,
+				StepsExecuted:   al.StepsExecuted,
+				Start:           al.Start,
+				End:             al.End,
+				Recommendation:  al.Recommendation,
+				ConfidenceLevel: al.ConfidenceLevel,
+			}
+		}
+		sEvals[i] = &serializableControlEvaluation{
+			Name:           ce.Name,
+			Result:         ce.Result,
+			Message:        ce.Message,
+			Control:        ce.Control,
+			AssessmentLogs: sLogs,
+		}
+	}
+	return &serializableEvaluationLog{
+		Metadata:    log.Metadata,
+		Result:      log.Result,
+		Evaluations: sEvals,
+		Target:      log.Target,
 	}
 }

--- a/internal/output/evaluator.go
+++ b/internal/output/evaluator.go
@@ -18,37 +18,44 @@ import (
 // Evaluator accumulates provider assessments for a single target and produces
 // a gemara.EvaluationLog grouped by control.
 type Evaluator struct {
-	policyID      string
-	targetID      string
-	reqToControl  map[string]string
-	reqToPlan     map[string]string
-	complypackRef string
-	controlEvals  map[string]*gemara.ControlEvaluation
-	controlOrder  []string
+	policyID       string
+	targetID       string
+	reqToControl   map[string]string
+	reqToPlan      map[string]string
+	complypackRefs map[string]string
+	reqToEvaluator map[string]string
+	controlEvals   map[string]*gemara.ControlEvaluation
+	controlOrder   []string
 	// controlStepNames tracks step name strings parallel to each control's
 	// AssessmentLogs slice. Keyed by control ID, each value is a slice of
 	// step name slices (one per assessment log under that control).
 	controlStepNames map[string][][]string
 }
 
+// defaultMap returns m if non-nil, otherwise a new empty map.
+func defaultMap(m map[string]string) map[string]string {
+	if m == nil {
+		return make(map[string]string)
+	}
+	return m
+}
+
 // NewEvaluator creates an Evaluator scoped to a single target. reqToControl
 // maps requirement IDs to control IDs; pass nil when the catalog is unavailable.
 // reqToPlan maps requirement IDs to assessment plan IDs for populating the Plan
-// field; pass nil when unavailable. complypackRef is the OCI reference
-// (repository@digest) for step identity; pass "" when no complypack is configured.
-func NewEvaluator(policyID, targetID string, reqToControl, reqToPlan map[string]string, complypackRef string) *Evaluator {
-	if reqToControl == nil {
-		reqToControl = make(map[string]string)
-	}
-	if reqToPlan == nil {
-		reqToPlan = make(map[string]string)
-	}
+// field; pass nil when unavailable. complypackRefs maps evaluator IDs to OCI
+// references (repository@digest) for step identity; pass nil when no complypacks
+// are configured. reqToEvaluator maps requirement IDs to evaluator IDs for
+// resolving which complypack reference applies to each assessment; pass nil
+// when unavailable.
+func NewEvaluator(policyID, targetID string, reqToControl, reqToPlan, complypackRefs, reqToEvaluator map[string]string) *Evaluator {
 	return &Evaluator{
 		policyID:         policyID,
 		targetID:         targetID,
-		reqToControl:     reqToControl,
-		reqToPlan:        reqToPlan,
-		complypackRef:    complypackRef,
+		reqToControl:     defaultMap(reqToControl),
+		reqToPlan:        defaultMap(reqToPlan),
+		complypackRefs:   defaultMap(complypackRefs),
+		reqToEvaluator:   defaultMap(reqToEvaluator),
 		controlEvals:     make(map[string]*gemara.ControlEvaluation),
 		controlStepNames: make(map[string][][]string),
 	}
@@ -292,6 +299,18 @@ func formatStepIdentity(complypackRef, stepName string) string {
 	return stepName
 }
 
+// resolveComplypackRef returns the OCI reference for the complypack associated
+// with the given requirement ID. It looks up the evaluator that owns the
+// requirement, then resolves the complypack reference for that evaluator.
+// Returns "" when no complypack is configured for the requirement's evaluator.
+func (e *Evaluator) resolveComplypackRef(requirementID string) string {
+	evalID, ok := e.reqToEvaluator[requirementID]
+	if !ok {
+		return ""
+	}
+	return e.complypackRefs[evalID]
+}
+
 // toSerializable converts a gemara.EvaluationLog into the shadow struct,
 // replacing AssessmentStep closures with formatted step identity strings.
 func (e *Evaluator) toSerializable(log *gemara.EvaluationLog) *serializableEvaluationLog {
@@ -301,13 +320,14 @@ func (e *Evaluator) toSerializable(log *gemara.EvaluationLog) *serializableEvalu
 		controlNames := e.controlStepNames[controlID]
 		sLogs := make([]*serializableAssessmentLog, len(ce.AssessmentLogs))
 		for j, al := range ce.AssessmentLogs {
+			complypackRef := e.resolveComplypackRef(al.Requirement.EntryId)
 			var names []string
 			if j < len(controlNames) {
 				names = controlNames[j]
 			}
 			steps := make([]string, len(names))
 			for k, name := range names {
-				steps[k] = formatStepIdentity(e.complypackRef, name)
+				steps[k] = formatStepIdentity(complypackRef, name)
 			}
 			sLogs[j] = &serializableAssessmentLog{
 				Requirement:     al.Requirement,

--- a/internal/output/evaluator_internal_test.go
+++ b/internal/output/evaluator_internal_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package output
+
+import (
+	"testing"
+
+	"github.com/gemaraproj/go-gemara"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/complytime/complyctl/pkg/provider"
+)
+
+func TestProviderStepToGemara_SingleStep(t *testing.T) {
+	step := provider.Step{
+		Name:    "check-permissions",
+		Result:  provider.ResultPassed,
+		Message: "all permissions valid",
+	}
+
+	closure := providerStepToGemara(step, provider.ConfidenceLevelHigh)
+	require.NotNil(t, closure)
+
+	result, msg, conf := closure(nil)
+	assert.Equal(t, gemara.Passed, result)
+	assert.Equal(t, "all permissions valid", msg)
+	assert.Equal(t, gemara.High, conf)
+}
+
+func TestProviderStepsToGemara_MultipleSteps(t *testing.T) {
+	steps := []provider.Step{
+		{Name: "step-1", Result: provider.ResultPassed, Message: "passed"},
+		{Name: "step-2", Result: provider.ResultFailed, Message: "failed check"},
+		{Name: "step-3", Result: provider.ResultSkipped, Message: "skipped"},
+	}
+
+	closures := providerStepsToGemara(steps, provider.ConfidenceLevelMedium)
+	require.Len(t, closures, 3)
+
+	r1, m1, c1 := closures[0](nil)
+	assert.Equal(t, gemara.Passed, r1)
+	assert.Equal(t, "passed", m1)
+	assert.Equal(t, gemara.Medium, c1)
+
+	r2, m2, c2 := closures[1](nil)
+	assert.Equal(t, gemara.Failed, r2)
+	assert.Equal(t, "failed check", m2)
+	assert.Equal(t, gemara.Medium, c2)
+
+	r3, m3, c3 := closures[2](nil)
+	assert.Equal(t, gemara.NotApplicable, r3)
+	assert.Equal(t, "skipped", m3)
+	assert.Equal(t, gemara.Medium, c3)
+}
+
+func TestProviderStepsToGemara_EmptySteps(t *testing.T) {
+	closures := providerStepsToGemara(nil, provider.ConfidenceLevelHigh)
+	assert.Nil(t, closures)
+
+	closures = providerStepsToGemara([]provider.Step{}, provider.ConfidenceLevelHigh)
+	assert.Nil(t, closures)
+}
+
+func TestProviderStepToGemara_ResultMapping(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    provider.Result
+		expected gemara.Result
+	}{
+		{"Passed", provider.ResultPassed, gemara.Passed},
+		{"Failed", provider.ResultFailed, gemara.Failed},
+		{"Skipped", provider.ResultSkipped, gemara.NotApplicable},
+		{"Error", provider.ResultError, gemara.Unknown},
+		{"Unrecognized", provider.Result(99), gemara.NotRun},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			step := provider.Step{
+				Name:    "test-step",
+				Result:  tt.input,
+				Message: "test",
+			}
+			closure := providerStepToGemara(step, provider.ConfidenceLevelUndetermined)
+			result, _, _ := closure(nil)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// Regression test for issue #573: before this fix, providerToGemaraAssessment
+// did not populate the Steps field, causing evaluation log YAML to always
+// contain steps: [] even when providers sent populated step data.
+func TestProviderToGemaraAssessment_StepsPopulated(t *testing.T) {
+	e := NewEvaluator("test-policy", "target-1", nil)
+
+	assessment := &provider.AssessmentLog{
+		RequirementID: "req-1",
+		Message:       "assessment complete",
+		Confidence:    provider.ConfidenceLevelHigh,
+		Steps: []provider.Step{
+			{Name: "check-a", Result: provider.ResultPassed, Message: "ok"},
+			{Name: "check-b", Result: provider.ResultPassed, Message: "ok too"},
+		},
+	}
+
+	result := e.providerToGemaraAssessment(assessment)
+
+	require.NotNil(t, result)
+	require.Len(t, result.Steps, 2)
+	assert.Equal(t, int64(2), result.StepsExecuted)
+
+	r1, m1, c1 := result.Steps[0](nil)
+	assert.Equal(t, gemara.Passed, r1)
+	assert.Equal(t, "ok", m1)
+	assert.Equal(t, gemara.High, c1)
+
+	r2, m2, c2 := result.Steps[1](nil)
+	assert.Equal(t, gemara.Passed, r2)
+	assert.Equal(t, "ok too", m2)
+	assert.Equal(t, gemara.High, c2)
+}

--- a/internal/output/evaluator_internal_test.go
+++ b/internal/output/evaluator_internal_test.go
@@ -93,7 +93,7 @@ func TestProviderStepToGemara_ResultMapping(t *testing.T) {
 // did not populate the Steps field, causing evaluation log YAML to always
 // contain steps: [] even when providers sent populated step data.
 func TestProviderToGemaraAssessment_StepsPopulated(t *testing.T) {
-	e := NewEvaluator("test-policy", "target-1", nil, nil, "")
+	e := NewEvaluator("test-policy", "target-1", nil, nil, nil, nil)
 
 	assessment := &provider.AssessmentLog{
 		RequirementID: "req-1",

--- a/internal/output/evaluator_internal_test.go
+++ b/internal/output/evaluator_internal_test.go
@@ -93,7 +93,7 @@ func TestProviderStepToGemara_ResultMapping(t *testing.T) {
 // did not populate the Steps field, causing evaluation log YAML to always
 // contain steps: [] even when providers sent populated step data.
 func TestProviderToGemaraAssessment_StepsPopulated(t *testing.T) {
-	e := NewEvaluator("test-policy", "target-1", nil)
+	e := NewEvaluator("test-policy", "target-1", nil, nil, "")
 
 	assessment := &provider.AssessmentLog{
 		RequirementID: "req-1",
@@ -105,7 +105,7 @@ func TestProviderToGemaraAssessment_StepsPopulated(t *testing.T) {
 		},
 	}
 
-	result := e.providerToGemaraAssessment(assessment)
+	result, _ := e.providerToGemaraAssessment(assessment)
 
 	require.NotNil(t, result)
 	require.Len(t, result.Steps, 2)

--- a/internal/output/evaluator_internal_test.go
+++ b/internal/output/evaluator_internal_test.go
@@ -93,7 +93,7 @@ func TestProviderStepToGemara_ResultMapping(t *testing.T) {
 // did not populate the Steps field, causing evaluation log YAML to always
 // contain steps: [] even when providers sent populated step data.
 func TestProviderToGemaraAssessment_StepsPopulated(t *testing.T) {
-	e := NewEvaluator("test-policy", "target-1", nil, nil, nil, nil)
+	e := NewEvaluator("test-policy", "target-1", nil, nil, nil)
 
 	assessment := &provider.AssessmentLog{
 		RequirementID: "req-1",

--- a/internal/output/evaluator_test.go
+++ b/internal/output/evaluator_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestNewEvaluator_NilMapsInitialized(t *testing.T) {
-	eval := output.NewEvaluator("pol", "tgt", nil, nil, nil, nil)
+	eval := output.NewEvaluator("pol", "tgt", nil, nil, nil)
 	// Should not panic when adding targets — nil maps are initialized internally.
 	eval.AddTarget([]provider.AssessmentLog{
 		{RequirementID: "R1", Steps: []provider.Step{{Result: provider.ResultPassed, Message: "ok"}}},
@@ -26,9 +26,8 @@ func TestNewEvaluator_NilMapsInitialized(t *testing.T) {
 func TestNewEvaluator_NonNilMapsPreserved(t *testing.T) {
 	reqToControl := map[string]string{"req-1": "ctrl-1"}
 	reqToPlan := map[string]string{"req-1": "plan-1"}
-	complypackRefs := map[string]string{"opa": "registry.example.com/complypacks/opa@sha256:abc"}
-	reqToEvaluator := map[string]string{"req-1": "opa"}
-	eval := output.NewEvaluator("pol", "tgt", reqToControl, reqToPlan, complypackRefs, reqToEvaluator)
+	reqToComplypackRef := map[string]string{"req-1": "registry.example.com/complypacks/opa@sha256:abc"}
+	eval := output.NewEvaluator("pol", "tgt", reqToControl, reqToPlan, reqToComplypackRef)
 	eval.AddTarget([]provider.AssessmentLog{
 		{
 			RequirementID: "req-1",
@@ -41,7 +40,7 @@ func TestNewEvaluator_NonNilMapsPreserved(t *testing.T) {
 }
 
 func TestGemaraLog_MetadataType(t *testing.T) {
-	eval := output.NewEvaluator("test-policy", "target-1", nil, nil, nil, nil)
+	eval := output.NewEvaluator("test-policy", "target-1", nil, nil, nil)
 	eval.AddTarget([]provider.AssessmentLog{
 		{
 			RequirementID: "REQ-1",
@@ -79,7 +78,7 @@ func TestGemaraLog_AggregatesResult(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			eval := output.NewEvaluator("pol", "tgt", nil, nil, nil, nil)
+			eval := output.NewEvaluator("pol", "tgt", nil, nil, nil)
 			eval.AddTarget([]provider.AssessmentLog{
 				{RequirementID: "R1", Steps: tt.steps},
 			})
@@ -89,7 +88,7 @@ func TestGemaraLog_AggregatesResult(t *testing.T) {
 }
 
 func TestGemaraLog_PopulatesTarget(t *testing.T) {
-	eval := output.NewEvaluator("policy-id", "my-target", nil, nil, nil, nil)
+	eval := output.NewEvaluator("policy-id", "my-target", nil, nil, nil)
 	eval.AddTarget([]provider.AssessmentLog{
 		{RequirementID: "R1", Steps: []provider.Step{{Result: provider.ResultPassed, Message: "ok"}}},
 	})
@@ -101,7 +100,7 @@ func TestGemaraLog_PopulatesTarget(t *testing.T) {
 }
 
 func TestGemaraLog_AssessmentMessageUsesStepViolation(t *testing.T) {
-	eval := output.NewEvaluator("pol", "tgt", nil, nil, nil, nil)
+	eval := output.NewEvaluator("pol", "tgt", nil, nil, nil)
 	eval.AddTarget([]provider.AssessmentLog{
 		{
 			RequirementID: "REQ-1",
@@ -119,7 +118,7 @@ func TestGemaraLog_AssessmentMessageUsesStepViolation(t *testing.T) {
 }
 
 func TestGemaraLog_PassingAssessmentKeepsProviderMessage(t *testing.T) {
-	eval := output.NewEvaluator("pol", "tgt", nil, nil, nil, nil)
+	eval := output.NewEvaluator("pol", "tgt", nil, nil, nil)
 	eval.AddTarget([]provider.AssessmentLog{
 		{
 			RequirementID: "REQ-1",
@@ -138,7 +137,7 @@ func TestGemaraLog_PassingAssessmentKeepsProviderMessage(t *testing.T) {
 
 func TestGemaraLog_PlanFieldPopulated(t *testing.T) {
 	reqToPlan := map[string]string{"req-1": "plan-1"}
-	eval := output.NewEvaluator("pol", "tgt", nil, reqToPlan, nil, nil)
+	eval := output.NewEvaluator("pol", "tgt", nil, reqToPlan, nil)
 	eval.AddTarget([]provider.AssessmentLog{
 		{RequirementID: "req-1", Steps: []provider.Step{{Result: provider.ResultPassed, Message: "ok"}}},
 	})
@@ -153,7 +152,7 @@ func TestGemaraLog_PlanFieldPopulated(t *testing.T) {
 }
 
 func TestGemaraLog_PlanFieldOmittedWhenNoMapping(t *testing.T) {
-	eval := output.NewEvaluator("pol", "tgt", nil, nil, nil, nil)
+	eval := output.NewEvaluator("pol", "tgt", nil, nil, nil)
 	eval.AddTarget([]provider.AssessmentLog{
 		{RequirementID: "req-1", Steps: []provider.Step{{Result: provider.ResultPassed, Message: "ok"}}},
 	})
@@ -166,7 +165,7 @@ func TestGemaraLog_PlanFieldOmittedWhenNoMapping(t *testing.T) {
 
 func TestGemaraLog_PlanFieldOmittedForUnmappedRequirement(t *testing.T) {
 	reqToPlan := map[string]string{"other-req": "plan-99"}
-	eval := output.NewEvaluator("pol", "tgt", nil, reqToPlan, nil, nil)
+	eval := output.NewEvaluator("pol", "tgt", nil, reqToPlan, nil)
 	eval.AddTarget([]provider.AssessmentLog{
 		{RequirementID: "req-1", Steps: []provider.Step{{Result: provider.ResultPassed, Message: "ok"}}},
 	})
@@ -179,7 +178,7 @@ func TestGemaraLog_PlanFieldOmittedForUnmappedRequirement(t *testing.T) {
 
 func TestEvaluator_Write(t *testing.T) {
 	outDir := t.TempDir()
-	eval := output.NewEvaluator("test-policy", "target-1", nil, nil, nil, nil)
+	eval := output.NewEvaluator("test-policy", "target-1", nil, nil, nil)
 	eval.AddTarget([]provider.AssessmentLog{
 		{RequirementID: "R1", Steps: []provider.Step{{Result: provider.ResultPassed, Message: "ok"}}},
 	})
@@ -193,9 +192,8 @@ func TestEvaluator_Write(t *testing.T) {
 func TestEvaluator_Write_StepIdentityWithComplypackRef(t *testing.T) {
 	outDir := t.TempDir()
 	reqToPlan := map[string]string{"req-1": "plan-1"}
-	complypackRefs := map[string]string{"opa": "registry.example.com/complypacks/opa@sha256:abc123"}
-	reqToEvaluator := map[string]string{"req-1": "opa"}
-	eval := output.NewEvaluator("pol", "tgt", nil, reqToPlan, complypackRefs, reqToEvaluator)
+	reqToComplypackRef := map[string]string{"req-1": "registry.example.com/complypacks/opa@sha256:abc123"}
+	eval := output.NewEvaluator("pol", "tgt", nil, reqToPlan, reqToComplypackRef)
 	eval.AddTarget([]provider.AssessmentLog{
 		{
 			RequirementID: "req-1",
@@ -219,7 +217,7 @@ func TestEvaluator_Write_StepIdentityWithComplypackRef(t *testing.T) {
 
 func TestEvaluator_Write_StepIdentityWithoutComplypack(t *testing.T) {
 	outDir := t.TempDir()
-	eval := output.NewEvaluator("pol", "tgt", nil, nil, nil, nil)
+	eval := output.NewEvaluator("pol", "tgt", nil, nil, nil)
 	eval.AddTarget([]provider.AssessmentLog{
 		{
 			RequirementID: "req-1",
@@ -241,7 +239,7 @@ func TestEvaluator_Write_StepIdentityWithoutComplypack(t *testing.T) {
 
 func TestEvaluator_Write_StepIdentityEmptyName(t *testing.T) {
 	outDir := t.TempDir()
-	eval := output.NewEvaluator("pol", "tgt", nil, nil, nil, nil)
+	eval := output.NewEvaluator("pol", "tgt", nil, nil, nil)
 	eval.AddTarget([]provider.AssessmentLog{
 		{
 			RequirementID: "req-1",

--- a/internal/output/evaluator_test.go
+++ b/internal/output/evaluator_test.go
@@ -14,8 +14,34 @@ import (
 	"github.com/complytime/complyctl/pkg/provider"
 )
 
+func TestNewEvaluator_NilMapsInitialized(t *testing.T) {
+	eval := output.NewEvaluator("pol", "tgt", nil, nil, nil, nil)
+	// Should not panic when adding targets — nil maps are initialized internally.
+	eval.AddTarget([]provider.AssessmentLog{
+		{RequirementID: "R1", Steps: []provider.Step{{Result: provider.ResultPassed, Message: "ok"}}},
+	})
+	assert.Equal(t, gemara.Passed, eval.GemaraLog().Result)
+}
+
+func TestNewEvaluator_NonNilMapsPreserved(t *testing.T) {
+	reqToControl := map[string]string{"req-1": "ctrl-1"}
+	reqToPlan := map[string]string{"req-1": "plan-1"}
+	complypackRefs := map[string]string{"opa": "registry.example.com/complypacks/opa@sha256:abc"}
+	reqToEvaluator := map[string]string{"req-1": "opa"}
+	eval := output.NewEvaluator("pol", "tgt", reqToControl, reqToPlan, complypackRefs, reqToEvaluator)
+	eval.AddTarget([]provider.AssessmentLog{
+		{
+			RequirementID: "req-1",
+			Steps:         []provider.Step{{Name: "check", Result: provider.ResultPassed, Message: "ok"}},
+		},
+	})
+	log := eval.GemaraLog()
+	require.Len(t, log.Evaluations, 1)
+	assert.Equal(t, "ctrl-1", log.Evaluations[0].Name)
+}
+
 func TestGemaraLog_MetadataType(t *testing.T) {
-	eval := output.NewEvaluator("test-policy", "target-1", nil, nil, "")
+	eval := output.NewEvaluator("test-policy", "target-1", nil, nil, nil, nil)
 	eval.AddTarget([]provider.AssessmentLog{
 		{
 			RequirementID: "REQ-1",
@@ -53,7 +79,7 @@ func TestGemaraLog_AggregatesResult(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			eval := output.NewEvaluator("pol", "tgt", nil, nil, "")
+			eval := output.NewEvaluator("pol", "tgt", nil, nil, nil, nil)
 			eval.AddTarget([]provider.AssessmentLog{
 				{RequirementID: "R1", Steps: tt.steps},
 			})
@@ -63,7 +89,7 @@ func TestGemaraLog_AggregatesResult(t *testing.T) {
 }
 
 func TestGemaraLog_PopulatesTarget(t *testing.T) {
-	eval := output.NewEvaluator("policy-id", "my-target", nil, nil, "")
+	eval := output.NewEvaluator("policy-id", "my-target", nil, nil, nil, nil)
 	eval.AddTarget([]provider.AssessmentLog{
 		{RequirementID: "R1", Steps: []provider.Step{{Result: provider.ResultPassed, Message: "ok"}}},
 	})
@@ -75,7 +101,7 @@ func TestGemaraLog_PopulatesTarget(t *testing.T) {
 }
 
 func TestGemaraLog_AssessmentMessageUsesStepViolation(t *testing.T) {
-	eval := output.NewEvaluator("pol", "tgt", nil, nil, "")
+	eval := output.NewEvaluator("pol", "tgt", nil, nil, nil, nil)
 	eval.AddTarget([]provider.AssessmentLog{
 		{
 			RequirementID: "REQ-1",
@@ -93,7 +119,7 @@ func TestGemaraLog_AssessmentMessageUsesStepViolation(t *testing.T) {
 }
 
 func TestGemaraLog_PassingAssessmentKeepsProviderMessage(t *testing.T) {
-	eval := output.NewEvaluator("pol", "tgt", nil, nil, "")
+	eval := output.NewEvaluator("pol", "tgt", nil, nil, nil, nil)
 	eval.AddTarget([]provider.AssessmentLog{
 		{
 			RequirementID: "REQ-1",
@@ -112,7 +138,7 @@ func TestGemaraLog_PassingAssessmentKeepsProviderMessage(t *testing.T) {
 
 func TestGemaraLog_PlanFieldPopulated(t *testing.T) {
 	reqToPlan := map[string]string{"req-1": "plan-1"}
-	eval := output.NewEvaluator("pol", "tgt", nil, reqToPlan, "")
+	eval := output.NewEvaluator("pol", "tgt", nil, reqToPlan, nil, nil)
 	eval.AddTarget([]provider.AssessmentLog{
 		{RequirementID: "req-1", Steps: []provider.Step{{Result: provider.ResultPassed, Message: "ok"}}},
 	})
@@ -127,7 +153,7 @@ func TestGemaraLog_PlanFieldPopulated(t *testing.T) {
 }
 
 func TestGemaraLog_PlanFieldOmittedWhenNoMapping(t *testing.T) {
-	eval := output.NewEvaluator("pol", "tgt", nil, nil, "")
+	eval := output.NewEvaluator("pol", "tgt", nil, nil, nil, nil)
 	eval.AddTarget([]provider.AssessmentLog{
 		{RequirementID: "req-1", Steps: []provider.Step{{Result: provider.ResultPassed, Message: "ok"}}},
 	})
@@ -140,7 +166,7 @@ func TestGemaraLog_PlanFieldOmittedWhenNoMapping(t *testing.T) {
 
 func TestGemaraLog_PlanFieldOmittedForUnmappedRequirement(t *testing.T) {
 	reqToPlan := map[string]string{"other-req": "plan-99"}
-	eval := output.NewEvaluator("pol", "tgt", nil, reqToPlan, "")
+	eval := output.NewEvaluator("pol", "tgt", nil, reqToPlan, nil, nil)
 	eval.AddTarget([]provider.AssessmentLog{
 		{RequirementID: "req-1", Steps: []provider.Step{{Result: provider.ResultPassed, Message: "ok"}}},
 	})
@@ -153,7 +179,7 @@ func TestGemaraLog_PlanFieldOmittedForUnmappedRequirement(t *testing.T) {
 
 func TestEvaluator_Write(t *testing.T) {
 	outDir := t.TempDir()
-	eval := output.NewEvaluator("test-policy", "target-1", nil, nil, "")
+	eval := output.NewEvaluator("test-policy", "target-1", nil, nil, nil, nil)
 	eval.AddTarget([]provider.AssessmentLog{
 		{RequirementID: "R1", Steps: []provider.Step{{Result: provider.ResultPassed, Message: "ok"}}},
 	})
@@ -167,7 +193,9 @@ func TestEvaluator_Write(t *testing.T) {
 func TestEvaluator_Write_StepIdentityWithComplypackRef(t *testing.T) {
 	outDir := t.TempDir()
 	reqToPlan := map[string]string{"req-1": "plan-1"}
-	eval := output.NewEvaluator("pol", "tgt", nil, reqToPlan, "registry.example.com/complypacks/opa@sha256:abc123")
+	complypackRefs := map[string]string{"opa": "registry.example.com/complypacks/opa@sha256:abc123"}
+	reqToEvaluator := map[string]string{"req-1": "opa"}
+	eval := output.NewEvaluator("pol", "tgt", nil, reqToPlan, complypackRefs, reqToEvaluator)
 	eval.AddTarget([]provider.AssessmentLog{
 		{
 			RequirementID: "req-1",
@@ -191,7 +219,7 @@ func TestEvaluator_Write_StepIdentityWithComplypackRef(t *testing.T) {
 
 func TestEvaluator_Write_StepIdentityWithoutComplypack(t *testing.T) {
 	outDir := t.TempDir()
-	eval := output.NewEvaluator("pol", "tgt", nil, nil, "")
+	eval := output.NewEvaluator("pol", "tgt", nil, nil, nil, nil)
 	eval.AddTarget([]provider.AssessmentLog{
 		{
 			RequirementID: "req-1",
@@ -213,7 +241,7 @@ func TestEvaluator_Write_StepIdentityWithoutComplypack(t *testing.T) {
 
 func TestEvaluator_Write_StepIdentityEmptyName(t *testing.T) {
 	outDir := t.TempDir()
-	eval := output.NewEvaluator("pol", "tgt", nil, nil, "")
+	eval := output.NewEvaluator("pol", "tgt", nil, nil, nil, nil)
 	eval.AddTarget([]provider.AssessmentLog{
 		{
 			RequirementID: "req-1",

--- a/internal/output/evaluator_test.go
+++ b/internal/output/evaluator_test.go
@@ -24,6 +24,7 @@ func TestGemaraLog_MetadataType(t *testing.T) {
 
 	log := eval.GemaraLog()
 	assert.Equal(t, gemara.EvaluationLogArtifact, log.Metadata.Type)
+	assert.Equal(t, gemara.SchemaVersion, log.Metadata.GemaraVersion)
 }
 
 func TestGemaraLog_AggregatesResult(t *testing.T) {

--- a/internal/output/evaluator_test.go
+++ b/internal/output/evaluator_test.go
@@ -3,6 +3,7 @@
 package output_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/gemaraproj/go-gemara"
@@ -14,7 +15,7 @@ import (
 )
 
 func TestGemaraLog_MetadataType(t *testing.T) {
-	eval := output.NewEvaluator("test-policy", "target-1", nil)
+	eval := output.NewEvaluator("test-policy", "target-1", nil, nil, "")
 	eval.AddTarget([]provider.AssessmentLog{
 		{
 			RequirementID: "REQ-1",
@@ -52,7 +53,7 @@ func TestGemaraLog_AggregatesResult(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			eval := output.NewEvaluator("pol", "tgt", nil)
+			eval := output.NewEvaluator("pol", "tgt", nil, nil, "")
 			eval.AddTarget([]provider.AssessmentLog{
 				{RequirementID: "R1", Steps: tt.steps},
 			})
@@ -62,7 +63,7 @@ func TestGemaraLog_AggregatesResult(t *testing.T) {
 }
 
 func TestGemaraLog_PopulatesTarget(t *testing.T) {
-	eval := output.NewEvaluator("policy-id", "my-target", nil)
+	eval := output.NewEvaluator("policy-id", "my-target", nil, nil, "")
 	eval.AddTarget([]provider.AssessmentLog{
 		{RequirementID: "R1", Steps: []provider.Step{{Result: provider.ResultPassed, Message: "ok"}}},
 	})
@@ -74,7 +75,7 @@ func TestGemaraLog_PopulatesTarget(t *testing.T) {
 }
 
 func TestGemaraLog_AssessmentMessageUsesStepViolation(t *testing.T) {
-	eval := output.NewEvaluator("pol", "tgt", nil)
+	eval := output.NewEvaluator("pol", "tgt", nil, nil, "")
 	eval.AddTarget([]provider.AssessmentLog{
 		{
 			RequirementID: "REQ-1",
@@ -92,7 +93,7 @@ func TestGemaraLog_AssessmentMessageUsesStepViolation(t *testing.T) {
 }
 
 func TestGemaraLog_PassingAssessmentKeepsProviderMessage(t *testing.T) {
-	eval := output.NewEvaluator("pol", "tgt", nil)
+	eval := output.NewEvaluator("pol", "tgt", nil, nil, "")
 	eval.AddTarget([]provider.AssessmentLog{
 		{
 			RequirementID: "REQ-1",
@@ -109,9 +110,50 @@ func TestGemaraLog_PassingAssessmentKeepsProviderMessage(t *testing.T) {
 	assert.Equal(t, "1 of 1 targets passed", log.Evaluations[0].AssessmentLogs[0].Message)
 }
 
+func TestGemaraLog_PlanFieldPopulated(t *testing.T) {
+	reqToPlan := map[string]string{"req-1": "plan-1"}
+	eval := output.NewEvaluator("pol", "tgt", nil, reqToPlan, "")
+	eval.AddTarget([]provider.AssessmentLog{
+		{RequirementID: "req-1", Steps: []provider.Step{{Result: provider.ResultPassed, Message: "ok"}}},
+	})
+
+	log := eval.GemaraLog()
+	require.Len(t, log.Evaluations, 1)
+	require.Len(t, log.Evaluations[0].AssessmentLogs, 1)
+	al := log.Evaluations[0].AssessmentLogs[0]
+	require.NotNil(t, al.Plan)
+	assert.Equal(t, "pol", al.Plan.ReferenceId)
+	assert.Equal(t, "plan-1", al.Plan.EntryId)
+}
+
+func TestGemaraLog_PlanFieldOmittedWhenNoMapping(t *testing.T) {
+	eval := output.NewEvaluator("pol", "tgt", nil, nil, "")
+	eval.AddTarget([]provider.AssessmentLog{
+		{RequirementID: "req-1", Steps: []provider.Step{{Result: provider.ResultPassed, Message: "ok"}}},
+	})
+
+	log := eval.GemaraLog()
+	require.Len(t, log.Evaluations, 1)
+	require.Len(t, log.Evaluations[0].AssessmentLogs, 1)
+	assert.Nil(t, log.Evaluations[0].AssessmentLogs[0].Plan)
+}
+
+func TestGemaraLog_PlanFieldOmittedForUnmappedRequirement(t *testing.T) {
+	reqToPlan := map[string]string{"other-req": "plan-99"}
+	eval := output.NewEvaluator("pol", "tgt", nil, reqToPlan, "")
+	eval.AddTarget([]provider.AssessmentLog{
+		{RequirementID: "req-1", Steps: []provider.Step{{Result: provider.ResultPassed, Message: "ok"}}},
+	})
+
+	log := eval.GemaraLog()
+	require.Len(t, log.Evaluations, 1)
+	require.Len(t, log.Evaluations[0].AssessmentLogs, 1)
+	assert.Nil(t, log.Evaluations[0].AssessmentLogs[0].Plan)
+}
+
 func TestEvaluator_Write(t *testing.T) {
 	outDir := t.TempDir()
-	eval := output.NewEvaluator("test-policy", "target-1", nil)
+	eval := output.NewEvaluator("test-policy", "target-1", nil, nil, "")
 	eval.AddTarget([]provider.AssessmentLog{
 		{RequirementID: "R1", Steps: []provider.Step{{Result: provider.ResultPassed, Message: "ok"}}},
 	})
@@ -120,4 +162,72 @@ func TestEvaluator_Write(t *testing.T) {
 	require.NoError(t, err)
 	assert.FileExists(t, path)
 	assert.Contains(t, path, "evaluation-log-test-policy-target-1-")
+}
+
+func TestEvaluator_Write_StepIdentityWithComplypackRef(t *testing.T) {
+	outDir := t.TempDir()
+	reqToPlan := map[string]string{"req-1": "plan-1"}
+	eval := output.NewEvaluator("pol", "tgt", nil, reqToPlan, "registry.example.com/complypacks/opa@sha256:abc123")
+	eval.AddTarget([]provider.AssessmentLog{
+		{
+			RequirementID: "req-1",
+			Steps: []provider.Step{
+				{Name: "kubernetes.run_as_nonroot", Result: provider.ResultPassed, Message: "ok"},
+			},
+		},
+	})
+
+	path, err := eval.Write(outDir)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	content := string(data)
+	assert.Contains(t, content, "registry.example.com/complypacks/opa@sha256:abc123#kubernetes.run_as_nonroot")
+	assert.NotContains(t, content, "providerStepToGemara")
+	assert.Contains(t, content, "plan:")
+	assert.Contains(t, content, "entry-id: plan-1")
+}
+
+func TestEvaluator_Write_StepIdentityWithoutComplypack(t *testing.T) {
+	outDir := t.TempDir()
+	eval := output.NewEvaluator("pol", "tgt", nil, nil, "")
+	eval.AddTarget([]provider.AssessmentLog{
+		{
+			RequirementID: "req-1",
+			Steps: []provider.Step{
+				{Name: "my-check", Result: provider.ResultPassed, Message: "ok"},
+			},
+		},
+	})
+
+	path, err := eval.Write(outDir)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	content := string(data)
+	assert.Contains(t, content, "- my-check")
+	assert.NotContains(t, content, "providerStepToGemara")
+}
+
+func TestEvaluator_Write_StepIdentityEmptyName(t *testing.T) {
+	outDir := t.TempDir()
+	eval := output.NewEvaluator("pol", "tgt", nil, nil, "")
+	eval.AddTarget([]provider.AssessmentLog{
+		{
+			RequirementID: "req-1",
+			Steps: []provider.Step{
+				{Name: "", Result: provider.ResultPassed, Message: "ok"},
+			},
+		},
+	})
+
+	path, err := eval.Write(outDir)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	content := string(data)
+	assert.NotContains(t, content, "providerStepToGemara")
 }

--- a/internal/output/oscal_test.go
+++ b/internal/output/oscal_test.go
@@ -20,8 +20,9 @@ import (
 func mockGemaraEvalLog() *gemara.EvaluationLog {
 	return &gemara.EvaluationLog{
 		Metadata: gemara.Metadata{
-			Id:          "test-policy",
-			Description: "Test evaluation log",
+			Id:            "test-policy",
+			GemaraVersion: gemara.SchemaVersion,
+			Description:   "Test evaluation log",
 			Author: gemara.Actor{
 				Id:   "complytime",
 				Name: "complytime",

--- a/internal/output/step_identity_test.go
+++ b/internal/output/step_identity_test.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package output
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatStepIdentity_WithComplypackRef(t *testing.T) {
+	result := formatStepIdentity("registry.example.com/complypacks/opa@sha256:abc123", "kubernetes.run_as_nonroot")
+	assert.Equal(t, "registry.example.com/complypacks/opa@sha256:abc123#kubernetes.run_as_nonroot", result)
+}
+
+func TestFormatStepIdentity_WithoutComplypackRef(t *testing.T) {
+	result := formatStepIdentity("", "my-check")
+	assert.Equal(t, "my-check", result)
+}
+
+func TestFormatStepIdentity_EmptyStepName(t *testing.T) {
+	result := formatStepIdentity("registry.example.com/complypacks/opa@sha256:abc123", "")
+	assert.Equal(t, "", result)
+}
+
+func TestFormatStepIdentity_BothEmpty(t *testing.T) {
+	result := formatStepIdentity("", "")
+	assert.Equal(t, "", result)
+}

--- a/openspec/changes/eval-log-plan-step-identity/.openspec.yaml
+++ b/openspec/changes/eval-log-plan-step-identity/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-11

--- a/openspec/changes/eval-log-plan-step-identity/design.md
+++ b/openspec/changes/eval-log-plan-step-identity/design.md
@@ -1,0 +1,70 @@
+## Context
+
+Evaluation logs produced by `complyctl scan` follow the Gemara `EvaluationLog` schema. The conversion from `provider.AssessmentLog` (data struct with `RequirementID`, `Steps []Step`) to `gemara.AssessmentLog` happens in `internal/output/evaluator.go`. PR #575 fixed the structural bug where `Steps` was always empty by wrapping `provider.Step` into `gemara.AssessmentStep` closures, but two identity problems remain:
+
+1. `gemara.AssessmentLog.Plan` (`*EntryMapping`) is never populated. The assessment plan ID exists in the dependency graph (`policy.Assessment.ID`) and is used to build configs for providers, but it is discarded during post-scan ID resolution (`resolveAssessmentIDs` overwrites `RequirementID` with the resolved requirement ID, losing the plan ID).
+
+2. `gemara.AssessmentStep` is a function type (`func(payload interface{}) (Result, string, ConfidenceLevel)`). When YAML-marshaled, Go serializes it as the runtime function pointer name (e.g., `github.com/complytime/complyctl/internal/output.providerStepsToGemara.providerStepToGemara.func1`). The step identity should be a meaningful string linking to the check that was run.
+
+Key constraints:
+- `gemara.AssessmentStep` is defined in go-gemara as a function type and cannot change
+- No new proto fields on `Step` (CUE validation constraint)
+- Providers already receive `Step.Name` via gRPC and can set it to complypack mapping IDs
+- Complypack OCI refs (repository + digest) are tracked in `internal/cache/state.go` via `State.Complypacks`
+
+## Goals / Non-Goals
+
+**Goals:**
+- Populate `gemara.AssessmentLog.Plan` with the assessment plan's `EntryMapping` so each assessment result links to its originating plan
+- Produce human-readable, digest-pinned step identity strings in serialized evaluation logs
+- Preserve backward compatibility: evaluation logs without complypacks still produce valid output (step names fall back to provider-supplied `Step.Name`)
+
+**Non-Goals:**
+- Changing the `gemara.AssessmentStep` function type in go-gemara
+- Adding new proto fields to `Step` or `AssessmentConfiguration`
+- Setting `Step.Name` to complypack mapping IDs on the provider side (that is a `complytime-providers` change)
+- Modifying SARIF, OSCAL, or Markdown output formatters (this change scopes to evaluation log only)
+
+## Decisions
+
+### D1: Preserve plan IDs through a reverse map
+
+**Decision**: Build a reverse map (`reqToPlan`: requirement_id -> plan_id) from the same `extractPlanToReqMap` data and pass it to `NewEvaluator()`.
+
+**Rationale**: `resolveAssessmentIDs()` destructively overwrites `RequirementID` with the resolved requirement ID before evaluators run. Rather than changing the mutation order or adding a field to `provider.AssessmentLog`, a reverse map lets the evaluator look up the original plan ID from the already-resolved requirement ID.
+
+**Alternatives considered**:
+- Store original plan ID on `provider.AssessmentLog` before mutation: Requires changing a cross-package type for a single consumer. More invasive.
+- Defer `resolveAssessmentIDs()` to after evaluator construction: Other formatters (SARIF, Markdown, scan summary) also depend on the resolved IDs. Reordering creates risk.
+- Pass `planToReq` map directly and invert inside evaluator: Pushes knowledge of the naming inversion into the output package. The scan command already has both maps available.
+
+### D2: Shadow struct for step serialization in Write()
+
+**Decision**: In `Evaluator.Write()`, build a parallel struct that mirrors `gemara.EvaluationLog` but replaces `Steps []AssessmentStep` (function slice) with `Steps []string` (identity strings). Marshal the shadow struct instead of the gemara struct.
+
+**Rationale**: `gemara.AssessmentStep` is a function type that cannot be meaningfully serialized by any YAML library. The shadow struct approach keeps the gemara domain types unchanged in memory (closures remain callable for any future in-process use) while controlling serialization output. This is a localized change in one method.
+
+**Alternatives considered**:
+- Custom YAML marshaler on `gemara.AssessmentLog`: Would require go-gemara changes or type aliasing hacks.
+- Store step identity strings alongside closures in a parallel slice on `gemara.AssessmentLog`: Requires go-gemara type changes.
+- Post-process the YAML bytes with string replacement: Fragile and dependent on marshal output format.
+
+### D3: Step identity format
+
+**Decision**: Step identity strings use the format `{oci-ref}#{step-name}` where `oci-ref` is `{repository}@{digest}` and `step-name` is the provider-supplied `Step.Name`. When no complypack OCI ref is available, fall back to bare `Step.Name`.
+
+**Format**: `registry.example.com/complypacks/opa@sha256:abc123#kubernetes.run_as_nonroot`
+
+**Rationale**: The OCI ref pins the exact complypack version, making step identity reproducible across runs. The `#` fragment separator is a natural delimiter that avoids ambiguity with OCI ref syntax. Bare `Step.Name` fallback ensures backward compatibility when no complypack is configured.
+
+### D4: Thread complypack OCI ref via evaluator-id keyed lookup
+
+**Decision**: In `scan.go`, after loading cache state, build a map from evaluator-id to complypack OCI ref string (`repository@digest`). Pass the OCI ref for each evaluator group into the evaluator construction. The `Evaluator` stores a single `complypackRef` string.
+
+**Rationale**: `State.Complypacks` is keyed by repository, but evaluator groups are keyed by evaluator-id. The complypack cache's `LookupByEvaluatorID()` already bridges this gap. The cache state's `PolicyState.Digest` provides the digest. Building the OCI ref string at the scan command level keeps the evaluator package unaware of cache internals.
+
+## Risks / Trade-offs
+
+- [Plan ID uniqueness] The reverse map (`reqToPlan`) assumes a 1:1 mapping from requirement ID to plan ID. If multiple plans map to the same requirement ID, only one plan ID is preserved. -> Mitigation: The Gemara schema specifies one assessment plan per requirement-id in a given policy. This is a structural constraint, not a runtime concern.
+- [Step.Name not set by providers] Until providers are updated to set `Step.Name` to complypack mapping IDs, step identity strings will be empty or generic. -> Mitigation: The complyctl-side change is forward-compatible. Step identity degrades gracefully to bare `Step.Name` or empty string. Provider updates are tracked in `complytime-providers`.
+- [Shadow struct maintenance] The shadow struct duplicates parts of the gemara type hierarchy. If go-gemara adds fields to `AssessmentLog`, the shadow struct must be updated. -> Mitigation: The shadow struct is minimal (only replaces the `Steps` field type). A compile-time test can verify field coverage.

--- a/openspec/changes/eval-log-plan-step-identity/proposal.md
+++ b/openspec/changes/eval-log-plan-step-identity/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+After PR #575 fixes the structural bug where evaluation logs showed `steps: []`, two identity gaps remain in the serialized output. Steps display Go function pointer names (e.g., `...providerStepToGemara.func1`) instead of meaningful identifiers, and the `plan` field on `gemara.AssessmentLog` is never populated. This breaks the requirement-to-plan-to-step traceability chain that Gemara evaluation logs are designed to provide. Without it, consumers of evaluation logs cannot trace an assessment result back to the specific plan that was executed or the specific check that produced it.
+
+## What Changes
+
+- Populate the `gemara.AssessmentLog.Plan` field (`*EntryMapping`) with the assessment plan ID, linking each assessment result to the policy plan that triggered it
+- Thread plan ID from the dependency graph through the scan pipeline into the `Evaluator`, preserving plan identity alongside the resolved requirement ID
+- Accept complypack OCI ref (repository + digest) in the `Evaluator` and combine it with `Step.Name` to produce stable, digest-pinned step identity strings at serialization time
+- Override step serialization in `Write()` using a shadow struct so that `gemara.AssessmentStep` function types render as human-readable identity strings (e.g., `registry.example.com/complypacks/opa@sha256:abc123#kubernetes.run_as_nonroot`) instead of Go function pointer names
+
+## Capabilities
+
+### New Capabilities
+- `eval-log-traceability`: Populating the assessment plan field and producing meaningful step identity strings in evaluation log output
+
+### Modified Capabilities
+
+## Impact
+
+- `internal/output/evaluator.go`: New fields on `Evaluator` struct (plan map, complypack OCI ref), updated `providerToGemaraAssessment()`, shadow struct in `Write()`
+- `cmd/complyctl/cli/scan.go`: Thread reverse plan map and complypack OCI ref from cache state into evaluator construction
+- `internal/cache/state.go`: Read-only usage of existing `State.Complypacks` entries (no changes to state itself)
+- No proto changes (`api/plugin/plugin.proto`): step identity uses existing `Step.name` field
+- No go-gemara changes: `AssessmentStep` stays a function type; shadow struct handles serialization
+- Provider-side (`complytime-providers`): Providers must set `Step.Name` to complypack mapping IDs -- tracked separately in complytime-providers, not in this change

--- a/openspec/changes/eval-log-plan-step-identity/specs/eval-log-traceability/spec.md
+++ b/openspec/changes/eval-log-plan-step-identity/specs/eval-log-traceability/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Assessment plan field populated in evaluation logs
+The evaluation log output SHALL populate the `plan` field on each `gemara.AssessmentLog` entry with an `EntryMapping` that links the assessment result to the assessment plan that triggered it. The `EntryMapping.ReferenceId` SHALL be the policy repository identifier and `EntryMapping.EntryId` SHALL be the assessment plan ID from the dependency graph.
+
+#### Scenario: Plan field present in evaluation log YAML
+- **WHEN** `complyctl scan` produces an evaluation log for a policy with assessment plans
+- **THEN** each `assessment-logs` entry in the YAML output SHALL contain a `plan` field with `reference-id` set to the policy repository and `entry-id` set to the assessment plan ID
+
+#### Scenario: Plan field absent when no plan ID is available
+- **WHEN** `complyctl scan` produces an evaluation log and no plan-to-requirement mapping exists for a given assessment
+- **THEN** the `plan` field SHALL be omitted from that `assessment-logs` entry (the field is optional per Gemara schema)
+
+### Requirement: Step identity strings in evaluation logs
+The evaluation log output SHALL serialize `gemara.AssessmentStep` entries as human-readable identity strings instead of Go function pointer names. Each step identity string SHALL combine the complypack OCI reference with the provider-supplied step name.
+
+#### Scenario: Step identity with complypack OCI ref
+- **WHEN** `complyctl scan` produces an evaluation log and a complypack OCI ref is available for the evaluator
+- **THEN** each step in the `steps` array SHALL be serialized as `{repository}@{digest}#{step-name}` where `repository` and `digest` come from the complypack cache state and `step-name` comes from `Step.Name`
+
+#### Scenario: Step identity without complypack
+- **WHEN** `complyctl scan` produces an evaluation log and no complypack is configured for the evaluator
+- **THEN** each step in the `steps` array SHALL be serialized as the bare `Step.Name` value from the provider response
+
+#### Scenario: Step identity with empty Step.Name
+- **WHEN** `complyctl scan` produces an evaluation log and the provider did not set `Step.Name`
+- **THEN** the step SHALL be serialized as an empty string (or omitted if the serialization library skips empty values)
+
+### Requirement: Traceability chain completeness
+The evaluation log SHALL provide a complete traceability chain from requirement through plan to step for each assessment result.
+
+#### Scenario: Full traceability chain
+- **WHEN** `complyctl scan` produces an evaluation log for a policy with assessment plans and a provider that sets step names
+- **THEN** the evaluation log SHALL contain: `requirement.entry-id` (the requirement ID), `plan.entry-id` (the assessment plan ID), and `steps` entries (step identity strings linking to the specific checks executed)
+
+### Requirement: Backward compatibility
+The evaluation log output SHALL remain valid when complypacks are not configured or when providers do not set step names.
+
+#### Scenario: No complypack configured
+- **WHEN** `complyctl scan` runs against a policy without complypacks
+- **THEN** the evaluation log SHALL omit the complypack OCI ref prefix from step identities and the `plan` field SHALL still be populated if plan IDs are available from the dependency graph
+
+#### Scenario: Provider does not set Step.Name
+- **WHEN** `complyctl scan` runs and a provider returns steps without setting the `Name` field
+- **THEN** the evaluation log SHALL still serialize steps (with empty or omitted identity strings) and SHALL still populate `plan` and `requirement` fields

--- a/openspec/changes/eval-log-plan-step-identity/tasks.md
+++ b/openspec/changes/eval-log-plan-step-identity/tasks.md
@@ -1,0 +1,34 @@
+## 1. Plan ID Threading
+
+- [x] 1.1 Add `reqToPlan map[string]string` field to `Evaluator` struct and accept it in `NewEvaluator()` (`internal/output/evaluator.go`)
+- [x] 1.2 Build reverse map (`reqToPlan`) from `extractPlanToReqMap` data in `runScanAndReport()` (`cmd/complyctl/cli/scan.go`)
+- [x] 1.3 Pass `reqToPlan` through `processScanOutput()` and `buildEvaluators()` into `NewEvaluator()` (`cmd/complyctl/cli/scan.go`)
+- [x] 1.4 Populate `Plan: &gemara.EntryMapping{ReferenceId: e.policyID, EntryId: planID}` in `providerToGemaraAssessment()` using `reqToPlan` lookup (`internal/output/evaluator.go`)
+- [x] 1.5 Add unit tests for plan field population: plan present, plan absent, plan omitted when no mapping exists (`internal/output/evaluator_test.go`)
+
+## 2. Complypack OCI Ref Threading
+
+- [x] 2.1 Add `complypackRef string` field to `Evaluator` struct and accept it in `NewEvaluator()` (`internal/output/evaluator.go`)
+- [x] 2.2 Build evaluator-id to complypack OCI ref map from `State.Complypacks` and complypack cache in `runScanAndReport()` or `processScanOutput()` (`cmd/complyctl/cli/scan.go`)
+- [x] 2.3 Pass complypack OCI ref through `buildEvaluators()` into `NewEvaluator()` (`cmd/complyctl/cli/scan.go`)
+- [x] 2.4 Add unit test verifying complypack ref is threaded to the evaluator (`cmd/complyctl/cli/cli_test.go`)
+
+## 3. Shadow Struct for Step Serialization
+
+- [x] 3.1 Define shadow structs mirroring `gemara.EvaluationLog`, `gemara.ControlEvaluation`, and `gemara.AssessmentLog` with `Steps []string` instead of `Steps []AssessmentStep` (`internal/output/evaluator.go`)
+- [x] 3.2 Add `formatStepIdentity(complypackRef, stepName string) string` helper that produces `{ref}#{name}` or bare `{name}` (`internal/output/evaluator.go`)
+- [x] 3.3 Add conversion function from `gemara.EvaluationLog` to shadow struct, extracting step names from closures via a stored name slice or parallel tracking (`internal/output/evaluator.go`)
+- [x] 3.4 Update `Write()` to marshal the shadow struct instead of the gemara struct (`internal/output/evaluator.go`)
+- [x] 3.5 Add unit tests for `formatStepIdentity()`: with OCI ref, without OCI ref, empty step name (`internal/output/evaluator_test.go`)
+- [x] 3.6 Add unit test for `Write()` verifying serialized YAML contains step identity strings instead of function pointer names (`internal/output/evaluator_test.go`)
+
+## 4. Step Name Tracking
+
+- [x] 4.1 Store step names alongside closures in `providerToGemaraAssessment()` so shadow struct conversion can access them (add `stepNames []string` field to `Evaluator` or accumulate per-assessment) (`internal/output/evaluator.go`)
+- [x] 4.2 Add unit test verifying step names are preserved through the conversion pipeline (`internal/output/evaluator_test.go`)
+
+## 5. Integration Verification
+
+- [x] 5.1 Run `make test-unit` and verify all new and existing tests pass
+- [x] 5.2 Run `make lint` and fix any linter warnings
+- [ ] 5.3 Verify evaluation log YAML output in devcontainer with OPA and Ampel providers: confirm `plan` field present and `steps` contain identity strings (or bare names if providers have not yet been updated)

--- a/openspec/changes/fix-scan-step-closures/.openspec.yaml
+++ b/openspec/changes/fix-scan-step-closures/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-09

--- a/openspec/changes/fix-scan-step-closures/design.md
+++ b/openspec/changes/fix-scan-step-closures/design.md
@@ -1,0 +1,108 @@
+## Context
+
+The `complyctl scan` command collects `provider.AssessmentLog` results from
+provider plugins via gRPC and converts them into `gemara.EvaluationLog` for
+output. The conversion lives in `internal/output/evaluator.go`, specifically
+the `providerToGemaraAssessment()` method (line 121).
+
+The provider pipeline works correctly end-to-end: providers populate
+`provider.Step` structs with Name, Result, and Message; the gRPC layer
+serializes/deserializes them faithfully via `api/plugin/plugin.proto` Step
+messages; and the evaluator receives intact `[]provider.Step` slices.
+
+The problem is at the final conversion step. `gemara.AssessmentLog.Steps` is
+typed as `[]gemara.AssessmentStep`, where `AssessmentStep` is a function type
+`func(payload interface{}) (Result, string, ConfidenceLevel)`. The evaluator
+never populates this field, so the YAML output always contains `steps: []`.
+
+Two helper functions already exist in `internal/output/sarif.go`:
+- `providerResultToGemara()` (line 42): maps `provider.Result` to `gemara.Result`
+- `aggregateResultFromSteps()` (line 57): iterates provider steps and aggregates
+
+These are package-private and already used by the evaluator.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Populate `gemara.AssessmentLog.Steps` with closures that return each
+  provider step's result, message, and confidence level.
+- Produce evaluation log YAML that passes Gemara schema validation (non-empty
+  `steps` arrays).
+- Maintain backward compatibility with all existing output formats (SARIF,
+  OSCAL, Markdown).
+
+**Non-Goals:**
+- Making the closures re-executable against live data. These are data-carrying
+  closures that replay fixed results; they are not live assessment functions.
+- Changing the provider gRPC API or proto definitions.
+- Modifying the gemara library itself.
+- Adding step-level detail to Markdown or OSCAL output formats (future work).
+
+## Decisions
+
+### D1: Wrap provider Steps as data-carrying closures
+
+Each `provider.Step` is converted to a `gemara.AssessmentStep` closure that
+ignores its `payload` argument and returns the step's pre-computed result,
+message, and confidence level:
+
+```go
+func providerStepToGemara(step provider.Step, confidence provider.ConfidenceLevel) gemara.AssessmentStep {
+    result := providerResultToGemara(step.Result)
+    conf := providerConfidenceToGemara(confidence)
+    return func(_ interface{}) (gemara.Result, string, gemara.ConfidenceLevel) {
+        return result, step.Message, conf
+    }
+}
+```
+
+**Rationale**: The gemara `AssessmentStep` type is designed for executable
+steps in a live evaluation engine. In the complyctl context, the evaluation
+has already been performed by the provider. The closure pattern satisfies
+the type contract while preserving the step data for serialization. The
+`MarshalYAML()` and `MarshalJSON()` methods on `AssessmentStep` use
+`runtime.FuncForPC()` to serialize the function name, which will produce a
+stable identifier for these closures.
+
+**Alternative considered**: Creating a separate struct that implements a
+hypothetical `AssessmentStep` interface. Rejected because `AssessmentStep`
+is a function type, not an interface, so no struct-based alternative is
+possible without modifying the gemara library.
+
+### D2: Use assessment-level confidence for all steps
+
+The `provider.Step` struct does not carry a per-step confidence level. The
+closure uses the parent `provider.AssessmentLog.Confidence` value for all
+steps within that assessment.
+
+**Rationale**: The provider gRPC API defines confidence at the assessment
+level, not the step level. Using the assessment-level confidence is the
+most accurate representation of what the provider communicated.
+
+### D3: Place the conversion function in evaluator.go
+
+The new `providerStepToGemara()` function lives in `evaluator.go` alongside
+`providerToGemaraAssessment()` and `providerConfidenceToGemara()`, since it
+is part of the same provider-to-gemara conversion pipeline.
+
+**Rationale**: Keeps the conversion logic colocated. The existing
+`providerResultToGemara()` in `sarif.go` is already called from
+`aggregateResultFromSteps()` which is used by the evaluator. No relocation
+of existing functions is needed.
+
+## Risks / Trade-offs
+
+- **[YAML serialization of closures]** The `AssessmentStep.MarshalYAML()`
+  method uses `runtime.FuncForPC()` to extract the function name. For
+  anonymous closures, this produces names like
+  `github.com/complytime/complyctl/internal/output.providerStepToGemara.func1`.
+  This is an implementation detail and not a human-readable step name.
+  Mitigation: This matches how go-gemara itself serializes steps. The step
+  Name field from the provider is preserved in the closure's message return
+  value. Future gemara versions may add a `Name` field to improve
+  serialization.
+
+- **[Test stability]** Function pointer names from `runtime.FuncForPC()` may
+  vary across Go versions or build configurations. Mitigation: Unit tests
+  should verify closure behavior (return values) rather than serialized
+  function names.

--- a/openspec/changes/fix-scan-step-closures/proposal.md
+++ b/openspec/changes/fix-scan-step-closures/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+The `complyctl scan` command produces `gemara.EvaluationLog` output, but the
+per-step assessment data from providers is lost during conversion. Providers
+send `provider.Step` structs (Name, Result, Message) via gRPC, and complyctl
+correctly aggregates them into a top-level result and counts them in
+`StepsExecuted`. However, the `gemara.AssessmentLog.Steps` field is never
+populated because `provider.Step` (a data struct) must be wrapped into
+`gemara.AssessmentStep` (a closure type). This causes evaluation log YAML to
+always contain `steps: []`, which fails Gemara schema validation and prevents
+downstream consumers from inspecting individual assessment steps.
+
+## What Changes
+
+- Add a conversion function that wraps each `provider.Step` into a
+  `gemara.AssessmentStep` closure, capturing the step's Name, Result, and
+  Message as fixed return values.
+- Add a `providerResultToGemara` mapping function in `evaluator.go` (or
+  reuse the existing one from `sarif.go`) to convert `provider.Result` to
+  `gemara.Result` within the closure.
+- Update `providerToGemaraAssessment()` in `internal/output/evaluator.go`
+  to populate the `Steps` field on the returned `gemara.AssessmentLog`.
+- Add unit tests for the step closure conversion and the updated evaluator
+  function.
+
+## Capabilities
+
+### New Capabilities
+
+- `step-closure-conversion`: Convert provider Step data structs into gemara
+  AssessmentStep closures so evaluation logs contain per-step assessment data.
+
+### Modified Capabilities
+
+## Impact
+
+- **Code**: `internal/output/evaluator.go` (primary), `internal/output/sarif.go`
+  (potential reuse of `providerResultToGemara`).
+- **Output**: Evaluation log YAML will now contain populated `steps` arrays,
+  changing the output shape for all scan formats that consume `gemara.EvaluationLog`.
+- **Downstream**: SARIF converter in `gemaraconv` will gain access to step data
+  for `LogicalLocation` enrichment. Markdown and OSCAL formatters are unaffected
+  (they already use `StepsExecuted`).
+- **Dependencies**: No new dependencies. Uses existing `go-gemara` types.
+- **API**: No proto or gRPC changes required. The provider-side data is already
+  transmitted correctly.

--- a/openspec/changes/fix-scan-step-closures/specs/step-closure-conversion/spec.md
+++ b/openspec/changes/fix-scan-step-closures/specs/step-closure-conversion/spec.md
@@ -1,0 +1,70 @@
+## ADDED Requirements
+
+### Requirement: Provider steps converted to gemara AssessmentStep closures
+
+The evaluator SHALL convert each `provider.Step` in a `provider.AssessmentLog`
+into a `gemara.AssessmentStep` closure when building the `gemara.AssessmentLog`.
+Each closure SHALL return the step's pre-computed Result (mapped to
+`gemara.Result`), Message, and the parent assessment's ConfidenceLevel (mapped
+to `gemara.ConfidenceLevel`).
+
+#### Scenario: Single step produces a populated closure
+
+- **WHEN** a provider returns an `AssessmentLog` with one `Step` having
+  Name="check-permissions", Result=Passed, Message="all permissions valid"
+- **THEN** the resulting `gemara.AssessmentLog.Steps` SHALL contain exactly
+  one `AssessmentStep` closure that, when invoked with any payload, returns
+  `(gemara.Passed, "all permissions valid", <mapped confidence>)`
+
+#### Scenario: Multiple steps produce ordered closures
+
+- **WHEN** a provider returns an `AssessmentLog` with three `Step` entries
+- **THEN** the resulting `gemara.AssessmentLog.Steps` SHALL contain three
+  `AssessmentStep` closures in the same order as the provider steps
+
+#### Scenario: Zero steps produce empty Steps slice
+
+- **WHEN** a provider returns an `AssessmentLog` with zero `Step` entries
+- **THEN** the resulting `gemara.AssessmentLog.Steps` SHALL be nil or empty
+  and `StepsExecuted` SHALL be 0
+
+### Requirement: Result mapping preserves provider semantics
+
+The conversion from `provider.Result` to `gemara.Result` within step closures
+SHALL use the same mapping as the existing `providerResultToGemara` function:
+Passed to Passed, Failed to Failed, Skipped to NotApplicable, Error to Unknown,
+and unrecognized values to NotRun.
+
+#### Scenario: Each provider result maps correctly
+
+- **WHEN** a provider step has Result=Failed
+- **THEN** the closure SHALL return `gemara.Failed`
+
+#### Scenario: Unrecognized result maps to NotRun
+
+- **WHEN** a provider step has an unrecognized Result value
+- **THEN** the closure SHALL return `gemara.NotRun`
+
+### Requirement: Confidence mapping uses assessment-level confidence
+
+Each step closure SHALL use the parent `provider.AssessmentLog.Confidence`
+value (mapped to `gemara.ConfidenceLevel`) since provider steps do not carry
+per-step confidence.
+
+#### Scenario: Assessment confidence propagates to all step closures
+
+- **WHEN** an `AssessmentLog` has Confidence=High and contains two steps
+- **THEN** both step closures SHALL return `gemara.High` as their
+  ConfidenceLevel
+
+### Requirement: Evaluation log YAML contains populated steps
+
+The YAML serialization of the `gemara.EvaluationLog` produced by the evaluator
+SHALL contain non-empty `steps` arrays in each `AssessmentLog` that has provider
+steps, enabling Gemara schema validation to pass.
+
+#### Scenario: YAML output contains step entries
+
+- **WHEN** a scan produces assessment logs with provider steps
+- **THEN** the written evaluation log YAML SHALL contain `steps:` arrays with
+  one entry per provider step, serialized via `AssessmentStep.MarshalYAML()`

--- a/openspec/changes/fix-scan-step-closures/tasks.md
+++ b/openspec/changes/fix-scan-step-closures/tasks.md
@@ -1,0 +1,22 @@
+## 1. Step Closure Conversion Function
+
+- [x] 1.1 Add `providerStepToGemara(step provider.Step, confidence provider.ConfidenceLevel) gemara.AssessmentStep` function in `internal/output/evaluator.go` that creates a closure returning `(providerResultToGemara(step.Result), step.Message, providerConfidenceToGemara(confidence))`
+- [x] 1.2 Add `providerStepsToGemara(steps []provider.Step, confidence provider.ConfidenceLevel) []gemara.AssessmentStep` helper that maps a slice of provider steps to gemara step closures
+
+## 2. Evaluator Integration
+
+- [x] 2.1 Update `providerToGemaraAssessment()` in `internal/output/evaluator.go` to populate the `Steps` field on the returned `gemara.AssessmentLog` using `providerStepsToGemara(a.Steps, a.Confidence)`
+
+## 3. Unit Tests
+
+- [x] 3.1 Add test `TestProviderStepToGemara_SingleStep` verifying a single closure returns the correct result, message, and confidence
+- [x] 3.2 Add test `TestProviderStepsToGemara_MultipleSteps` verifying slice conversion preserves order and count
+- [x] 3.3 Add test `TestProviderStepsToGemara_EmptySteps` verifying empty input returns nil/empty slice
+- [x] 3.4 Add test `TestProviderStepToGemara_ResultMapping` verifying each provider.Result maps to the correct gemara.Result (Passed, Failed, Skipped, Error, unrecognized)
+- [x] 3.5 Add test `TestProviderToGemaraAssessment_StepsPopulated` verifying the full `providerToGemaraAssessment()` method now populates `Steps` with the correct count and callable closures
+
+## 4. Verification
+
+- [x] 4.1 Run `make test-unit` and confirm all tests pass
+- [x] 4.2 Run `make lint` and confirm no lint errors
+- [x] 4.3 Run `make vet` and confirm no vet issues


### PR DESCRIPTION
## Description 

The evaluation log YAML emitted by complyctl scan had two identity gaps after [PR #575](https://github.com/complytime/complyctl/pull/575) fixed the structural step closure bug:

1. The plan field on `gemara.AssessmentLog` was never populated, breaking the requirement-to-plan traceability chain
2. Steps serialized as Go function pointer names (`github.com/complytime/complyctl/internal/output.providerStepsToGemara.providerStepToGemara.func1`)instead of meaningful identifiers linking back to the checks that were run. 

### Notes

The step summary included the Go function pointer names rather than the identifiers from the `.rego` files in the complypack `complytime-mapping.json` associate the gemara requirement-ids (in the Policy assessment plan) to its `.rego` namespace id equivalent (i.e., the assessment plan testable condition related to its actual testable `.rego` file executable checks). By pointing to the correct step execution link they can be accessed by their sha256 once updated in subsequent versions. 

```yaml
evaluations:
- name: force-push-protection
  result: Passed
  message: 1 of 1 repositories passed
  control:
    reference-id: policies/test-branch-protection
    entry-id: force-push-protection
  assessment-logs:
  - requirement:
      reference-id: policies/test-branch-protection
      entry-id: block-force-push
    description: 1 of 1 repositories passed
    result: Passed
    message: 1 of 1 repositories passed
    applicability:
    - default
    steps:
    - github.com/complytime/complyctl/internal/output.providerStepsToGemara.providerStepToGemara.func1 # using the pointer here
    steps-executed: 1
    start: "2026-06-10T01:44:46Z"
    confidence-level: High
```

### Changes
- Add `reqToPlan` and `complypackRef` fields to Evaluator struct. Thread plan ID reverse map and complypack OCI ref from scan pipeline through `processScanOutput`/`buildEvaluators` into `NewEvaluator`
- Populate Plan (*EntryMapping) in `providerToGemaraAssessment` using reqToPlan lookup from the dependency graph
- Define shadow structs mirroring `gemara.EvaluationLog` hierarchy with `Steps []string` instead of `Steps []AssessmentStep` (function type)
- Add `formatStepIdentity()` to produce `'{oci-ref}#{step-name}'` format with **bare step name fallback** when **no** **`complypack`** is configured
- Store step names parallel to closures in stepNames map keyed by `AssessmentLog` pointer; `toSerializable()` converts to shadow struct
- Update `Write()` to marshal shadow struct instead of gemara struct
- Add reverseMap() with collision warning logging
- Add resolveComplypackRef() with debug logging on cache errors

### Unchanged
- `proto` changes
-  no `go-gemara` changes 

> **Note:** Provider-side `Step.Name` population is tracked separately in `complytime-providers`.

## Related Issues

Closes #578 
Supersedes #573 

## Review Hints

---
Testing Steps
Prerequisites: A GitHub Codespace from the opsx/eval-log-plan-step-identity branch on hbraswelrh/complyctl.
1. Rebuild complyctl
```
cd /workspaces/complyctl
make build
```
2. Rebuild OPA provider with synthetic step fix
```
PROVIDERS_TMP=$(mktemp -d)
git clone --depth 1 -b opsx/fix-synthetic-step-names \
    https://github.com/hbraswelrh/complytime-providers.git \
    "$PROVIDERS_TMP/complytime-providers"
make -C "$PROVIDERS_TMP/complytime-providers" build
cp -f "$PROVIDERS_TMP/complytime-providers/bin/complyctl-provider-opa" \
    ~/.complytime/providers/
rm -rf "$PROVIDERS_TMP"
```
3. Clear stale cache and resync
```
cd ~/test-workspace
rm -f ~/.complytime/state.json
rm -rf .complytime/scan .complytime/opa
complyctl get
```
4. Run scan and inspect the evaluation log
```
complyctl scan --policy-id test-opa-bp
cat .complytime/scan/evaluation-log-policies-test-opa-policy-*.yaml
```
5. Verify the output
Check each assessment-logs entry in the YAML for:
- plan: field is present with reference-id and entry-id (was previously missing)
- steps: array contains a string like `"complypacks/test-opa-complypack@sha256:...#test-deployment.yaml"` (was previously `steps: []` or a Go function pointer name like ...`providerStepToGemara.func1`)
Example of correct output:
```
assessment-logs:
- requirement:
    reference-id: policies/test-opa-policy
    entry-id: check-run-as-nonroot
  plan:
    reference-id: policies/test-opa-policy
    entry-id: check-run-as-nonroot
  steps:
  - "complypacks/test-opa-complypack@sha256:...#test-deployment.yaml"
  steps-executed: 1
  confidence-level: High
```
**Note:** Step 2 requires the companion PR hbraswelrh/complytime-providers#opsx/fix-synthetic-step-names (https://github.com/hbraswelrh/complytime-providers/compare/opsx/fix-synthetic-step-names) which populates steps on synthetic passing assessments in the OPA provider. Without it, steps will be steps: [] for requirements that passed all checks.

---
Assisted-by: Claude (Anthropic, Claude Opus 4.6)
