### PR TITLE
docs: remove stale ci_crapload_main.yml reference from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,6 @@ make crapload-check     # check for CRAP regressions against baseline
 | Integration Test | `integration_test.yml` | Shell-based integration tests |
 | Cross-Repo Integration | `ci_cross_repo_integration.yml` | Cross-repo integration tests with complytime-providers |
 | CRAP Load | `ci_crapload.yml` | CRAP analysis on PRs (reusable from org-infra) |
-| CRAP Main | `ci_crapload_main.yml` | CRAP baseline updates on main |
 | Security | `ci_security.yml` | Security scanning |
 | Compliance | `ci_compliance.yml` | Compliance checks |
 | Dependencies | `ci_dependencies.yml` | Dependency management |


### PR DESCRIPTION
## Summary

Remove the `ci_crapload_main.yml` row from the CI Workflow Structure table in `AGENTS.md`. The workflow was deleted in #576 as part of zizmor security hardening, but the documentation reference was not updated.

## Related Issues

- Follow-up to #576

## Review Hints

- Single-line deletion in `AGENTS.md` -  the `CRAP Main` row in the CI Workflow Structure table (line 83).
- The `ci_crapload.yml` PR-level CRAP analysis workflow is unaffected and remains in the table.
