### PR TITLE
fix(bug): updates support for oci refs

### DIFF
--- a/.gaze/baseline.json
+++ b/.gaze/baseline.json
@@ -154,15 +154,15 @@
       "function": "(*generateOptions).generatePolicy",
       "file": "cmd/complyctl/cli/generate.go",
       "line": 95,
-      "complexity": 4,
-      "line_coverage": 29.41176470588235,
-      "crap": 9.627518827600243
+      "complexity": 5,
+      "line_coverage": 31.57894736842105,
+      "crap": 13.007727073917481
     },
     {
       "package": "cli",
       "function": "invokeGenerate",
       "file": "cmd/complyctl/cli/generate.go",
-      "line": 123,
+      "line": 126,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -171,7 +171,7 @@
       "package": "cli",
       "function": "buildExecutionPlan",
       "file": "cmd/complyctl/cli/generate.go",
-      "line": 137,
+      "line": 140,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -180,7 +180,7 @@
       "package": "cli",
       "function": "providerStatus",
       "file": "cmd/complyctl/cli/generate.go",
-      "line": 155,
+      "line": 158,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -189,7 +189,7 @@
       "package": "cli",
       "function": "saveGenerationAndPrint",
       "file": "cmd/complyctl/cli/generate.go",
-      "line": 162,
+      "line": 165,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -272,15 +272,15 @@
       "function": "syncSinglePolicy",
       "file": "cmd/complyctl/cli/get.go",
       "line": 153,
-      "complexity": 3,
-      "line_coverage": 75,
-      "crap": 3.140625
+      "complexity": 4,
+      "line_coverage": 72.22222222222223,
+      "crap": 4.342935528120713
     },
     {
       "package": "cli",
       "function": "resolveLatestVersion",
       "file": "cmd/complyctl/cli/get.go",
-      "line": 177,
+      "line": 180,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -289,7 +289,7 @@
       "package": "cli",
       "function": "syncAllComplypacks",
       "file": "cmd/complyctl/cli/get.go",
-      "line": 189,
+      "line": 192,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -298,10 +298,10 @@
       "package": "cli",
       "function": "syncSingleComplypack",
       "file": "cmd/complyctl/cli/get.go",
-      "line": 204,
-      "complexity": 4,
+      "line": 207,
+      "complexity": 5,
       "line_coverage": 0,
-      "crap": 20,
+      "crap": 30,
       "fix_strategy": "add_tests"
     },
     {
@@ -358,7 +358,7 @@
       "line": 26,
       "complexity": 4,
       "line_coverage": 41.666666666666664,
-      "crap": 7.175925925925927
+      "crap": 7.1759259259259265
     },
     {
       "package": "cli",
@@ -383,15 +383,15 @@
       "function": "(*listOptions).run",
       "file": "cmd/complyctl/cli/list.go",
       "line": 69,
-      "complexity": 7,
-      "line_coverage": 86.95652173913044,
-      "crap": 7.10873674693844
+      "complexity": 8,
+      "line_coverage": 84,
+      "crap": 8.262144000000001
     },
     {
       "package": "cli",
       "function": "printGemaraPolicyTable",
       "file": "cmd/complyctl/cli/list.go",
-      "line": 108,
+      "line": 111,
       "complexity": 1,
       "line_coverage": 80,
       "crap": 1.008
@@ -403,7 +403,11 @@
       "line": 24,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "no_effects_detected"
     },
     {
       "package": "cli",
@@ -412,7 +416,10 @@
       "line": 31,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 50,
+      "gaze_crap": 1.125,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cli",
@@ -430,7 +437,7 @@
       "line": 48,
       "complexity": 4,
       "line_coverage": 77.77777777777777,
-      "crap": 4.175582990397805
+      "crap": 4.175582990397806
     },
     {
       "package": "cli",
@@ -475,7 +482,10 @@
       "line": 33,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cli",
@@ -484,7 +494,10 @@
       "line": 38,
       "complexity": 2,
       "line_coverage": 100,
-      "crap": 2
+      "crap": 2,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cli",
@@ -493,7 +506,10 @@
       "line": 45,
       "complexity": 5,
       "line_coverage": 70.58823529411765,
-      "crap": 5.636067575819254
+      "crap": 5.636067575819255,
+      "contract_coverage": 100,
+      "gaze_crap": 5,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cli",
@@ -529,7 +545,10 @@
       "line": 86,
       "complexity": 2,
       "line_coverage": 92.3076923076923,
-      "crap": 2.0018206645425582
+      "crap": 2.0018206645425582,
+      "contract_coverage": 100,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cli",
@@ -608,16 +627,16 @@
       "function": "(*scanOptions).scanPolicy",
       "file": "cmd/complyctl/cli/scan.go",
       "line": 254,
-      "complexity": 5,
-      "line_coverage": 23.80952380952381,
-      "crap": 16.057121261202894,
+      "complexity": 6,
+      "line_coverage": 26.08695652173913,
+      "crap": 20.536697624722606,
       "fix_strategy": "add_tests"
     },
     {
       "package": "cli",
       "function": "(*scanOptions).executeScanPhase",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 294,
+      "line": 297,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -626,7 +645,7 @@
       "package": "cli",
       "function": "(*scanOptions).maybeExport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 302,
+      "line": 305,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -635,7 +654,7 @@
       "package": "cli",
       "function": "resolveVersionAndGraph",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 315,
+      "line": 318,
       "complexity": 3,
       "line_coverage": 60,
       "crap": 3.576
@@ -644,7 +663,7 @@
       "package": "cli",
       "function": "loadProviders",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 332,
+      "line": 335,
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
@@ -654,7 +673,7 @@
       "package": "cli",
       "function": "evaluatorIDList",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 348,
+      "line": 351,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -663,7 +682,7 @@
       "package": "cli",
       "function": "targetIDList",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 356,
+      "line": 359,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -672,7 +691,7 @@
       "package": "cli",
       "function": "ensureGenerated",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 364,
+      "line": 367,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -681,7 +700,7 @@
       "package": "cli",
       "function": "runScanAndReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 379,
+      "line": 382,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -690,7 +709,7 @@
       "package": "cli",
       "function": "processScanOutput",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 400,
+      "line": 403,
       "complexity": 3,
       "line_coverage": 87.5,
       "crap": 3.017578125
@@ -699,7 +718,7 @@
       "package": "cli",
       "function": "reportOperationalWarnings",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 418,
+      "line": 421,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -708,7 +727,7 @@
       "package": "cli",
       "function": "checkOperationalErrors",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 427,
+      "line": 430,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -717,7 +736,7 @@
       "package": "cli",
       "function": "buildEvaluators",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 438,
+      "line": 441,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -726,7 +745,7 @@
       "package": "cli",
       "function": "filterTargetByID",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 457,
+      "line": 460,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -735,7 +754,7 @@
       "package": "cli",
       "function": "filterTargetsForPolicy",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 466,
+      "line": 469,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -744,25 +763,16 @@
       "package": "cli",
       "function": "checkGenerationFreshness",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 476,
+      "line": 479,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
     },
     {
       "package": "cli",
-      "function": "complypackDigestsByEvaluator",
-      "file": "cmd/complyctl/cli/scan.go",
-      "line": 492,
-      "complexity": 4,
-      "line_coverage": 100,
-      "crap": 4
-    },
-    {
-      "package": "cli",
       "function": "needsRegeneration",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 502,
+      "line": 494,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -771,7 +781,7 @@
       "package": "cli",
       "function": "evaluatorArtifactsExist",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 519,
+      "line": 511,
       "complexity": 6,
       "line_coverage": 100,
       "crap": 6
@@ -780,7 +790,7 @@
       "package": "cli",
       "function": "runGeneration",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 534,
+      "line": 526,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -789,7 +799,7 @@
       "package": "cli",
       "function": "generateForAllTargets",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 550,
+      "line": 542,
       "complexity": 5,
       "line_coverage": 36.36363636363637,
       "crap": 11.442524417731029
@@ -798,7 +808,7 @@
       "package": "cli",
       "function": "executeScan",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 570,
+      "line": 562,
       "complexity": 1,
       "line_coverage": 0,
       "crap": 2
@@ -807,7 +817,7 @@
       "package": "cli",
       "function": "scanAllTargets",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 578,
+      "line": 570,
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
@@ -817,7 +827,7 @@
       "package": "cli",
       "function": "scanSingleTarget",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 604,
+      "line": 596,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -826,7 +836,7 @@
       "package": "cli",
       "function": "writeScanReports",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 623,
+      "line": 615,
       "complexity": 3,
       "line_coverage": 71.42857142857143,
       "crap": 3.2099125364431487
@@ -835,7 +845,7 @@
       "package": "cli",
       "function": "writeFormatReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 637,
+      "line": 629,
       "complexity": 4,
       "line_coverage": 40,
       "crap": 7.4559999999999995
@@ -844,7 +854,7 @@
       "package": "cli",
       "function": "writePrettyReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 649,
+      "line": 641,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -853,7 +863,7 @@
       "package": "cli",
       "function": "writeSARIFReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 660,
+      "line": 652,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -862,7 +872,7 @@
       "package": "cli",
       "function": "writeOSCALReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 669,
+      "line": 661,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -871,7 +881,7 @@
       "package": "cli",
       "function": "(*scanOptions).runExport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 680,
+      "line": 672,
       "complexity": 5,
       "line_coverage": 16.666666666666668,
       "crap": 19.467592592592588,
@@ -881,7 +891,7 @@
       "package": "cli",
       "function": "authRequired",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 706,
+      "line": 698,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -890,7 +900,7 @@
       "package": "cli",
       "function": "validateAuthCredentials",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 710,
+      "line": 702,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -899,7 +909,7 @@
       "package": "cli",
       "function": "resolveCollectorAuth",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 717,
+      "line": 709,
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
@@ -909,7 +919,7 @@
       "package": "cli",
       "function": "exportToProviders",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 732,
+      "line": 724,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -918,7 +928,7 @@
       "package": "cli",
       "function": "exportSingleProvider",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 740,
+      "line": 732,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -927,7 +937,7 @@
       "package": "cli",
       "function": "resolveOIDCToken",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 757,
+      "line": 749,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -936,7 +946,7 @@
       "package": "cli",
       "function": "formatExportSummary",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 770,
+      "line": 762,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -945,7 +955,7 @@
       "package": "cli",
       "function": "appendExportRow",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 790,
+      "line": 782,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -954,7 +964,7 @@
       "package": "cli",
       "function": "appendResponseRow",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 804,
+      "line": 796,
       "complexity": 3,
       "line_coverage": 85.71428571428571,
       "crap": 3.0262390670553936
@@ -963,7 +973,7 @@
       "package": "cli",
       "function": "exportResponseStatus",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 817,
+      "line": 809,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -972,7 +982,7 @@
       "package": "cli",
       "function": "countExportFailures",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 839,
+      "line": 831,
       "complexity": 7,
       "line_coverage": 100,
       "crap": 7
@@ -981,7 +991,7 @@
       "package": "cli",
       "function": "injectWorkspaceIntoTargets",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 860,
+      "line": 852,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -990,7 +1000,7 @@
       "package": "cli",
       "function": "extractReqToControlMap",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 871,
+      "line": 863,
       "complexity": 6,
       "line_coverage": 90,
       "crap": 6.036
@@ -999,7 +1009,7 @@
       "package": "cli",
       "function": "extractPlanToReqMap",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 892,
+      "line": 884,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -1008,7 +1018,7 @@
       "package": "cli",
       "function": "resolveAssessmentIDs",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 907,
+      "line": 899,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -1017,7 +1027,7 @@
       "package": "cli",
       "function": "reverseMap",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 917,
+      "line": 909,
       "complexity": 3,
       "line_coverage": 83.33333333333333,
       "crap": 3.0416666666666665
@@ -1026,7 +1036,7 @@
       "package": "cli",
       "function": "buildReqToComplypackRef",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 938,
+      "line": 930,
       "complexity": 11,
       "line_coverage": 82.6086956521739,
       "crap": 11.636475712994166
@@ -1293,7 +1303,10 @@
       "line": 19,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
@@ -1302,7 +1315,10 @@
       "line": 25,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
@@ -1311,7 +1327,10 @@
       "line": 30,
       "complexity": 3,
       "line_coverage": 71.42857142857143,
-      "crap": 3.2099125364431487
+      "crap": 3.2099125364431487,
+      "contract_coverage": 50,
+      "gaze_crap": 4.125,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
@@ -1320,7 +1339,10 @@
       "line": 44,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
@@ -1339,7 +1361,10 @@
       "line": 77,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cachetest",
@@ -1431,7 +1456,10 @@
       "line": 38,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
@@ -1440,7 +1468,10 @@
       "line": 48,
       "complexity": 7,
       "line_coverage": 81.81818181818181,
-      "crap": 7.294515401953419
+      "crap": 7.294515401953419,
+      "contract_coverage": 100,
+      "gaze_crap": 7,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
@@ -1458,7 +1489,10 @@
       "line": 77,
       "complexity": 13,
       "line_coverage": 66.66666666666667,
-      "crap": 19.259259259259252,
+      "crap": 19.259259259259256,
+      "contract_coverage": 100,
+      "gaze_crap": 13,
+      "quadrant": "Q2_ComplexButTested",
       "fix_strategy": "add_tests"
     },
     {
@@ -1468,7 +1502,10 @@
       "line": 149,
       "complexity": 6,
       "line_coverage": 75,
-      "crap": 6.5625
+      "crap": 6.5625,
+      "contract_coverage": 100,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
@@ -1477,7 +1514,10 @@
       "line": 190,
       "complexity": 10,
       "line_coverage": 83.33333333333333,
-      "crap": 10.462962962962964
+      "crap": 10.462962962962964,
+      "contract_coverage": 100,
+      "gaze_crap": 10,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
@@ -1486,7 +1526,10 @@
       "line": 232,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
@@ -1522,7 +1565,10 @@
       "line": 72,
       "complexity": 5,
       "line_coverage": 85.71428571428571,
-      "crap": 5.072886297376093
+      "crap": 5.072886297376093,
+      "contract_coverage": 100,
+      "gaze_crap": 5,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
@@ -1531,17 +1577,22 @@
       "line": 26,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
       "function": "(*ComplypackSync).SyncComplypack",
       "file": "internal/cache/complypack_sync.go",
       "line": 42,
-      "complexity": 15,
-      "line_coverage": 85.29411764705883,
-      "crap": 15.715576022796661,
-      "fix_strategy": "decompose"
+      "complexity": 13,
+      "line_coverage": 84.375,
+      "crap": 13.644683837890625,
+      "contract_coverage": 100,
+      "gaze_crap": 13,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
@@ -1577,7 +1628,10 @@
       "line": 33,
       "complexity": 4,
       "line_coverage": 81.81818181818181,
-      "crap": 4.096168294515402
+      "crap": 4.096168294515402,
+      "contract_coverage": 100,
+      "gaze_crap": 4,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
@@ -1595,7 +1649,10 @@
       "line": 71,
       "complexity": 4,
       "line_coverage": 66.66666666666667,
-      "crap": 4.592592592592593
+      "crap": 4.592592592592593,
+      "contract_coverage": 100,
+      "gaze_crap": 4,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
@@ -1604,7 +1661,10 @@
       "line": 91,
       "complexity": 2,
       "line_coverage": 75,
-      "crap": 2.0625
+      "crap": 2.0625,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
@@ -1613,7 +1673,10 @@
       "line": 104,
       "complexity": 2,
       "line_coverage": 75,
-      "crap": 2.0625
+      "crap": 2.0625,
+      "contract_coverage": 100,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
@@ -1622,7 +1685,10 @@
       "line": 115,
       "complexity": 2,
       "line_coverage": 75,
-      "crap": 2.0625
+      "crap": 2.0625,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
@@ -1631,31 +1697,52 @@
       "line": 130,
       "complexity": 2,
       "line_coverage": 75,
-      "crap": 2.0625
+      "crap": 2.0625,
+      "contract_coverage": 100,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "cache",
+      "function": "BuildLookupRef",
+      "file": "internal/cache/sync.go",
+      "line": 18,
+      "complexity": 5,
+      "line_coverage": 100,
+      "crap": 5,
+      "contract_coverage": 100,
+      "gaze_crap": 5,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
       "function": "NewSync",
       "file": "internal/cache/sync.go",
-      "line": 20,
+      "line": 35,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "cache",
       "function": "(*Sync).SyncPolicy",
       "file": "internal/cache/sync.go",
-      "line": 31,
-      "complexity": 14,
-      "line_coverage": 84,
-      "crap": 14.802816
+      "line": 46,
+      "complexity": 12,
+      "line_coverage": 82.6086956521739,
+      "crap": 12.757458699761651,
+      "contract_coverage": 100,
+      "gaze_crap": 12,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "complytime",
       "function": "ValidateOCIRef",
       "file": "internal/complytime/config.go",
-      "line": 23,
+      "line": 24,
       "complexity": 6,
       "line_coverage": 100,
       "crap": 6
@@ -1664,7 +1751,7 @@
       "package": "complytime",
       "function": "(PolicyEntry).EffectiveID",
       "file": "internal/complytime/config.go",
-      "line": 84,
+      "line": 85,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -1673,16 +1760,16 @@
       "package": "complytime",
       "function": "ParsePolicyRef",
       "file": "internal/complytime/config.go",
-      "line": 112,
-      "complexity": 8,
-      "line_coverage": 100,
-      "crap": 8
+      "line": 134,
+      "complexity": 12,
+      "line_coverage": 96.42857142857143,
+      "crap": 12.006559766763848
     },
     {
       "package": "complytime",
       "function": "FindPolicy",
       "file": "internal/complytime/config.go",
-      "line": 142,
+      "line": 189,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -1691,7 +1778,7 @@
       "package": "complytime",
       "function": "PolicyIDs",
       "file": "internal/complytime/config.go",
-      "line": 155,
+      "line": 202,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -1700,16 +1787,28 @@
       "package": "complytime",
       "function": "LoadFrom",
       "file": "internal/complytime/config.go",
-      "line": 165,
+      "line": 212,
+      "complexity": 6,
+      "line_coverage": 69.23076923076923,
+      "crap": 7.048702776513427,
+      "contract_coverage": 50,
+      "gaze_crap": 10.5,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "complytime",
+      "function": "validatePolicyRefs",
+      "file": "internal/complytime/config.go",
+      "line": 248,
       "complexity": 5,
-      "line_coverage": 63.63636363636363,
-      "crap": 6.202103681442525
+      "line_coverage": 100,
+      "crap": 5
     },
     {
       "package": "complytime",
       "function": "resolveEnvVars",
       "file": "internal/complytime/config.go",
-      "line": 195,
+      "line": 265,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -1718,7 +1817,7 @@
       "package": "complytime",
       "function": "resolveCollectorEnvVars",
       "file": "internal/complytime/config.go",
-      "line": 208,
+      "line": 278,
       "complexity": 5,
       "line_coverage": 100,
       "crap": 5
@@ -1727,7 +1826,7 @@
       "package": "complytime",
       "function": "expandEnvRef",
       "file": "internal/complytime/config.go",
-      "line": 230,
+      "line": 300,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -1736,16 +1835,19 @@
       "package": "complytime",
       "function": "SaveTo",
       "file": "internal/complytime/config.go",
-      "line": 247,
+      "line": 317,
       "complexity": 3,
       "line_coverage": 0,
-      "crap": 12
+      "crap": 12,
+      "contract_coverage": 100,
+      "gaze_crap": 3,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "complytime",
       "function": "Validate",
       "file": "internal/complytime/config.go",
-      "line": 261,
+      "line": 331,
       "complexity": 13,
       "line_coverage": 92.3076923076923,
       "crap": 13.076923076923077
@@ -1754,7 +1856,7 @@
       "package": "complytime",
       "function": "validateEntries",
       "file": "internal/complytime/config.go",
-      "line": 313,
+      "line": 383,
       "complexity": 6,
       "line_coverage": 100,
       "crap": 6
@@ -1775,7 +1877,10 @@
       "line": 90,
       "complexity": 2,
       "line_coverage": 100,
-      "crap": 2
+      "crap": 2,
+      "contract_coverage": 100,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "complytime",
@@ -1820,7 +1925,15 @@
       "line": 25,
       "complexity": 3,
       "line_coverage": 100,
-      "crap": 3
+      "crap": 3,
+      "contract_coverage": 0,
+      "gaze_crap": 12,
+      "quadrant": "Q1_Safe",
+      "contract_coverage_reason": "all_effects_ambiguous",
+      "effect_confidence_range": [
+        69,
+        69
+      ]
     },
     {
       "package": "complytime",
@@ -1829,7 +1942,10 @@
       "line": 40,
       "complexity": 2,
       "line_coverage": 100,
-      "crap": 2
+      "crap": 2,
+      "contract_coverage": 50,
+      "gaze_crap": 2.5,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "complytime",
@@ -1847,7 +1963,10 @@
       "line": 59,
       "complexity": 2,
       "line_coverage": 66.66666666666667,
-      "crap": 2.148148148148148
+      "crap": 2.148148148148148,
+      "contract_coverage": 100,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "complytime",
@@ -1856,7 +1975,10 @@
       "line": 67,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "complytime",
@@ -1874,7 +1996,10 @@
       "line": 77,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "complytime",
@@ -1883,7 +2008,10 @@
       "line": 83,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "complytime",
@@ -1892,7 +2020,10 @@
       "line": 88,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "complytime",
@@ -1901,7 +2032,10 @@
       "line": 93,
       "complexity": 2,
       "line_coverage": 75,
-      "crap": 2.0625
+      "crap": 2.0625,
+      "contract_coverage": 0,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "complytime",
@@ -1910,7 +2044,10 @@
       "line": 108,
       "complexity": 13,
       "line_coverage": 87.5,
-      "crap": 13.330078125
+      "crap": 13.330078125,
+      "contract_coverage": 100,
+      "gaze_crap": 13,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "complytime",
@@ -1919,7 +2056,10 @@
       "line": 154,
       "complexity": 3,
       "line_coverage": 100,
-      "crap": 3
+      "crap": 3,
+      "contract_coverage": 100,
+      "gaze_crap": 3,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "complytime",
@@ -1946,7 +2086,10 @@
       "line": 96,
       "complexity": 4,
       "line_coverage": 25,
-      "crap": 10.75
+      "crap": 10.75,
+      "contract_coverage": 100,
+      "gaze_crap": 4,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "doctor",
@@ -1963,16 +2106,19 @@
       "function": "CheckPolicyVersions",
       "file": "internal/doctor/doctor.go",
       "line": 221,
-      "complexity": 15,
-      "line_coverage": 100,
-      "crap": 15,
+      "complexity": 16,
+      "line_coverage": 95,
+      "crap": 16.032,
+      "contract_coverage": 100,
+      "gaze_crap": 16,
+      "quadrant": "Q4_Dangerous",
       "fix_strategy": "decompose"
     },
     {
       "package": "doctor",
       "function": "resolvePinnedFallback",
       "file": "internal/doctor/doctor.go",
-      "line": 317,
+      "line": 326,
       "complexity": 5,
       "line_coverage": 100,
       "crap": 5
@@ -1981,35 +2127,44 @@
       "package": "doctor",
       "function": "CheckCache",
       "file": "internal/doctor/doctor.go",
-      "line": 359,
+      "line": 368,
       "complexity": 5,
       "line_coverage": 90.9090909090909,
-      "crap": 5.018782870022539
+      "crap": 5.018782870022539,
+      "contract_coverage": 100,
+      "gaze_crap": 5,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "doctor",
       "function": "CheckVariables",
       "file": "internal/doctor/doctor.go",
-      "line": 414,
-      "complexity": 34,
-      "line_coverage": 87.8048780487805,
-      "crap": 36.09660335746724,
+      "line": 423,
+      "complexity": 35,
+      "line_coverage": 85.88235294117646,
+      "crap": 38.44685528190515,
+      "contract_coverage": 100,
+      "gaze_crap": 35,
+      "quadrant": "Q4_Dangerous",
       "fix_strategy": "decompose"
     },
     {
       "package": "doctor",
       "function": "CheckPolicyActivePeriod",
       "file": "internal/doctor/doctor.go",
-      "line": 582,
-      "complexity": 11,
-      "line_coverage": 92.85714285714286,
-      "crap": 11.044096209912537
+      "line": 595,
+      "complexity": 12,
+      "line_coverage": 90,
+      "crap": 12.144,
+      "contract_coverage": 100,
+      "gaze_crap": 12,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "doctor",
       "function": "parseDatetime",
       "file": "internal/doctor/doctor.go",
-      "line": 655,
+      "line": 671,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -2018,7 +2173,7 @@
       "package": "doctor",
       "function": "evaluateTimeline",
       "file": "internal/doctor/doctor.go",
-      "line": 664,
+      "line": 680,
       "complexity": 7,
       "line_coverage": 86.66666666666667,
       "crap": 7.116148148148148
@@ -2027,7 +2182,7 @@
       "package": "doctor",
       "function": "countResolved",
       "file": "internal/doctor/doctor.go",
-      "line": 694,
+      "line": 710,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -2036,7 +2191,7 @@
       "package": "doctor",
       "function": "unmappedReason",
       "file": "internal/doctor/doctor.go",
-      "line": 704,
+      "line": 720,
       "complexity": 3,
       "line_coverage": 80,
       "crap": 3.072
@@ -2045,25 +2200,31 @@
       "package": "doctor",
       "function": "CheckCollector",
       "file": "internal/doctor/doctor.go",
-      "line": 717,
+      "line": 733,
       "complexity": 6,
       "line_coverage": 100,
-      "crap": 6
+      "crap": 6,
+      "contract_coverage": 100,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "doctor",
       "function": "CheckComplypacks",
       "file": "internal/doctor/doctor.go",
-      "line": 758,
-      "complexity": 12,
-      "line_coverage": 81.25,
-      "crap": 12.94921875
+      "line": 774,
+      "complexity": 13,
+      "line_coverage": 79.41176470588235,
+      "crap": 14.474837166700592,
+      "contract_coverage": 100,
+      "gaze_crap": 13,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "doctor",
       "function": "checkExportEnabled",
       "file": "internal/doctor/doctor.go",
-      "line": 829,
+      "line": 848,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -2072,7 +2233,7 @@
       "package": "doctor",
       "function": "checkCollectorAuth",
       "file": "internal/doctor/doctor.go",
-      "line": 855,
+      "line": 874,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -2081,7 +2242,7 @@
       "package": "doctor",
       "function": "effectiveGlobals",
       "file": "internal/doctor/doctor.go",
-      "line": 880,
+      "line": 899,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -2090,7 +2251,7 @@
       "package": "doctor",
       "function": "joinNames",
       "file": "internal/doctor/doctor.go",
-      "line": 889,
+      "line": 908,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -2111,7 +2272,10 @@
       "line": 48,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "output",
@@ -2354,7 +2518,10 @@
       "line": 59,
       "complexity": 9,
       "line_coverage": 88.88888888888889,
-      "crap": 9.11111111111111
+      "crap": 9.11111111111111,
+      "contract_coverage": 100,
+      "gaze_crap": 9,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "output",
@@ -2363,7 +2530,10 @@
       "line": 144,
       "complexity": 4,
       "line_coverage": 100,
-      "crap": 4
+      "crap": 4,
+      "contract_coverage": 100,
+      "gaze_crap": 4,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
@@ -2372,7 +2542,10 @@
       "line": 19,
       "complexity": 2,
       "line_coverage": 100,
-      "crap": 2
+      "crap": 2,
+      "contract_coverage": 100,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
@@ -2381,52 +2554,58 @@
       "line": 36,
       "complexity": 3,
       "line_coverage": 100,
-      "crap": 3
+      "crap": 3,
+      "contract_coverage": 50,
+      "gaze_crap": 4.125,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
       "function": "SaveGenerationState",
       "file": "internal/policy/generation_state.go",
-      "line": 31,
+      "line": 29,
       "complexity": 4,
       "line_coverage": 70,
-      "crap": 4.432
+      "crap": 4.432,
+      "contract_coverage": 100,
+      "gaze_crap": 4,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
       "function": "LoadGenerationState",
       "file": "internal/policy/generation_state.go",
-      "line": 51,
+      "line": 49,
       "complexity": 4,
       "line_coverage": 90,
-      "crap": 4.016
+      "crap": 4.016,
+      "contract_coverage": 100,
+      "gaze_crap": 4,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
       "function": "(*GenerationState).IsFresh",
       "file": "internal/policy/generation_state.go",
-      "line": 71,
-      "complexity": 2,
+      "line": 68,
+      "complexity": 1,
       "line_coverage": 100,
-      "crap": 2
-    },
-    {
-      "package": "policy",
-      "function": "normalizeNilMap",
-      "file": "internal/policy/generation_state.go",
-      "line": 78,
-      "complexity": 2,
-      "line_coverage": 100,
-      "crap": 2
+      "crap": 1,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
       "function": "NewGenerationState",
       "file": "internal/policy/generation_state.go",
-      "line": 86,
+      "line": 73,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
@@ -2435,7 +2614,10 @@
       "line": 24,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
@@ -2444,7 +2626,10 @@
       "line": 33,
       "complexity": 5,
       "line_coverage": 81.81818181818181,
-      "crap": 5.150262960180315
+      "crap": 5.150262960180315,
+      "contract_coverage": 50,
+      "gaze_crap": 8.125,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
@@ -2453,7 +2638,10 @@
       "line": 59,
       "complexity": 10,
       "line_coverage": 87.5,
-      "crap": 10.1953125
+      "crap": 10.1953125,
+      "contract_coverage": 100,
+      "gaze_crap": 10,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
@@ -2471,7 +2659,10 @@
       "line": 113,
       "complexity": 12,
       "line_coverage": 74.07407407407408,
-      "crap": 14.509373571101964
+      "crap": 14.509373571101964,
+      "contract_coverage": 50,
+      "gaze_crap": 30,
+      "quadrant": "Q3_SimpleButUnderspecified"
     },
     {
       "package": "policy",
@@ -2480,7 +2671,10 @@
       "line": 162,
       "complexity": 5,
       "line_coverage": 77.77777777777777,
-      "crap": 5.274348422496571
+      "crap": 5.274348422496571,
+      "contract_coverage": 100,
+      "gaze_crap": 5,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
@@ -2498,7 +2692,10 @@
       "line": 205,
       "complexity": 4,
       "line_coverage": 87.5,
-      "crap": 4.03125
+      "crap": 4.03125,
+      "contract_coverage": 100,
+      "gaze_crap": 4,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
@@ -2507,7 +2704,10 @@
       "line": 221,
       "complexity": 4,
       "line_coverage": 84.61538461538461,
-      "crap": 4.058261265361857
+      "crap": 4.058261265361857,
+      "contract_coverage": 100,
+      "gaze_crap": 4,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
@@ -2526,7 +2726,10 @@
       "line": 76,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
@@ -2544,7 +2747,10 @@
       "line": 91,
       "complexity": 6,
       "line_coverage": 100,
-      "crap": 6
+      "crap": 6,
+      "contract_coverage": 100,
+      "gaze_crap": 6,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "policy",
@@ -2725,7 +2931,10 @@
       "line": 49,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 100,
+      "gaze_crap": 1,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "terminal",
@@ -2771,7 +2980,10 @@
       "line": 40,
       "complexity": 4,
       "line_coverage": 90,
-      "crap": 4.016
+      "crap": 4.016,
+      "contract_coverage": 100,
+      "gaze_crap": 4,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "log",
@@ -3053,7 +3265,10 @@
       "line": 26,
       "complexity": 1,
       "line_coverage": 100,
-      "crap": 1
+      "crap": 1,
+      "contract_coverage": 0,
+      "gaze_crap": 2,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "provider",
@@ -3062,7 +3277,10 @@
       "line": 35,
       "complexity": 6,
       "line_coverage": 73.33333333333333,
-      "crap": 6.682666666666667
+      "crap": 6.682666666666667,
+      "contract_coverage": 66.66666666666667,
+      "gaze_crap": 7.333333333333332,
+      "quadrant": "Q1_Safe"
     },
     {
       "package": "provider",
@@ -3550,14 +3768,24 @@
   ],
   "summary": {
     "total_functions": 388,
-    "avg_complexity": 3.515463917525773,
-    "avg_line_coverage": 48.62931481853226,
-    "avg_crap": 9.959355678367528,
-    "crapload": 55,
+    "avg_complexity": 3.5489690721649483,
+    "avg_line_coverage": 48.59530700313812,
+    "avg_crap": 10.036572652333856,
+    "crapload": 54,
     "crap_threshold": 15,
+    "gaze_crapload": 3,
+    "gaze_crap_threshold": 15,
+    "avg_gaze_crap": 5.546948356807511,
+    "avg_contract_coverage": 74.88262910798123,
+    "quadrant_counts": {
+      "Q1_Safe": 67,
+      "Q2_ComplexButTested": 1,
+      "Q3_SimpleButUnderspecified": 1,
+      "Q4_Dangerous": 2
+    },
     "fix_strategy_counts": {
       "add_tests": 51,
-      "decompose": 3,
+      "decompose": 2,
       "decompose_and_test": 1
     },
     "worst_crap": [
@@ -3572,10 +3800,10 @@
         "fix_strategy": "decompose_and_test"
       },
       {
-        "package": "cli",
-        "function": "promptTargets",
-        "file": "cmd/complyctl/cli/init.go",
-        "line": 153,
+        "package": "terminal",
+        "function": "ShowPlainTable",
+        "file": "internal/terminal/table.go",
+        "line": 19,
         "complexity": 10,
         "line_coverage": 0,
         "crap": 110,
@@ -3592,10 +3820,10 @@
         "fix_strategy": "add_tests"
       },
       {
-        "package": "terminal",
-        "function": "ShowPlainTable",
-        "file": "internal/terminal/table.go",
-        "line": 19,
+        "package": "cli",
+        "function": "promptTargets",
+        "file": "cmd/complyctl/cli/init.go",
+        "line": 153,
         "complexity": 10,
         "line_coverage": 0,
         "crap": 110,
@@ -3612,7 +3840,81 @@
         "fix_strategy": "add_tests"
       }
     ],
