### PR TITLE
fix(proto): resolve protolint line-length violations

### DIFF
--- a/api/plugin/plugin.proto
+++ b/api/plugin/plugin.proto
@@ -7,6 +7,7 @@ syntax = "proto3";
 
 package complyctl.plugin.v1;
 
+// protolint:disable:next MAX_LINE_LENGTH
 option go_package = "github.com/complytime/complyctl/internal/proto/plugin/v1;pluginv1";
 
 // Plugin service for compliance evaluation
@@ -24,18 +25,22 @@ service Plugin {
   // requirements. Called during plugin discovery and doctor diagnostics.
   rpc Describe(DescribeRequest) returns (DescribeResponse);
 
-  // Export ships scan evidence to a Beacon collector via ProofWatch.
-  // Called during `complyctl scan` when COMPLYTIME_EXPORT_ENABLED is set, after scan completes.
-  // Only plugins that declare supports_export=true in DescribeResponse
-  // will receive this call.
+  // Export ships scan evidence to a Beacon collector
+  // via ProofWatch. Called during `complyctl scan` when
+  // COMPLYTIME_EXPORT_ENABLED is set, after scan completes.
+  // Only plugins that declare supports_export=true in
+  // DescribeResponse will receive this call.
   rpc Export(ExportRequest) returns (ExportResponse);
 }
 
-// GenerateRequest contains assessment plan configuration for policy preparation.
+// GenerateRequest contains assessment plan configuration
+// for policy preparation.
 // Uses the three-tier variable model (R48):
 //   Tier 1: global_variables — workspace-level variables
-//   Tier 2: target_variables — per-target variables from complytime.yaml targets[].variables
-//   Tier 3: test variables — per-requirement (in AssessmentConfiguration.parameters)
+//   Tier 2: target_variables — per-target variables
+//          from complytime.yaml targets[].variables
+//   Tier 3: test variables — per-requirement
+//          (in AssessmentConfiguration.parameters)
 message GenerateRequest {
   // Workspace-level variables from complytime.yaml `variables` section.
   // See R48: specs/001-gemara-native-workflow/research.md
@@ -141,6 +146,7 @@ message Step {
 // ConfidenceLevel indicates the evaluator's confidence in an assessment result.
 // Mirrors go-gemara ConfidenceLevel enum (1:1 mapping, no lossy conversion).
 enum ConfidenceLevel {
+  // protolint:disable:next ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH
   CONFIDENCE_LEVEL_NOT_SET = 0;
   CONFIDENCE_LEVEL_UNDETERMINED = 1;
   CONFIDENCE_LEVEL_LOW = 2;

--- a/specs/001-gemara-native-workflow/contracts/plugin.proto
+++ b/specs/001-gemara-native-workflow/contracts/plugin.proto
@@ -33,7 +33,8 @@ message GenerateRequest {
   // Workspace-scoped config (e.g., scan output directory)
   map<string, string> global_variables = 1;
 
-  // Per-requirement test configuration (test variables from policy assessment plan)
+  // Per-requirement test configuration
+  // (test variables from policy assessment plan)
   repeated AssessmentConfiguration configurations = 2;
 }
 
@@ -71,7 +72,8 @@ message Target {
   // Target identifier
   string target_id = 1;
 
-  // Target variables — per-target runtime config (credentials, profile, kubeconfig)
+  // Target variables — per-target runtime config
+  // (credentials, profile, kubeconfig)
   map<string, string> variables = 2;
 }
 

--- a/specs/001-gemara-native-workflow/contracts/plugin.proto
+++ b/specs/001-gemara-native-workflow/contracts/plugin.proto
@@ -28,7 +28,8 @@ service Plugin {
 
 // GenerateRequest contains assessment plan configuration for policy preparation
 message GenerateRequest {
-  // Global variables from workspace config top-level `variables` section (R48, R49)
+  // Global variables from workspace config top-level
+  // `variables` section (R48, R49).
   // Workspace-scoped config (e.g., scan output directory)
   map<string, string> global_variables = 1;
 
@@ -110,6 +111,7 @@ message Step {
 // ConfidenceLevel indicates the evaluator's confidence in an assessment result
 // Mirrors go-gemara ConfidenceLevel enum
 enum ConfidenceLevel {
+  // protolint:disable:next ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH
   CONFIDENCE_LEVEL_NOT_SET = 0;
   CONFIDENCE_LEVEL_UNDETERMINED = 1;
   CONFIDENCE_LEVEL_LOW = 2;


### PR DESCRIPTION
## Summary

Wrap long comments in `api/plugin/plugin.proto` to stay within the 80-character protolint limit. Add `protolint:disable` directives for the `go_package` option line (cannot be shortened) and the `CONFIDENCE_LEVEL_NOT_SET` enum value (deliberate naming choice per spec R29 for 1:1 mapping with go-gemara, not an `_UNSPECIFIED` case).

Apply the same fixes to the spec contract proto.

Generated Go code is unchanged - all fixes are proto comments only.

This failure was pre-existing on main.

## Related Issues

- Follow-up to #576 (zizmor security hardening exposed the pre-existing protolint failures in CI)

## Review Hints

- Only two `.proto` files are changed. No generated code, no Go source, no behavioral changes.
- The `protolint:disable:next` directives follow the same pattern already used in `specs/001-gemara-native-workflow/contracts/plugin.proto:10` for the `go_package` line.
- The `CONFIDENCE_LEVEL_NOT_SET` name is intentionally preserved per spec R29 (`specs/001-gemara-native-workflow/research.md:342`) - go-gemara uses `Undetermined` (iota 0) as its zero value, while the proto uses `NOT_SET` (value 0) to distinguish "no confidence reported" from "confidence evaluated but undetermined."