+    "worst_gaze_crap": [
+      {
+        "package": "doctor",
+        "function": "CheckVariables",
+        "file": "internal/doctor/doctor.go",
+        "line": 423,
+        "complexity": 35,
+        "line_coverage": 85.88235294117646,
+        "crap": 38.44685528190515,
+        "contract_coverage": 100,
+        "gaze_crap": 35,
+        "quadrant": "Q4_Dangerous",
+        "fix_strategy": "decompose"
+      },
+      {
+        "package": "policy",
+        "function": "(*Loader).LoadBundleFiles",
+        "file": "internal/policy/loader.go",
+        "line": 113,
+        "complexity": 12,
+        "line_coverage": 74.07407407407408,
+        "crap": 14.509373571101964,
+        "contract_coverage": 50,
+        "gaze_crap": 30,
+        "quadrant": "Q3_SimpleButUnderspecified"
+      },
+      {
+        "package": "doctor",
+        "function": "CheckPolicyVersions",
+        "file": "internal/doctor/doctor.go",
+        "line": 221,
+        "complexity": 16,
+        "line_coverage": 95,
+        "crap": 16.032,
+        "contract_coverage": 100,
+        "gaze_crap": 16,
+        "quadrant": "Q4_Dangerous",
+        "fix_strategy": "decompose"
+      },
+      {
+        "package": "cache",
+        "function": "(*ComplypackCache).Store",
+        "file": "internal/cache/complypack.go",
+        "line": 77,
+        "complexity": 13,
+        "line_coverage": 66.66666666666667,
+        "crap": 19.259259259259256,
+        "contract_coverage": 100,
+        "gaze_crap": 13,
+        "quadrant": "Q2_ComplexButTested",
+        "fix_strategy": "add_tests"
+      },
+      {
+        "package": "complytime",
+        "function": "ResolveWorkspaceDir",
+        "file": "internal/complytime/workspace.go",
+        "line": 108,
+        "complexity": 13,
+        "line_coverage": 87.5,
+        "crap": 13.330078125,
+        "contract_coverage": 100,
+        "gaze_crap": 13,
+        "quadrant": "Q1_Safe"
+      }
+    ],
     "recommended_actions": [
+      {
+        "function": "(*MockPolicySource).CopyPolicy",
+        "package": "cachetest",
+        "file": "internal/cache/cachetest/mock_source.go",
+        "line": 73,
+        "fix_strategy": "add_tests",
+        "crap": 110,
+        "complexity": 10
+      },
       {
         "function": "ShowPlainTable",
         "package": "terminal",
@@ -3632,15 +3934,6 @@
         "complexity": 10
       },
       {
-        "function": "(*MockPolicySource).CopyPolicy",
-        "package": "cachetest",
-        "file": "internal/cache/cachetest/mock_source.go",
-        "line": 73,
-        "fix_strategy": "add_tests",
-        "crap": 110,
-        "complexity": 10
-      },
-      {
         "function": "main",
         "package": "main",
         "file": "cmd/behavioral-report/main.go",
@@ -3648,15 +3941,6 @@
         "fix_strategy": "add_tests",
         "crap": 90,
         "complexity": 9
-      },
-      {
-        "function": "DigestRecordedInState",
-        "package": "behavioral",
-        "file": "tests/behavioral/supply_chain.go",
-        "line": 50,
-        "fix_strategy": "add_tests",
-        "crap": 72,
-        "complexity": 8
       },
       {
         "function": "CheckProviders",
@@ -3668,19 +3952,19 @@
         "complexity": 8
       },
       {
-        "function": "(*Cache).ListPolicies",
-        "package": "cache",
-        "file": "internal/cache/cache.go",
-        "line": 50,
-        "fix_strategy": "add_tests",
-        "crap": 56,
-        "complexity": 7
-      },
-      {
-        "function": "SignatureVerified",
+        "function": "DigestRecordedInState",
         "package": "behavioral",
         "file": "tests/behavioral/supply_chain.go",
-        "line": 19,
+        "line": 50,
+        "fix_strategy": "add_tests",
+        "crap": 72,
+        "complexity": 8
+      },
+      {
+        "function": "PluginBinaryIntegrityCheck",
+        "package": "behavioral",
+        "file": "tests/behavioral/plugin_security.go",
+        "line": 67,
         "fix_strategy": "add_tests",
         "crap": 56,
         "complexity": 7
@@ -3695,19 +3979,28 @@
         "complexity": 7
       },
       {
-        "function": "PluginBinaryIntegrityCheck",
+        "function": "OSCALResultProduced",
         "package": "behavioral",
-        "file": "tests/behavioral/plugin_security.go",
-        "line": 67,
+        "file": "tests/behavioral/audit.go",
+        "line": 48,
         "fix_strategy": "add_tests",
         "crap": 56,
         "complexity": 7
       },
       {
-        "function": "OSCALResultProduced",
+        "function": "SignatureVerified",
         "package": "behavioral",
-        "file": "tests/behavioral/audit.go",
-        "line": 48,
+        "file": "tests/behavioral/supply_chain.go",
+        "line": 19,
+        "fix_strategy": "add_tests",
+        "crap": 56,
+        "complexity": 7
+      },
+      {
+        "function": "(*Cache).ListPolicies",
+        "package": "cache",
+        "file": "internal/cache/cache.go",
+        "line": 50,
         "fix_strategy": "add_tests",
         "crap": 56,
         "complexity": 7
@@ -3722,19 +4015,19 @@
         "complexity": 6
       },
       {
-        "function": "HTTPSchemeRejected",
-        "package": "behavioral",
-        "file": "tests/behavioral/transport_security.go",
-        "line": 17,
+        "function": "(*Client).fetchVersion",
+        "package": "registry",
+        "file": "internal/registry/client.go",
+        "line": 118,
         "fix_strategy": "add_tests",
         "crap": 42,
         "complexity": 6
       },
       {
-        "function": "(*Client).fetchVersion",
-        "package": "registry",
-        "file": "internal/registry/client.go",
-        "line": 118,
+        "function": "HTTPSchemeRejected",
+        "package": "behavioral",
+        "file": "tests/behavioral/transport_security.go",
+        "line": 17,
         "fix_strategy": "add_tests",
         "crap": 42,
         "complexity": 6
@@ -3758,10 +4051,10 @@
         "complexity": 6
       },
       {
-        "function": "UnsetEnvVarFails",
+        "function": "findFile",
         "package": "behavioral",
-        "file": "tests/behavioral/credential_protection.go",
-        "line": 17,
+        "file": "tests/behavioral/audit.go",
+        "line": 76,
         "fix_strategy": "add_tests",
         "crap": 30,
         "complexity": 5
@@ -3776,6 +4069,15 @@
         "complexity": 5
       },
       {
+        "function": "HTTPSSchemeNoPlainHTTP",
+        "package": "behavioral",
+        "file": "tests/behavioral/transport_security.go",
+        "line": 48,
+        "fix_strategy": "add_tests",
+        "crap": 30,
+        "complexity": 5
+      },
+      {
         "function": "LogCredentialRedaction",
         "package": "behavioral",
         "file": "tests/behavioral/log_security.go",
@@ -3783,30 +4085,7 @@
         "fix_strategy": "add_tests",
         "crap": 30,
         "complexity": 5
-      },
-      {
-        "function": "EnvVarResolution",
-        "package": "behavioral",
-        "file": "tests/behavioral/credential_protection.go",
-        "line": 54,
-        "fix_strategy": "add_tests",
-        "crap": 30,
-        "complexity": 5
       }
-    ],
-    "ssa_degraded_packages": [
-      "github.com/complytime/complyctl/cmd/complyctl/cli",
-      "github.com/complytime/complyctl/cmd/mock-oci-registry",
-      "github.com/complytime/complyctl/internal/cache",
-      "github.com/complytime/complyctl/internal/complytime",
-      "github.com/complytime/complyctl/internal/doctor",
-      "github.com/complytime/complyctl/internal/output",
-      "github.com/complytime/complyctl/internal/policy",
-      "github.com/complytime/complyctl/internal/registry",
-      "github.com/complytime/complyctl/internal/terminal",
-      "github.com/complytime/complyctl/internal/version",
-      "github.com/complytime/complyctl/pkg/log",
-      "github.com/complytime/complyctl/pkg/provider"
     ]
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,19 +51,16 @@
 
 ### Fixed
 
-<<<<<<< HEAD
 - Generation freshness detection now tracks complypack digests alongside
   policy digests. Previously, updating a complypack without changing the
   policy would skip regeneration, causing providers to use stale
   artifacts (#583).
-=======
 - OCI reference parsing now supports standard `:tag` syntax (e.g.,
   `registry.com/org/image:v0.4.0`) in addition to the existing `@version`
   notation for both policies and complypacks. Digest references
   (`@sha256:...`) are also supported. Invalid OCI references in
   `complytime.yaml` are now detected at config load time with clear
   error messages. (#594)
->>>>>>> 2ac9b0eb (fix(bug): updates support for oci refs)
 - Scan reports now resolve assessment plan IDs to requirement IDs,
   ensuring output displays meaningful identifiers instead of internal
   plan references. Affects EvaluationLog, OSCAL, SARIF, and Markdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,10 +51,19 @@
 
 ### Fixed
 
+<<<<<<< HEAD
 - Generation freshness detection now tracks complypack digests alongside
   policy digests. Previously, updating a complypack without changing the
   policy would skip regeneration, causing providers to use stale
   artifacts (#583).
+=======
+- OCI reference parsing now supports standard `:tag` syntax (e.g.,
+  `registry.com/org/image:v0.4.0`) in addition to the existing `@version`
+  notation for both policies and complypacks. Digest references
+  (`@sha256:...`) are also supported. Invalid OCI references in
+  `complytime.yaml` are now detected at config load time with clear
+  error messages. (#594)
+>>>>>>> 2ac9b0eb (fix(bug): updates support for oci refs)
 - Scan reports now resolve assessment plan IDs to requirement IDs,
   ensuring output displays meaningful identifiers instead of internal
   plan references. Affects EvaluationLog, OSCAL, SARIF, and Markdown

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ crapload-baseline: ensure-gaze test-unit ## generate baseline thresholds in .gaz
 	@mkdir -p .gaze
 	@REPO_ROOT=$$(pwd); \
 	gaze crap --format=json --coverprofile=$(GAZE_COVERPROFILE) ./... | \
-		jq --arg root "$$REPO_ROOT/" '(.scores[],.summary.worst_crap[]?,.summary.worst_gaze_crap[]?) |= (.file |= ltrimstr($$root))' > $(GAZE_BASELINE)
+		jq --arg root "$$REPO_ROOT/" '(.scores[],.summary.worst_crap[]?,.summary.worst_gaze_crap[]?,.summary.recommended_actions[]?) |= (.file |= ltrimstr($$root))' > $(GAZE_BASELINE)
 	@echo "Baseline written to $(GAZE_BASELINE)"
 .PHONY: crapload-baseline
 
@@ -163,7 +163,7 @@ crapload-check: ensure-gaze test-unit ## check for CRAP regressions against base
 	fi
 	@REPO_ROOT=$$(pwd); \
 	gaze crap --format=json --coverprofile=$(GAZE_COVERPROFILE) ./... | \
-		jq --arg root "$$REPO_ROOT/" '(.scores[],.summary.worst_crap[]?,.summary.worst_gaze_crap[]?) |= (.file |= ltrimstr($$root))' > /tmp/crapload-current.json
+		jq --arg root "$$REPO_ROOT/" '(.scores[],.summary.worst_crap[]?,.summary.worst_gaze_crap[]?,.summary.recommended_actions[]?) |= (.file |= ltrimstr($$root))' > /tmp/crapload-current.json
 	@echo "Comparing against baseline..."
 	@jq -r '.scores[] | "\(.file):\(.function) \(.crap) \(.gaze_crap // 0)"' $(GAZE_BASELINE) | sort > /tmp/crapload-baseline.txt
 	@jq -r '.scores[] | "\(.file):\(.function) \(.crap) \(.gaze_crap // 0)"' /tmp/crapload-current.json | sort > /tmp/crapload-current.txt

--- a/cmd/complyctl/cli/generate.go
+++ b/cmd/complyctl/cli/generate.go
@@ -93,7 +93,10 @@ func (o *generateOptions) run(ctx context.Context) error {
 }
 
 func (o *generateOptions) generatePolicy(ctx context.Context, cfg *complytime.WorkspaceConfig, entry complytime.PolicyEntry, baseDir string) error {
-	ref := complytime.ParsePolicyRef(entry.URL)
+	ref, err := complytime.ParsePolicyRef(entry.URL)
+	if err != nil {
+		return fmt.Errorf("invalid policy reference %q: %w", entry.URL, err)
+	}
 	eid := entry.EffectiveID()
 
 	version, graph, err := resolveVersionAndGraph(o.cacheDir, ref)

--- a/cmd/complyctl/cli/get.go
+++ b/cmd/complyctl/cli/get.go
@@ -151,7 +151,10 @@ func syncAllPolicies(ctx context.Context, cacheMgr *cache.Cache, state *cache.St
 }
 
 func syncSinglePolicy(ctx context.Context, cacheMgr *cache.Cache, state *cache.State, credFunc auth.CredentialFunc, entry complytime.PolicyEntry, index, total int) error {
-	ref := complytime.ParsePolicyRef(entry.URL)
+	ref, err := complytime.ParsePolicyRef(entry.URL)
+	if err != nil {
+		return fmt.Errorf("invalid policy reference %q: %w", entry.URL, err)
+	}
 	version := ref.Version
 
 	client := registry.NewClient(ref.Registry, credFunc)
@@ -202,7 +205,10 @@ func syncAllComplypacks(ctx context.Context, state *cache.State, credFunc auth.C
 }
 
 func syncSingleComplypack(ctx context.Context, state *cache.State, credFunc auth.CredentialFunc, entry complytime.PolicyEntry, index, total int, cacheDir string) error {
-	ref := complytime.ParsePolicyRef(entry.URL)
+	ref, err := complytime.ParsePolicyRef(entry.URL)
+	if err != nil {
+		return fmt.Errorf("invalid complypack reference %q: %w", entry.URL, err)
+	}
 	version := ref.Version
 
 	client := registry.NewClient(ref.Registry, credFunc)

--- a/cmd/complyctl/cli/list.go
+++ b/cmd/complyctl/cli/list.go
@@ -88,7 +88,10 @@ func (o *listOptions) run(_ context.Context) error {
 			continue
 		}
 
-		ref := complytime.ParsePolicyRef(p.URL)
+		ref, err := complytime.ParsePolicyRef(p.URL)
+		if err != nil {
+			return fmt.Errorf("invalid policy reference %q: %w", p.URL, err)
+		}
 		versions, _ := loader.GetCachedVersions(ref.Repository)
 
 		var versionStr string

--- a/cmd/complyctl/cli/scan.go
+++ b/cmd/complyctl/cli/scan.go
@@ -252,7 +252,10 @@ func loadWorkspaceConfig(baseDir string) (*complytime.WorkspaceConfig, error) {
 }
 
 func (o *scanOptions) scanPolicy(ctx context.Context, cfg *complytime.WorkspaceConfig, entry complytime.PolicyEntry, targetID, baseDir string) error {
-	ref := complytime.ParsePolicyRef(entry.URL)
+	ref, err := complytime.ParsePolicyRef(entry.URL)
+	if err != nil {
+		return fmt.Errorf("invalid policy reference %q: %w", entry.URL, err)
+	}
 	eid := entry.EffectiveID()
 
 	version, graph, err := resolveVersionAndGraph(o.cacheDir, ref)

--- a/internal/cache/complypack_sync.go
+++ b/internal/cache/complypack_sync.go
@@ -44,10 +44,7 @@ func (s *ComplypackSync) SyncComplypack(ctx context.Context, repository, version
 		return false, fmt.Errorf("complypack repository cannot be empty")
 	}
 
-	lookupRef := repository
-	if version != "" && version != "latest" {
-		lookupRef = repository + ":" + version
-	}
+	lookupRef := BuildLookupRef(repository, version)
 
 	remoteDigest, remoteVersion, err := s.source.DefinitionVersion(ctx, lookupRef)
 	if err != nil {

--- a/internal/cache/sync.go
+++ b/internal/cache/sync.go
@@ -6,9 +6,24 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/complytime/complyctl/internal/registry"
 )
+
+// BuildLookupRef constructs an OCI lookup reference from a repository and
+// version string. For digest versions (sha256:, sha512:) it uses "@" as
+// the separator; for tag versions it uses ":". If the version is empty or
+// "latest", the bare repository is returned so oras resolves the default tag.
+func BuildLookupRef(repository, version string) string {
+	if version == "" || version == "latest" {
+		return repository
+	}
+	if strings.HasPrefix(version, "sha256:") || strings.HasPrefix(version, "sha512:") {
+		return repository + "@" + version
+	}
+	return repository + ":" + version
+}
 
 // Sync provides incremental sync using oras.Copy() for remote-to-local transfer.
 type Sync struct {
@@ -33,10 +48,7 @@ func (s *Sync) SyncPolicy(ctx context.Context, policyID, version string) error {
 		return fmt.Errorf("policy ID cannot be empty")
 	}
 
-	lookupRef := policyID
-	if version != "" && version != "latest" {
-		lookupRef = policyID + ":" + version
-	}
+	lookupRef := BuildLookupRef(policyID, version)
 
 	remoteDigest, remoteVersion, err := s.source.DefinitionVersion(ctx, lookupRef)
 	if err != nil {

--- a/internal/cache/sync_test.go
+++ b/internal/cache/sync_test.go
@@ -241,3 +241,36 @@ func TestSync_StressConcurrentFailures(t *testing.T) {
 			"OCI layout marker must exist after successful syncs")
 	}
 }
+
+func TestBuildLookupRef(t *testing.T) {
+	tests := []struct {
+		name       string
+		repository string
+		version    string
+		want       string
+	}{
+		{"tag version", "org/policy", "v1.0", "org/policy:v1.0"},
+		{"sha256 digest", "org/policy", "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", "org/policy@sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"},
+		{"sha512 digest", "org/policy", "sha512:def456", "org/policy@sha512:def456"},
+		{"empty version", "org/policy", "", "org/policy"},
+		{"latest version", "org/policy", "latest", "org/policy"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cache.BuildLookupRef(tt.repository, tt.version)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestBuildLookupRef_Regression_NoDoubleTag verifies that the original
+// bug (issue #594) is prevented: a :tag in the repository must not
+// produce a double-tagged reference like "repo:v0.4.0:v0.4.0".
+func TestBuildLookupRef_Regression_NoDoubleTag(t *testing.T) {
+	// When ParsePolicyRef correctly extracts the tag, Repository
+	// will be "complytime/complypack-ampel-bp" and Version "v0.4.0".
+	// BuildLookupRef should produce a single-tagged reference.
+	lookupRef := cache.BuildLookupRef("complytime/complypack-ampel-bp", "v0.4.0")
+	assert.Equal(t, "complytime/complypack-ampel-bp:v0.4.0", lookupRef)
+	assert.NotContains(t, lookupRef, ":v0.4.0:v0.4.0")
+}

--- a/internal/complytime/config.go
+++ b/internal/complytime/config.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/goccy/go-yaml"
+	orasreg "oras.land/oras-go/v2/registry"
 )
 
 var envVarPattern = regexp.MustCompile(`\$\{([^}]+)\}`)
@@ -85,7 +86,9 @@ func (p PolicyEntry) EffectiveID() string {
 	if p.ID != "" {
 		return p.ID
 	}
-	ref := ParsePolicyRef(p.URL)
+	// Error ignored: LoadFrom validates all URLs via validatePolicyRefs
+	// at config load time, so ParsePolicyRef will not fail for loaded entries.
+	ref, _ := ParsePolicyRef(p.URL)
 	segments := strings.Split(ref.Repository, "/")
 	return segments[len(segments)-1]
 }
@@ -98,21 +101,45 @@ type TargetConfig struct {
 	Variables map[string]string `yaml:"variables,omitempty"`
 }
 
-// PolicyRef represents a parsed OCI policy reference.
+// PolicyRef represents a parsed OCI policy reference with its components
+// separated for downstream use (registry client construction, cache lookup,
+// version resolution).
 type PolicyRef struct {
-	Raw        string
-	Registry   string
+	// Raw is the original unparsed input string.
+	Raw string
+	// Registry is the registry host, optionally prefixed with http:// or
+	// https://. Empty for bare policy IDs (no slash in input).
+	Registry string
+	// Repository is the repository path within the registry (e.g.,
+	// "policies/nist-800-53-r5"). For bare policy IDs, this is the
+	// identifier itself.
 	Repository string
-	Version    string
+	// Version is the tag, digest, or empty string. For :tag and @version
+	// inputs it holds the version string (e.g., "v1.0"). For digest inputs
+	// it holds the full algorithm:hex string (e.g., "sha256:9f86d...").
+	// Empty when no version or tag was specified.
+	Version string
 }
 
 // ParsePolicyRef parses a full OCI reference into its components.
 // Handles optional scheme (http://, https://), registry host detection,
-// and @version suffix.
-func ParsePolicyRef(raw string) PolicyRef {
+// :tag, @version, @digest, and bare policy IDs (no slash). Delegates to
+// oras-go's registry.ParseReference for standard OCI references.
+//
+// The @version notation (e.g., "registry.com/repo@v1.0") is a complytime
+// convention that predates standard OCI tag syntax. ParsePolicyRef converts
+// @version to :tag before delegating to oras-go, preserving backwards
+// compatibility. Actual digests (e.g., "@sha256:...") are passed through
+// to oras-go directly.
+func ParsePolicyRef(raw string) (PolicyRef, error) {
 	ref := PolicyRef{Raw: raw}
 	s := strings.TrimSpace(raw)
 
+	if s == "" {
+		return ref, fmt.Errorf("policy reference cannot be empty")
+	}
+
+	// Strip URL scheme prefix; oras-go does not accept schemes.
 	var scheme string
 	if strings.HasPrefix(s, "http://") {
 		scheme = "http://"
@@ -122,20 +149,40 @@ func ParsePolicyRef(raw string) PolicyRef {
 		s = strings.TrimPrefix(s, "https://")
 	}
 
-	if idx := strings.LastIndex(s, "@"); idx > 0 && idx < len(s)-1 {
-		ref.Version = s[idx+1:]
-		s = s[:idx]
-	}
-
-	parts := strings.SplitN(s, "/", 2)
-	if len(parts) == 2 && (strings.Contains(parts[0], ".") || strings.Contains(parts[0], ":")) {
-		ref.Registry = scheme + parts[0]
-		ref.Repository = parts[1]
-	} else {
+	// Bare policy IDs (no slash) are convention-based identifiers, not OCI
+	// references. Handle them directly: extract an optional @version suffix
+	// and treat the rest as the repository.
+	if !strings.Contains(s, "/") {
+		if idx := strings.LastIndex(s, "@"); idx > 0 && idx < len(s)-1 {
+			ref.Version = s[idx+1:]
+			s = s[:idx]
+		}
 		ref.Repository = s
+		return ref, nil
 	}
 
-	return ref
+	// Convert complytime's @version notation to standard :tag syntax before
+	// delegating to oras-go. Actual digests (sha256:, sha512:) keep the @
+	// separator so oras-go parses them as digests.
+	if idx := strings.LastIndex(s, "@"); idx > 0 && idx < len(s)-1 {
+		suffix := s[idx+1:]
+		if !strings.HasPrefix(suffix, "sha256:") && !strings.HasPrefix(suffix, "sha512:") {
+			// Non-digest @version — convert to :tag for oras-go.
+			s = s[:idx] + ":" + suffix
+		}
+	}
+
+	// Delegate to oras-go for standard OCI references.
+	orasRef, err := orasreg.ParseReference(s)
+	if err != nil {
+		return ref, fmt.Errorf("invalid OCI reference %q: %w", raw, err)
+	}
+
+	ref.Registry = scheme + orasRef.Registry
+	ref.Repository = orasRef.Repository
+	ref.Version = orasRef.Reference
+
+	return ref, nil
 }
 
 // FindPolicy matches a policy identifier against the policies list by effective ID.
@@ -186,7 +233,30 @@ func LoadFrom(configPath string) (*WorkspaceConfig, error) {
 		return nil, err
 	}
 
+	if err := validatePolicyRefs(&config); err != nil {
+		return nil, fmt.Errorf("invalid config %s: %w", configPath, err)
+	}
+
 	return &config, nil
+}
+
+// validatePolicyRefs checks that all policy and complypack URLs are
+// parseable OCI references. Called by LoadFrom at load time; if any
+// entry fails parsing, LoadFrom returns an error and the config is not
+// returned. Downstream code can therefore assume ParsePolicyRef will
+// succeed for any URL in a loaded config.
+func validatePolicyRefs(config *WorkspaceConfig) error {
+	for _, entry := range config.Policies {
+		if _, err := ParsePolicyRef(entry.URL); err != nil {
+			return fmt.Errorf("policies[].url %q: %w", entry.URL, err)
+		}
+	}
+	for _, entry := range config.Complypacks {
+		if _, err := ParsePolicyRef(entry.URL); err != nil {
+			return fmt.Errorf("complypacks[].url %q: %w", entry.URL, err)
+		}
+	}
+	return nil
 }
 
 // resolveEnvVars expands ${VAR} references in target variable values

--- a/internal/complytime/config_test.go
+++ b/internal/complytime/config_test.go
@@ -14,52 +14,104 @@ import (
 )
 
 func TestParsePolicyRef_FullReference(t *testing.T) {
-	ref := complytime.ParsePolicyRef("registry.com/policies/nist-800-53-r5@v1.2.3")
+	ref, err := complytime.ParsePolicyRef("registry.com/policies/nist-800-53-r5@v1.2.3")
+	require.NoError(t, err)
 	assert.Equal(t, "registry.com", ref.Registry)
 	assert.Equal(t, "policies/nist-800-53-r5", ref.Repository)
 	assert.Equal(t, "v1.2.3", ref.Version)
 }
 
 func TestParsePolicyRef_NoVersion(t *testing.T) {
-	ref := complytime.ParsePolicyRef("registry.com/policies/nist-800-53-r5")
+	ref, err := complytime.ParsePolicyRef("registry.com/policies/nist-800-53-r5")
+	require.NoError(t, err)
 	assert.Equal(t, "registry.com", ref.Registry)
 	assert.Equal(t, "policies/nist-800-53-r5", ref.Repository)
 	assert.Empty(t, ref.Version)
 }
 
 func TestParsePolicyRef_WithHTTPScheme(t *testing.T) {
-	ref := complytime.ParsePolicyRef("http://localhost:5000/policies/test@v1.0")
+	ref, err := complytime.ParsePolicyRef("http://localhost:5000/policies/test@v1.0")
+	require.NoError(t, err)
 	assert.Equal(t, "http://localhost:5000", ref.Registry)
 	assert.Equal(t, "policies/test", ref.Repository)
 	assert.Equal(t, "v1.0", ref.Version)
 }
 
 func TestParsePolicyRef_WithHTTPSScheme(t *testing.T) {
-	ref := complytime.ParsePolicyRef("https://ghcr.io/org/policy@latest")
+	ref, err := complytime.ParsePolicyRef("https://ghcr.io/org/policy@latest")
+	require.NoError(t, err)
 	assert.Equal(t, "https://ghcr.io", ref.Registry)
 	assert.Equal(t, "org/policy", ref.Repository)
 	assert.Equal(t, "latest", ref.Version)
 }
 
 func TestParsePolicyRef_NoRegistry(t *testing.T) {
-	ref := complytime.ParsePolicyRef("nist-800-53-r5@v1.0")
+	ref, err := complytime.ParsePolicyRef("nist-800-53-r5@v1.0")
+	require.NoError(t, err)
 	assert.Empty(t, ref.Registry)
 	assert.Equal(t, "nist-800-53-r5", ref.Repository)
 	assert.Equal(t, "v1.0", ref.Version)
 }
 
 func TestParsePolicyRef_BareID(t *testing.T) {
-	ref := complytime.ParsePolicyRef("nist-800-53-r5")
+	ref, err := complytime.ParsePolicyRef("nist-800-53-r5")
+	require.NoError(t, err)
 	assert.Empty(t, ref.Registry)
 	assert.Equal(t, "nist-800-53-r5", ref.Repository)
 	assert.Empty(t, ref.Version)
 }
 
 func TestParsePolicyRef_PortInRegistry(t *testing.T) {
-	ref := complytime.ParsePolicyRef("localhost:5000/policy@v2")
+	ref, err := complytime.ParsePolicyRef("localhost:5000/policy@v2")
+	require.NoError(t, err)
 	assert.Equal(t, "localhost:5000", ref.Registry)
 	assert.Equal(t, "policy", ref.Repository)
 	assert.Equal(t, "v2", ref.Version)
+}
+
+func TestParsePolicyRef_ColonTag(t *testing.T) {
+	ref, err := complytime.ParsePolicyRef("quay.io/complytime/complypack-ampel-bp:v0.4.0")
+	require.NoError(t, err)
+	assert.Equal(t, "quay.io", ref.Registry)
+	assert.Equal(t, "complytime/complypack-ampel-bp", ref.Repository)
+	assert.Equal(t, "v0.4.0", ref.Version)
+}
+
+func TestParsePolicyRef_ColonLatest(t *testing.T) {
+	ref, err := complytime.ParsePolicyRef("quay.io/complytime/complypack-ampel-bp:latest")
+	require.NoError(t, err)
+	assert.Equal(t, "quay.io", ref.Registry)
+	assert.Equal(t, "complytime/complypack-ampel-bp", ref.Repository)
+	assert.Equal(t, "latest", ref.Version)
+}
+
+func TestParsePolicyRef_Digest(t *testing.T) {
+	digest := "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+	ref, err := complytime.ParsePolicyRef("quay.io/complytime/complypack-ampel-bp@" + digest)
+	require.NoError(t, err)
+	assert.Equal(t, "quay.io", ref.Registry)
+	assert.Equal(t, "complytime/complypack-ampel-bp", ref.Repository)
+	assert.Equal(t, digest, ref.Version)
+}
+
+func TestParsePolicyRef_HTTPSchemeWithColonTag(t *testing.T) {
+	ref, err := complytime.ParsePolicyRef("http://localhost:5000/policies/test:v1.0")
+	require.NoError(t, err)
+	assert.Equal(t, "http://localhost:5000", ref.Registry)
+	assert.Equal(t, "policies/test", ref.Repository)
+	assert.Equal(t, "v1.0", ref.Version)
+}
+
+func TestParsePolicyRef_ErrorOnEmpty(t *testing.T) {
+	_, err := complytime.ParsePolicyRef("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be empty")
+}
+
+func TestParsePolicyRef_ErrorOnWhitespace(t *testing.T) {
+	_, err := complytime.ParsePolicyRef("   ")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be empty")
 }
 
 func TestPolicyEntry_EffectiveID_ExplicitID(t *testing.T) {
@@ -692,6 +744,71 @@ targets:
 
 	// Verify EffectiveID derivation works for the entry without explicit ID
 	assert.Equal(t, "complypack-ubuntu", cfg.Complypacks[1].EffectiveID())
+}
+
+func TestLoadFrom_InvalidPolicyURL(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "complytime.yml")
+
+	yamlContent := `policies:
+  - url: ""
+targets:
+  - id: local
+    policies:
+      - nist
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(yamlContent), 0600))
+
+	_, err := complytime.LoadFrom(configPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid config")
+}
+
+func TestLoadFrom_InvalidComplypackURL(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "complytime.yml")
+
+	yamlContent := `policies:
+  - url: registry.com/policies/nist@v1.0
+    id: nist
+complypacks:
+  - url: "   "
+targets:
+  - id: local
+    policies:
+      - nist
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(yamlContent), 0600))
+
+	_, err := complytime.LoadFrom(configPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid config")
+}
+
+// TestLoadFrom_ColonTagComplypack verifies the fix for issue #594:
+// complypack URLs using :tag syntax must load and parse correctly.
+func TestLoadFrom_ColonTagComplypack(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "complytime.yml")
+
+	yamlContent := `policies:
+  - url: quay.io/complytime/policies-ampel-bp:latest
+    id: ampel-bp
+complypacks:
+  - url: quay.io/complytime/complypack-ampel-bp:v0.4.0
+    id: ampel-bp-pack
+targets:
+  - id: local
+    policies:
+      - ampel-bp
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(yamlContent), 0600))
+
+	cfg, err := complytime.LoadFrom(configPath)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.Len(t, cfg.Complypacks, 1)
+	assert.Equal(t, "quay.io/complytime/complypack-ampel-bp:v0.4.0", cfg.Complypacks[0].URL)
 }
 
 func TestLoadFrom_WithoutComplypacks(t *testing.T) {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -241,7 +241,16 @@ func CheckPolicyVersions(cfg *complytime.WorkspaceConfig, cacheDir string, versi
 	var results []CheckResult
 
 	for _, p := range cfg.Policies {
-		ref := complytime.ParsePolicyRef(p.URL)
+		ref, err := complytime.ParsePolicyRef(p.URL)
+		if err != nil {
+			results = append(results, CheckResult{
+				Name:     fmt.Sprintf("policy/%s", p.EffectiveID()),
+				Status:   StatusFail,
+				Message:  fmt.Sprintf("invalid policy reference: %v", err),
+				Blocking: true,
+			})
+			continue
+		}
 		eid := p.EffectiveID()
 
 		if unreachable[ref.Registry] {
@@ -435,7 +444,11 @@ func CheckVariables(cfg *complytime.WorkspaceConfig, healthData []ProviderHealth
 					resolveFailures++
 					continue
 				}
-				ref := complytime.ParsePolicyRef(entry.URL)
+				ref, refErr := complytime.ParsePolicyRef(entry.URL)
+				if refErr != nil {
+					resolveFailures++
+					continue
+				}
 				version, err := resolver.ResolveVersion(ref.Repository, ref.Version)
 				if err != nil {
 					resolveFailures++
@@ -588,7 +601,10 @@ func CheckPolicyActivePeriod(cfg *complytime.WorkspaceConfig, resolver PolicyGra
 	var results []CheckResult
 
 	for _, p := range cfg.Policies {
-		ref := complytime.ParsePolicyRef(p.URL)
+		ref, refErr := complytime.ParsePolicyRef(p.URL)
+		if refErr != nil {
+			continue
+		}
 		eid := p.EffectiveID()
 
 		version, err := resolver.ResolveVersion(ref.Repository, ref.Version)
@@ -770,7 +786,10 @@ func CheckComplypacks(cfg *complytime.WorkspaceConfig, cacheDir string, resolver
 	// following the same resolution pattern as CheckVariables.
 	evaluatorIDs := make(map[string]bool)
 	for _, p := range cfg.Policies {
-		ref := complytime.ParsePolicyRef(p.URL)
+		ref, refErr := complytime.ParsePolicyRef(p.URL)
+		if refErr != nil {
+			continue
+		}
 		version, err := resolver.ResolveVersion(ref.Repository, ref.Version)
 		if err != nil {
 			continue

--- a/openspec/changes/fix-complypack-oci-ref/.openspec.yaml
+++ b/openspec/changes/fix-complypack-oci-ref/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-18

--- a/openspec/changes/fix-complypack-oci-ref/design.md
+++ b/openspec/changes/fix-complypack-oci-ref/design.md
@@ -1,0 +1,55 @@
+## Context
+
+`ParsePolicyRef` is a hand-rolled OCI reference parser in `internal/complytime/config.go` used by 10 production call sites across `cmd/` and `internal/`. It only recognizes `@` as a version separator, missing the standard `:tag` syntax. The codebase already vendors `oras.land/oras-go/v2` (v2.6.1) which includes `registry.ParseReference` — a robust parser that handles all four OCI reference forms (`:tag`, `@digest`, `:tag@digest`, and bare).
+
+The downstream sync functions (`SyncPolicy`, `SyncComplypack`) construct `lookupRef` by concatenating `repository + ":" + version`, which produces invalid double-tagged references when the tag was not stripped from the repository during parsing.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Support `:tag`, `@digest`, and bare OCI references in both `policies` and `complypacks` config entries
+- Return validation errors for malformed OCI references
+- Fail fast at config load time with clear error messages
+- Maintain backwards compatibility with existing `@version` notation and bare policy IDs
+
+**Non-Goals:**
+- Distinguishing digest from tag at the `PolicyRef` struct level (keep single `Version` field)
+- Changing `EffectiveID()` signature
+- Refactoring the sync functions beyond the `lookupRef` construction fix
+- Supporting `registry/repo:tag@digest` form (oras-go silently drops the tag in this case, which is acceptable)
+
+## Decisions
+
+### 1. Delegate to oras-go `registry.ParseReference` for OCI refs
+
+**Decision:** Strip any URL scheme prefix, then delegate to `registry.ParseReference` for inputs containing a `/`. For bare IDs (no `/`), handle directly as repository-only refs.
+
+**Rationale:** oras-go's parser is battle-tested, handles all four OCI forms correctly, and is already vendored. Reimplementing this logic is the source of the current bug.
+
+**Alternatives considered:**
+- Fix the hand-rolled parser to also handle `:tag` — viable but fragile, duplicates logic that oras-go already provides.
+- Replace `PolicyRef` with oras-go's `Reference` directly — too invasive, loses the scheme handling and bare-ID support that `ParsePolicyRef` provides.
+
+### 2. Keep `Version` field as-is (Option 3 from exploration)
+
+**Decision:** Map oras-go's `Reference.Reference` field directly to `PolicyRef.Version`. Callers that construct OCI references check `strings.HasPrefix(version, "sha256:")` to decide between `@` and `:` separators.
+
+**Rationale:** Minimal struct change, no new fields. The digest-vs-tag distinction only matters in two places (the sync `lookupRef` construction), and a prefix check is clear and sufficient.
+
+### 3. Validate at `LoadFrom` time
+
+**Decision:** After unmarshaling `complytime.yaml`, iterate all `Policies` and `Complypacks` entries and call `ParsePolicyRef` on each URL. Return an error if any are invalid.
+
+**Rationale:** Fail fast with a clear error message. Downstream code (including `EffectiveID()`) can then assume valid refs without propagating errors. This avoids changing `EffectiveID()` to return `(string, error)`, which would cascade through many callers.
+
+### 4. Extract `lookupRef` construction into a helper
+
+**Decision:** Add a small helper (e.g., `buildLookupRef(repository, version string) string`) that encapsulates the tag-vs-digest logic, used by both `SyncPolicy` and `SyncComplypack`.
+
+**Rationale:** Both sync functions have identical `lookupRef` construction logic. Centralizing it prevents the digest handling from being duplicated.
+
+## Risks / Trade-offs
+
+- **[Bare IDs bypass oras-go validation]** → Bare IDs like `nist-800-53-r5` are intentionally passed through without oras-go validation. These are convention-based identifiers, not OCI refs. If stricter validation is needed later, it can be added separately.
+- **[Scheme stripping before oras-go]** → `ParsePolicyRef` strips `http://`/`https://` before passing to oras-go, then reattaches the scheme to `Registry`. If oras-go ever changes how it validates the registry component, this could interact poorly. Mitigation: the scheme handling is straightforward string manipulation with existing test coverage.
+- **[`EffectiveID()` trusts pre-validation]** → If `ParsePolicyRef` is called on an unvalidated string outside of config loading, `EffectiveID()` could silently produce wrong IDs. Mitigation: `ParsePolicyRef` returns an error, so any new call site will be prompted by the compiler to handle it.

--- a/openspec/changes/fix-complypack-oci-ref/proposal.md
+++ b/openspec/changes/fix-complypack-oci-ref/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+`ParsePolicyRef` in `internal/complytime/config.go` only recognizes `@` as a version separator, not the standard OCI `:tag` syntax. When a complypack (or policy) URL uses `:v0.4.0`, the tag is left embedded in the `Repository` field. Downstream sync functions then append `":" + version`, producing a double-tagged reference like `org/pack:v0.4.0:v0.4.0` which fails as an invalid OCI reference. The `:latest` tag works only by accident due to a guard that skips appending when the version is `"latest"`. This is tracked in [issue #594](https://github.com/complytime/complyctl/issues/594).
+
+## What Changes
+
+- Rewrite `ParsePolicyRef` to delegate OCI reference parsing to the vendored `oras.land/oras-go/v2/registry.ParseReference`, which correctly handles `:tag`, `@digest`, and bare references.
+- Change `ParsePolicyRef` signature from `ParsePolicyRef(raw string) PolicyRef` to `ParsePolicyRef(raw string) (PolicyRef, error)`, returning validation errors for malformed OCI references.
+- Add digest-aware reference construction in `SyncPolicy` and `SyncComplypack` so digest versions use `@` instead of `:` when building `lookupRef`.
+- Add config-time validation in `LoadFrom` to fail fast on invalid policy/complypack URLs with clear error messages.
+- Update all 10 production callers of `ParsePolicyRef` to handle the new error return.
+
+## Capabilities
+
+### New Capabilities
+- `oci-ref-parsing`: Standard OCI reference parsing for policy and complypack URLs, supporting `:tag`, `@digest`, and bare repository forms with validation.
+
+### Modified Capabilities
+
+## Impact
+
+- `internal/complytime/config.go` — `ParsePolicyRef` signature and implementation change; `LoadFrom` gains validation loop
+- `internal/complytime/config_test.go` — existing tests updated for error return; new test cases for `:tag` and `@digest`
+- `internal/cache/sync.go` — `lookupRef` construction handles digest references
+- `internal/cache/complypack_sync.go` — `lookupRef` construction handles digest references
+- `cmd/complyctl/cli/get.go` — 2 call sites handle `ParsePolicyRef` error
+- `cmd/complyctl/cli/scan.go` — 1 call site handles `ParsePolicyRef` error
+- `cmd/complyctl/cli/list.go` — 1 call site handles `ParsePolicyRef` error
+- `cmd/complyctl/cli/generate.go` — 1 call site handles `ParsePolicyRef` error
+- `internal/doctor/doctor.go` — 4 call sites handle `ParsePolicyRef` error
+- `EffectiveID()` is unchanged — config validation at load time ensures it never receives invalid refs

--- a/openspec/changes/fix-complypack-oci-ref/specs/oci-ref-parsing/spec.md
+++ b/openspec/changes/fix-complypack-oci-ref/specs/oci-ref-parsing/spec.md
@@ -1,0 +1,88 @@
+## ADDED Requirements
+
+### Requirement: ParsePolicyRef supports colon-tag syntax
+`ParsePolicyRef` SHALL parse OCI references using `:tag` syntax (e.g., `registry.com/org/image:v0.4.0`) and populate `PolicyRef.Version` with the tag value and `PolicyRef.Repository` with the repository path excluding the tag.
+
+#### Scenario: Reference with colon tag
+- **WHEN** `ParsePolicyRef` is called with `"quay.io/complytime/complypack-ampel-bp:v0.4.0"`
+- **THEN** `PolicyRef.Registry` SHALL be `"quay.io"`, `PolicyRef.Repository` SHALL be `"complytime/complypack-ampel-bp"`, and `PolicyRef.Version` SHALL be `"v0.4.0"`
+
+#### Scenario: Reference with latest tag
+- **WHEN** `ParsePolicyRef` is called with `"quay.io/complytime/complypack-ampel-bp:latest"`
+- **THEN** `PolicyRef.Registry` SHALL be `"quay.io"`, `PolicyRef.Repository` SHALL be `"complytime/complypack-ampel-bp"`, and `PolicyRef.Version` SHALL be `"latest"`
+
+### Requirement: ParsePolicyRef supports digest syntax
+`ParsePolicyRef` SHALL parse OCI references using `@digest` syntax (e.g., `registry.com/org/image@sha256:abc123`) and populate `PolicyRef.Version` with the digest value.
+
+#### Scenario: Reference with SHA256 digest
+- **WHEN** `ParsePolicyRef` is called with `"quay.io/complytime/complypack-ampel-bp@sha256:abc123def456"`
+- **THEN** `PolicyRef.Registry` SHALL be `"quay.io"`, `PolicyRef.Repository` SHALL be `"complytime/complypack-ampel-bp"`, and `PolicyRef.Version` SHALL be `"sha256:abc123def456"`
+
+### Requirement: ParsePolicyRef supports bare references
+`ParsePolicyRef` SHALL parse bare OCI references with no tag or digest and leave `PolicyRef.Version` empty.
+
+#### Scenario: Reference without tag or digest
+- **WHEN** `ParsePolicyRef` is called with `"quay.io/complytime/complypack-ampel-bp"`
+- **THEN** `PolicyRef.Registry` SHALL be `"quay.io"`, `PolicyRef.Repository` SHALL be `"complytime/complypack-ampel-bp"`, and `PolicyRef.Version` SHALL be `""`
+
+### Requirement: ParsePolicyRef supports bare policy IDs
+`ParsePolicyRef` SHALL accept bare policy identifiers with no registry or path separator and populate only `PolicyRef.Repository`.
+
+#### Scenario: Bare policy ID without version
+- **WHEN** `ParsePolicyRef` is called with `"nist-800-53-r5"`
+- **THEN** `PolicyRef.Registry` SHALL be `""`, `PolicyRef.Repository` SHALL be `"nist-800-53-r5"`, and `PolicyRef.Version` SHALL be `""`
+
+#### Scenario: Bare policy ID with at-version
+- **WHEN** `ParsePolicyRef` is called with `"nist-800-53-r5@v1.0"`
+- **THEN** `PolicyRef.Registry` SHALL be `""`, `PolicyRef.Repository` SHALL be `"nist-800-53-r5"`, and `PolicyRef.Version` SHALL be `"v1.0"`
+
+### Requirement: ParsePolicyRef supports URL scheme prefixes
+`ParsePolicyRef` SHALL strip `http://` and `https://` scheme prefixes and include them in `PolicyRef.Registry`.
+
+#### Scenario: HTTP scheme with port
+- **WHEN** `ParsePolicyRef` is called with `"http://localhost:5000/policies/test:v1.0"`
+- **THEN** `PolicyRef.Registry` SHALL be `"http://localhost:5000"`, `PolicyRef.Repository` SHALL be `"policies/test"`, and `PolicyRef.Version` SHALL be `"v1.0"`
+
+#### Scenario: HTTPS scheme with tag
+- **WHEN** `ParsePolicyRef` is called with `"https://ghcr.io/org/policy:v2.0"`
+- **THEN** `PolicyRef.Registry` SHALL be `"https://ghcr.io"`, `PolicyRef.Repository` SHALL be `"org/policy"`, and `PolicyRef.Version` SHALL be `"v2.0"`
+
+### Requirement: ParsePolicyRef returns error for invalid references
+`ParsePolicyRef` SHALL return an error for OCI references that are structurally invalid.
+
+#### Scenario: Empty input
+- **WHEN** `ParsePolicyRef` is called with `""`
+- **THEN** it SHALL return a non-nil error
+
+#### Scenario: Whitespace-only input
+- **WHEN** `ParsePolicyRef` is called with `"   "`
+- **THEN** it SHALL return a non-nil error
+
+### Requirement: ParsePolicyRef preserves at-version backwards compatibility
+`ParsePolicyRef` SHALL continue to support the existing `@version` notation used in policy references.
+
+#### Scenario: Full reference with at-version
+- **WHEN** `ParsePolicyRef` is called with `"registry.com/policies/nist-800-53-r5@v1.2.3"`
+- **THEN** `PolicyRef.Registry` SHALL be `"registry.com"`, `PolicyRef.Repository` SHALL be `"policies/nist-800-53-r5"`, and `PolicyRef.Version` SHALL be `"v1.2.3"`
+
+### Requirement: Sync functions construct valid lookup references for digests
+`SyncPolicy` and `SyncComplypack` SHALL use `@` as the separator when constructing lookup references for digest versions and `:` for tag versions.
+
+#### Scenario: Lookup reference with tag version
+- **WHEN** `SyncPolicy` or `SyncComplypack` is called with `repository="org/policy"` and `version="v1.0"`
+- **THEN** the lookup reference SHALL be `"org/policy:v1.0"`
+
+#### Scenario: Lookup reference with digest version
+- **WHEN** `SyncPolicy` or `SyncComplypack` is called with `repository="org/policy"` and `version="sha256:abc123"`
+- **THEN** the lookup reference SHALL be `"org/policy@sha256:abc123"`
+
+### Requirement: Config loading validates OCI references
+`LoadFrom` SHALL validate all policy and complypack URLs after loading `complytime.yaml` and return an error if any are structurally invalid.
+
+#### Scenario: Invalid policy URL in config
+- **WHEN** `LoadFrom` loads a `complytime.yaml` containing a policy with an invalid OCI reference
+- **THEN** it SHALL return an error identifying the invalid entry
+
+#### Scenario: Valid config with mixed reference styles
+- **WHEN** `LoadFrom` loads a `complytime.yaml` containing policies using `:tag`, `@version`, and bare references
+- **THEN** it SHALL succeed without error

--- a/openspec/changes/fix-complypack-oci-ref/tasks.md
+++ b/openspec/changes/fix-complypack-oci-ref/tasks.md
@@ -1,0 +1,27 @@
+## 1. ParsePolicyRef Rewrite
+
+- [x] 1.1 Rewrite `ParsePolicyRef` in `internal/complytime/config.go` to delegate to `oras.land/oras-go/v2/registry.ParseReference` for inputs containing `/`, handling scheme stripping and bare IDs separately. Change signature to `(PolicyRef, error)`.
+- [x] 1.2 Update `internal/complytime/config_test.go`: update existing 7 test cases for `(PolicyRef, error)` return and add new cases for `:tag`, `@sha256:digest`, empty input, and whitespace-only input.
+
+## 2. Config Load Validation
+
+- [x] 2.1 Add a validation loop in `LoadFrom` (`internal/complytime/config.go`) after YAML unmarshal to call `ParsePolicyRef` on all `Policies` and `Complypacks` entry URLs, returning an error on the first invalid reference.
+
+## 3. Sync Lookup Reference Fix
+
+- [x] 3.1 Extract a `buildLookupRef(repository, version string) string` helper (in `internal/cache/` or alongside the sync functions) that uses `@` for digest versions and `:` for tag versions.
+- [x] 3.2 Update `SyncPolicy` in `internal/cache/sync.go` to use `buildLookupRef`.
+- [x] 3.3 Update `SyncComplypack` in `internal/cache/complypack_sync.go` to use `buildLookupRef`.
+
+## 4. Caller Updates
+
+- [x] 4.1 Update `syncSinglePolicy` and `syncSingleComplypack` in `cmd/complyctl/cli/get.go` to handle `ParsePolicyRef` error return.
+- [x] 4.2 Update `scanOptions.scanPolicy` in `cmd/complyctl/cli/scan.go` to handle `ParsePolicyRef` error return.
+- [x] 4.3 Update list command in `cmd/complyctl/cli/list.go` to handle `ParsePolicyRef` error return.
+- [x] 4.4 Update `generateOptions.generatePolicy` in `cmd/complyctl/cli/generate.go` to handle `ParsePolicyRef` error return.
+- [x] 4.5 Update 4 call sites in `internal/doctor/doctor.go` (`CheckPolicyStaleness`, `CheckVariables`, `CheckPolicyExpiry`, `CheckComplypackCache`) to handle `ParsePolicyRef` error return.
+
+## 5. Verification
+
+- [x] 5.1 Run `make test-unit` and confirm all tests pass.
+- [x] 5.2 Run `make lint` and confirm no lint errors.


### PR DESCRIPTION
## Summary

This PR updates the `ParsePolicyRef` to hand off OCI reference parsing to the already-vendored oras-go library. The update now supports `:tag` and `@digest` syntax in policy and complypack URLs. No new dependencies. Backwards compatible with existing `@version` notation.

## Related Issues

- Issue #594 
- Closes #594 

## Review Hints

- Test in the complyctl `.devcontainer` / devpod environment. 
- Update the `.complytime/complytime.yaml` workspace configuration file with
```
policies:
  - url: quay.io/complytime/policies-ampel-branch-protection:latest
    id: ampel-bp

complypacks:
  - url: quay.io/complytime/complypack-ampel-branch-protection:v0.4.0
    id: ampel-bp-pack

targets:
  - id: complytime-complyctl
    policies:
      - ampel-bp
    variables:
      url: https://github.com/complytime/complyctl
      specs: builtin:github/branch-rules.yaml
```
**Run the commands** 
- `complyctl get` # ensure fetched policies with no errors
- `complyctl generate --policy-id ampel-bp` # make sure all 5 requirements were generated
- `complyctl scan --policy-id ampel-bp --format pretty` # look at the Markdown result

**Reference Results**

<details>
  <summary>Compliance Scan Report Results</summary>

# Compliance Scan Report: complytime/policies-ampel-branch-protection

**Generated**: 2026-06-18T16:30:02Z

---

## Control: force-push-restriction

- **Result**: Passed
- **Message**: 1 of 1 repositories passed

### block-force-push
- **Confidence**: High
- **Result**: Passed
- **Message**: 1 of 1 repositories passed
- **Steps Executed**: 1

## Control: approval-requirements

- **Result**: Passed
- **Message**: 3 of 3 repositories passed

### minimum-approvals
- **Confidence**: High
- **Result**: Passed
- **Message**: 3 of 3 repositories passed
- **Steps Executed**: 3

## Control: admin-bypass-prevention

- **Result**: Passed
- **Message**: 1 of 1 repositories passed

### prevent-admin-bypass
- **Confidence**: High
- **Result**: Passed
- **Message**: 1 of 1 repositories passed
- **Steps Executed**: 1

## Control: code-owner-enforcement

- **Result**: Passed
- **Message**: 1 of 1 repositories passed

### require-code-owner-review
- **Confidence**: High
- **Result**: Passed
- **Message**: 1 of 1 repositories passed
- **Steps Executed**: 1

## Control: pull-request-enforcement

- **Result**: Passed
- **Message**: 1 of 1 repositories passed

### require-pull-request
- **Confidence**: High
- **Result**: Passed
- **Message**: 1 of 1 repositories passed
- **Steps Executed**: 1

---

## Evaluation Log

```yaml
metadata:
  id: complytime/policies-ampel-branch-protection
  type: EvaluationLog
  gemara-version: v1.0.0
  description: Compliance scan evaluation log
  author:
    id: complytime
    name: complytime
    type: Software
    uri: https://github.com/complytime/complyctl
result: Passed
evaluations:
- name: force-push-restriction
  result: Passed
  message: 1 of 1 repositories passed
  control:
    reference-id: complytime/policies-ampel-branch-protection
    entry-id: force-push-restriction
  assessment-logs:
  - requirement:
      reference-id: complytime/policies-ampel-branch-protection
      entry-id: block-force-push
    plan:
      reference-id: complytime/policies-ampel-branch-protection
      entry-id: block-force-push
    description: 1 of 1 repositories passed
    result: Passed
    message: 1 of 1 repositories passed
    applicability:
    - default
    steps:
    - "complytime/complypack-ampel-branch-protection@sha256:8856c34cc7bf7d0f7149afd3b0d73027ee704d33057be5dc1a70eaef236e8b8e#complytime/complyctl@main"
    steps-executed: 1
    start: "2026-06-18T16:30:02Z"
    confidence-level: High
- name: approval-requirements
  result: Passed
  message: 3 of 3 repositories passed
  control:
    reference-id: complytime/policies-ampel-branch-protection
    entry-id: approval-requirements
  assessment-logs:
  - requirement:
      reference-id: complytime/policies-ampel-branch-protection
      entry-id: minimum-approvals
    plan:
      reference-id: complytime/policies-ampel-branch-protection
      entry-id: minimum-approvals
    description: 3 of 3 repositories passed
    result: Passed
    message: 3 of 3 repositories passed
    applicability:
    - default
    steps:
    - "complytime/complypack-ampel-branch-protection@sha256:8856c34cc7bf7d0f7149afd3b0d73027ee704d33057be5dc1a70eaef236e8b8e#complytime/complyctl@main"
    - "complytime/complypack-ampel-branch-protection@sha256:8856c34cc7bf7d0f7149afd3b0d73027ee704d33057be5dc1a70eaef236e8b8e#complytime/complyctl@main"
    - "complytime/complypack-ampel-branch-protection@sha256:8856c34cc7bf7d0f7149afd3b0d73027ee704d33057be5dc1a70eaef236e8b8e#complytime/complyctl@main"
    steps-executed: 3
    start: "2026-06-18T16:30:02Z"
    confidence-level: High
- name: admin-bypass-prevention
  result: Passed
  message: 1 of 1 repositories passed
  control:
    reference-id: complytime/policies-ampel-branch-protection
    entry-id: admin-bypass-prevention
  assessment-logs:
  - requirement:
      reference-id: complytime/policies-ampel-branch-protection
      entry-id: prevent-admin-bypass
    plan:
      reference-id: complytime/policies-ampel-branch-protection
      entry-id: prevent-admin-bypass
    description: 1 of 1 repositories passed
    result: Passed
    message: 1 of 1 repositories passed
    applicability:
    - default
    steps:
    - "complytime/complypack-ampel-branch-protection@sha256:8856c34cc7bf7d0f7149afd3b0d73027ee704d33057be5dc1a70eaef236e8b8e#complytime/complyctl@main"
    steps-executed: 1
    start: "2026-06-18T16:30:02Z"
    confidence-level: High
- name: code-owner-enforcement
  result: Passed
  message: 1 of 1 repositories passed
  control:
    reference-id: complytime/policies-ampel-branch-protection
    entry-id: code-owner-enforcement
  assessment-logs:
  - requirement:
      reference-id: complytime/policies-ampel-branch-protection
      entry-id: require-code-owner-review
    plan:
      reference-id: complytime/policies-ampel-branch-protection
      entry-id: require-code-owner-review
    description: 1 of 1 repositories passed
    result: Passed
    message: 1 of 1 repositories passed
    applicability:
    - default
    steps:
    - "complytime/complypack-ampel-branch-protection@sha256:8856c34cc7bf7d0f7149afd3b0d73027ee704d33057be5dc1a70eaef236e8b8e#complytime/complyctl@main"
    steps-executed: 1
    start: "2026-06-18T16:30:02Z"
    confidence-level: High
- name: pull-request-enforcement
  result: Passed
  message: 1 of 1 repositories passed
  control:
    reference-id: complytime/policies-ampel-branch-protection
    entry-id: pull-request-enforcement
  assessment-logs:
  - requirement:
      reference-id: complytime/policies-ampel-branch-protection
      entry-id: require-pull-request
    plan:
      reference-id: complytime/policies-ampel-branch-protection
      entry-id: require-pull-request
    description: 1 of 1 repositories passed
    result: Passed
    message: 1 of 1 repositories passed
    applicability:
    - default
    steps:
    - "complytime/complypack-ampel-branch-protection@sha256:8856c34cc7bf7d0f7149afd3b0d73027ee704d33057be5dc1a70eaef236e8b8e#complytime/complyctl@main"
    steps-executed: 1
    start: "2026-06-18T16:30:02Z"
    confidence-level: High
target:
  id: complytime-complyctl
  name: complytime-complyctl
  type: Software

```
</details>