### PR TITLE
chore: align PolicyRef with OCI reference semantics

### DIFF
--- a/.gaze/baseline.json
+++ b/.gaze/baseline.json
@@ -770,9 +770,18 @@
     },
     {
       "package": "cli",
+      "function": "complypackDigestsByEvaluator",
+      "file": "cmd/complyctl/cli/scan.go",
+      "line": 495,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4
+    },
+    {
+      "package": "cli",
       "function": "needsRegeneration",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 494,
+      "line": 505,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -781,7 +790,7 @@
       "package": "cli",
       "function": "evaluatorArtifactsExist",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 511,
+      "line": 522,
       "complexity": 6,
       "line_coverage": 100,
       "crap": 6
@@ -790,7 +799,7 @@
       "package": "cli",
       "function": "runGeneration",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 526,
+      "line": 537,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -799,7 +808,7 @@
       "package": "cli",
       "function": "generateForAllTargets",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 542,
+      "line": 553,
       "complexity": 5,
       "line_coverage": 36.36363636363637,
       "crap": 11.442524417731029
@@ -808,7 +817,7 @@
       "package": "cli",
       "function": "executeScan",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 562,
+      "line": 573,
       "complexity": 1,
       "line_coverage": 0,
       "crap": 2
@@ -817,7 +826,7 @@
       "package": "cli",
       "function": "scanAllTargets",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 570,
+      "line": 581,
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
@@ -827,7 +836,7 @@
       "package": "cli",
       "function": "scanSingleTarget",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 596,
+      "line": 607,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -836,7 +845,7 @@
       "package": "cli",
       "function": "writeScanReports",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 615,
+      "line": 626,
       "complexity": 3,
       "line_coverage": 71.42857142857143,
       "crap": 3.2099125364431487
@@ -845,7 +854,7 @@
       "package": "cli",
       "function": "writeFormatReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 629,
+      "line": 640,
       "complexity": 4,
       "line_coverage": 40,
       "crap": 7.4559999999999995
@@ -854,7 +863,7 @@
       "package": "cli",
       "function": "writePrettyReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 641,
+      "line": 652,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -863,7 +872,7 @@
       "package": "cli",
       "function": "writeSARIFReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 652,
+      "line": 663,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -872,7 +881,7 @@
       "package": "cli",
       "function": "writeOSCALReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 661,
+      "line": 672,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -881,7 +890,7 @@
       "package": "cli",
       "function": "(*scanOptions).runExport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 672,
+      "line": 683,
       "complexity": 5,
       "line_coverage": 16.666666666666668,
       "crap": 19.467592592592588,
@@ -891,7 +900,7 @@
       "package": "cli",
       "function": "authRequired",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 698,
+      "line": 709,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -900,7 +909,7 @@
       "package": "cli",
       "function": "validateAuthCredentials",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 702,
+      "line": 713,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -909,7 +918,7 @@
       "package": "cli",
       "function": "resolveCollectorAuth",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 709,
+      "line": 720,
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
@@ -919,7 +928,7 @@
       "package": "cli",
       "function": "exportToProviders",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 724,
+      "line": 735,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -928,7 +937,7 @@
       "package": "cli",
       "function": "exportSingleProvider",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 732,
+      "line": 743,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -937,7 +946,7 @@
       "package": "cli",
       "function": "resolveOIDCToken",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 749,
+      "line": 760,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -946,7 +955,7 @@
       "package": "cli",
       "function": "formatExportSummary",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 762,
+      "line": 773,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -955,7 +964,7 @@
       "package": "cli",
       "function": "appendExportRow",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 782,
+      "line": 793,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -964,7 +973,7 @@
       "package": "cli",
       "function": "appendResponseRow",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 796,
+      "line": 807,
       "complexity": 3,
       "line_coverage": 85.71428571428571,
       "crap": 3.0262390670553936
@@ -973,7 +982,7 @@
       "package": "cli",
       "function": "exportResponseStatus",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 809,
+      "line": 820,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -982,7 +991,7 @@
       "package": "cli",
       "function": "countExportFailures",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 831,
+      "line": 842,
       "complexity": 7,
       "line_coverage": 100,
       "crap": 7
@@ -991,7 +1000,7 @@
       "package": "cli",
       "function": "injectWorkspaceIntoTargets",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 852,
+      "line": 863,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -1000,7 +1009,7 @@
       "package": "cli",
       "function": "extractReqToControlMap",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 863,
+      "line": 874,
       "complexity": 6,
       "line_coverage": 90,
       "crap": 6.036
@@ -1009,7 +1018,7 @@
       "package": "cli",
       "function": "extractPlanToReqMap",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 884,
+      "line": 895,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -1018,7 +1027,7 @@
       "package": "cli",
       "function": "resolveAssessmentIDs",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 899,
+      "line": 910,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -1027,7 +1036,7 @@
       "package": "cli",
       "function": "reverseMap",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 909,
+      "line": 920,
       "complexity": 3,
       "line_coverage": 83.33333333333333,
       "crap": 3.0416666666666665
@@ -1036,7 +1045,7 @@
       "package": "cli",
       "function": "buildReqToComplypackRef",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 930,
+      "line": 941,
       "complexity": 11,
       "line_coverage": 82.6086956521739,
       "crap": 11.636475712994166
@@ -1588,8 +1597,8 @@
       "file": "internal/cache/complypack_sync.go",
       "line": 42,
       "complexity": 13,
-      "line_coverage": 84.375,
-      "crap": 13.644683837890625,
+      "line_coverage": 84.84848484848484,
+      "crap": 13.587834265520216,
       "contract_coverage": 100,
       "gaze_crap": 13,
       "quadrant": "Q1_Safe"
@@ -1706,19 +1715,28 @@
       "package": "cache",
       "function": "BuildLookupRef",
       "file": "internal/cache/sync.go",
-      "line": 18,
-      "complexity": 5,
+      "line": 20,
+      "complexity": 4,
       "line_coverage": 100,
-      "crap": 5,
+      "crap": 4,
       "contract_coverage": 100,
-      "gaze_crap": 5,
+      "gaze_crap": 4,
       "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "cache",
+      "function": "classifyVersion",
+      "file": "internal/cache/sync.go",
+      "line": 35,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
     },
     {
       "package": "cache",
       "function": "NewSync",
       "file": "internal/cache/sync.go",
-      "line": 35,
+      "line": 49,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1,
@@ -1730,10 +1748,10 @@
       "package": "cache",
       "function": "(*Sync).SyncPolicy",
       "file": "internal/cache/sync.go",
-      "line": 46,
+      "line": 60,
       "complexity": 12,
-      "line_coverage": 82.6086956521739,
-      "crap": 12.757458699761651,
+      "line_coverage": 83.33333333333333,
+      "crap": 12.666666666666668,
       "contract_coverage": 100,
       "gaze_crap": 12,
       "quadrant": "Q1_Safe"
@@ -1742,7 +1760,7 @@
       "package": "complytime",
       "function": "ValidateOCIRef",
       "file": "internal/complytime/config.go",
-      "line": 24,
+      "line": 33,
       "complexity": 6,
       "line_coverage": 100,
       "crap": 6
@@ -1751,7 +1769,16 @@
       "package": "complytime",
       "function": "(PolicyEntry).EffectiveID",
       "file": "internal/complytime/config.go",
-      "line": 85,
+      "line": 94,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
+    },
+    {
+      "package": "complytime",
+      "function": "(PolicyRef).VersionString",
+      "file": "internal/complytime/config.go",
+      "line": 139,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -1760,16 +1787,17 @@
       "package": "complytime",
       "function": "ParsePolicyRef",
       "file": "internal/complytime/config.go",
-      "line": 134,
-      "complexity": 12,
-      "line_coverage": 96.42857142857143,
-      "crap": 12.006559766763848
+      "line": 156,
+      "complexity": 17,
+      "line_coverage": 97.5609756097561,
+      "crap": 17.004193206714934,
+      "fix_strategy": "decompose"
     },
     {
       "package": "complytime",
       "function": "FindPolicy",
       "file": "internal/complytime/config.go",
-      "line": 189,
+      "line": 239,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -1778,7 +1806,7 @@
       "package": "complytime",
       "function": "PolicyIDs",
       "file": "internal/complytime/config.go",
-      "line": 202,
+      "line": 252,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -1787,7 +1815,7 @@
       "package": "complytime",
       "function": "LoadFrom",
       "file": "internal/complytime/config.go",
-      "line": 212,
+      "line": 262,
       "complexity": 6,
       "line_coverage": 69.23076923076923,
       "crap": 7.048702776513427,
@@ -1799,7 +1827,7 @@
       "package": "complytime",
       "function": "validatePolicyRefs",
       "file": "internal/complytime/config.go",
-      "line": 248,
+      "line": 298,
       "complexity": 5,
       "line_coverage": 100,
       "crap": 5
@@ -1808,7 +1836,7 @@
       "package": "complytime",
       "function": "resolveEnvVars",
       "file": "internal/complytime/config.go",
-      "line": 265,
+      "line": 315,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -1817,7 +1845,7 @@
       "package": "complytime",
       "function": "resolveCollectorEnvVars",
       "file": "internal/complytime/config.go",
-      "line": 278,
+      "line": 328,
       "complexity": 5,
       "line_coverage": 100,
       "crap": 5
@@ -1826,7 +1854,7 @@
       "package": "complytime",
       "function": "expandEnvRef",
       "file": "internal/complytime/config.go",
-      "line": 300,
+      "line": 350,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -1835,7 +1863,7 @@
       "package": "complytime",
       "function": "SaveTo",
       "file": "internal/complytime/config.go",
-      "line": 317,
+      "line": 367,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12,
@@ -1847,7 +1875,7 @@
       "package": "complytime",
       "function": "Validate",
       "file": "internal/complytime/config.go",
-      "line": 331,
+      "line": 381,
       "complexity": 13,
       "line_coverage": 92.3076923076923,
       "crap": 13.076923076923077
@@ -1856,7 +1884,7 @@
       "package": "complytime",
       "function": "validateEntries",
       "file": "internal/complytime/config.go",
-      "line": 383,
+      "line": 433,
       "complexity": 6,
       "line_coverage": 100,
       "crap": 6
@@ -2107,8 +2135,8 @@
       "file": "internal/doctor/doctor.go",
       "line": 221,
       "complexity": 16,
-      "line_coverage": 95,
-      "crap": 16.032,
+      "line_coverage": 95.1219512195122,
+      "crap": 16.02971518114943,
       "contract_coverage": 100,
       "gaze_crap": 16,
       "quadrant": "Q4_Dangerous",
@@ -2118,7 +2146,7 @@
       "package": "doctor",
       "function": "resolvePinnedFallback",
       "file": "internal/doctor/doctor.go",
-      "line": 326,
+      "line": 327,
       "complexity": 5,
       "line_coverage": 100,
       "crap": 5
@@ -2127,7 +2155,7 @@
       "package": "doctor",
       "function": "CheckCache",
       "file": "internal/doctor/doctor.go",
-      "line": 368,
+      "line": 370,
       "complexity": 5,
       "line_coverage": 90.9090909090909,
       "crap": 5.018782870022539,
@@ -2139,10 +2167,10 @@
       "package": "doctor",
       "function": "CheckVariables",
       "file": "internal/doctor/doctor.go",
-      "line": 423,
+      "line": 425,
       "complexity": 35,
-      "line_coverage": 85.88235294117646,
-      "crap": 38.44685528190515,
+      "line_coverage": 93.4065934065934,
+      "crap": 35.35112816177905,
       "contract_coverage": 100,
       "gaze_crap": 35,
       "quadrant": "Q4_Dangerous",
@@ -2152,10 +2180,10 @@
       "package": "doctor",
       "function": "CheckPolicyActivePeriod",
       "file": "internal/doctor/doctor.go",
-      "line": 595,
+      "line": 623,
       "complexity": 12,
-      "line_coverage": 90,
-      "crap": 12.144,
+      "line_coverage": 93.54838709677419,
+      "crap": 12.03866939679769,
       "contract_coverage": 100,
       "gaze_crap": 12,
       "quadrant": "Q1_Safe"
@@ -2164,7 +2192,7 @@
       "package": "doctor",
       "function": "parseDatetime",
       "file": "internal/doctor/doctor.go",
-      "line": 671,
+      "line": 705,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -2173,7 +2201,7 @@
       "package": "doctor",
       "function": "evaluateTimeline",
       "file": "internal/doctor/doctor.go",
-      "line": 680,
+      "line": 714,
       "complexity": 7,
       "line_coverage": 86.66666666666667,
       "crap": 7.116148148148148
@@ -2182,7 +2210,7 @@
       "package": "doctor",
       "function": "countResolved",
       "file": "internal/doctor/doctor.go",
-      "line": 710,
+      "line": 744,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -2191,7 +2219,7 @@
       "package": "doctor",
       "function": "unmappedReason",
       "file": "internal/doctor/doctor.go",
-      "line": 720,
+      "line": 754,
       "complexity": 3,
       "line_coverage": 80,
       "crap": 3.072
@@ -2200,7 +2228,7 @@
       "package": "doctor",
       "function": "CheckCollector",
       "file": "internal/doctor/doctor.go",
-      "line": 733,
+      "line": 767,
       "complexity": 6,
       "line_coverage": 100,
       "crap": 6,
@@ -2212,10 +2240,10 @@
       "package": "doctor",
       "function": "CheckComplypacks",
       "file": "internal/doctor/doctor.go",
-      "line": 774,
+      "line": 808,
       "complexity": 13,
-      "line_coverage": 79.41176470588235,
-      "crap": 14.474837166700592,
+      "line_coverage": 82.85714285714286,
+      "crap": 13.85140524781341,
       "contract_coverage": 100,
       "gaze_crap": 13,
       "quadrant": "Q1_Safe"
@@ -2224,7 +2252,7 @@
       "package": "doctor",
       "function": "checkExportEnabled",
       "file": "internal/doctor/doctor.go",
-      "line": 848,
+      "line": 888,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -2233,7 +2261,7 @@
       "package": "doctor",
       "function": "checkCollectorAuth",
       "file": "internal/doctor/doctor.go",
-      "line": 874,
+      "line": 914,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -2242,7 +2270,7 @@
       "package": "doctor",
       "function": "effectiveGlobals",
       "file": "internal/doctor/doctor.go",
-      "line": 899,
+      "line": 939,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -2251,7 +2279,7 @@
       "package": "doctor",
       "function": "joinNames",
       "file": "internal/doctor/doctor.go",
-      "line": 908,
+      "line": 948,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -2563,7 +2591,7 @@
       "package": "policy",
       "function": "SaveGenerationState",
       "file": "internal/policy/generation_state.go",
-      "line": 29,
+      "line": 31,
       "complexity": 4,
       "line_coverage": 70,
       "crap": 4.432,
@@ -2575,7 +2603,7 @@
       "package": "policy",
       "function": "LoadGenerationState",
       "file": "internal/policy/generation_state.go",
-      "line": 49,
+      "line": 51,
       "complexity": 4,
       "line_coverage": 90,
       "crap": 4.016,
@@ -2587,19 +2615,28 @@
       "package": "policy",
       "function": "(*GenerationState).IsFresh",
       "file": "internal/policy/generation_state.go",
-      "line": 68,
-      "complexity": 1,
+      "line": 71,
+      "complexity": 2,
       "line_coverage": 100,
-      "crap": 1,
+      "crap": 2,
       "contract_coverage": 100,
-      "gaze_crap": 1,
+      "gaze_crap": 2,
       "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "policy",
+      "function": "normalizeNilMap",
+      "file": "internal/policy/generation_state.go",
+      "line": 78,
+      "complexity": 2,
+      "line_coverage": 100,
+      "crap": 2
     },
     {
       "package": "policy",
       "function": "NewGenerationState",
       "file": "internal/policy/generation_state.go",
-      "line": 73,
+      "line": 86,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1,
@@ -3767,11 +3804,11 @@
     }
   ],
   "summary": {
-    "total_functions": 388,
-    "avg_complexity": 3.5489690721649483,
-    "avg_line_coverage": 48.59530700313812,
-    "avg_crap": 10.036572652333856,
-    "crapload": 54,
+    "total_functions": 392,
+    "avg_complexity": 3.5510204081632653,
+    "avg_line_coverage": 49.163136736891275,
+    "avg_crap": 9.962279098160602,
+    "crapload": 55,
     "crap_threshold": 15,
     "gaze_crapload": 3,
     "gaze_crap_threshold": 15,
@@ -3785,7 +3822,7 @@
     },
     "fix_strategy_counts": {
       "add_tests": 51,
-      "decompose": 2,
+      "decompose": 3,
       "decompose_and_test": 1
     },
     "worst_crap": [
@@ -3798,6 +3835,16 @@
         "line_coverage": 0,
         "crap": 380,
         "fix_strategy": "decompose_and_test"
+      },
+      {
+        "package": "cli",
+        "function": "promptTargets",
+        "file": "cmd/complyctl/cli/init.go",
+        "line": 153,
+        "complexity": 10,
+        "line_coverage": 0,
+        "crap": 110,
+        "fix_strategy": "add_tests"
       },
       {
         "package": "terminal",
@@ -3820,16 +3867,6 @@
         "fix_strategy": "add_tests"
       },
       {
-        "package": "cli",
-        "function": "promptTargets",
-        "file": "cmd/complyctl/cli/init.go",
-        "line": 153,
-        "complexity": 10,
-        "line_coverage": 0,
-        "crap": 110,
-        "fix_strategy": "add_tests"
-      },
-      {
         "package": "main",
         "function": "main",
         "file": "cmd/behavioral-report/main.go",
@@ -3845,10 +3882,10 @@
         "package": "doctor",
         "function": "CheckVariables",
         "file": "internal/doctor/doctor.go",
-        "line": 423,
+        "line": 425,
         "complexity": 35,
-        "line_coverage": 85.88235294117646,
-        "crap": 38.44685528190515,
+        "line_coverage": 93.4065934065934,
+        "crap": 35.35112816177905,
         "contract_coverage": 100,
         "gaze_crap": 35,
         "quadrant": "Q4_Dangerous",
@@ -3872,8 +3909,8 @@
         "file": "internal/doctor/doctor.go",
         "line": 221,
         "complexity": 16,
-        "line_coverage": 95,
-        "crap": 16.032,
+        "line_coverage": 95.1219512195122,
+        "crap": 16.02971518114943,
         "contract_coverage": 100,
         "gaze_crap": 16,
         "quadrant": "Q4_Dangerous",
@@ -3907,15 +3944,6 @@
     ],
     "recommended_actions": [
       {
-        "function": "(*MockPolicySource).CopyPolicy",
-        "package": "cachetest",
-        "file": "internal/cache/cachetest/mock_source.go",
-        "line": 73,
-        "fix_strategy": "add_tests",
-        "crap": 110,
-        "complexity": 10
-      },
-      {
         "function": "ShowPlainTable",
         "package": "terminal",
         "file": "internal/terminal/table.go",
@@ -3934,6 +3962,15 @@
         "complexity": 10
       },
       {
+        "function": "(*MockPolicySource).CopyPolicy",
+        "package": "cachetest",
+        "file": "internal/cache/cachetest/mock_source.go",
+        "line": 73,
+        "fix_strategy": "add_tests",
+        "crap": 110,
+        "complexity": 10
+      },
+      {
         "function": "main",
         "package": "main",
         "file": "cmd/behavioral-report/main.go",
@@ -3941,15 +3978,6 @@
         "fix_strategy": "add_tests",
         "crap": 90,
         "complexity": 9
-      },
-      {
-        "function": "CheckProviders",
-        "package": "doctor",
-        "file": "internal/doctor/doctor.go",
-        "line": 136,
-        "fix_strategy": "add_tests",
-        "crap": 72,
-        "complexity": 8
       },
       {
         "function": "DigestRecordedInState",
@@ -3961,28 +3989,19 @@
         "complexity": 8
       },
       {
-        "function": "PluginBinaryIntegrityCheck",
-        "package": "behavioral",
-        "file": "tests/behavioral/plugin_security.go",
-        "line": 67,
+        "function": "CheckProviders",
+        "package": "doctor",
+        "file": "internal/doctor/doctor.go",
+        "line": 136,
         "fix_strategy": "add_tests",
-        "crap": 56,
-        "complexity": 7
+        "crap": 72,
+        "complexity": 8
       },
       {
-        "function": "InstallTestPlugin",
-        "package": "behavioral",
-        "file": "tests/behavioral/reusable_steps.go",
-        "line": 57,
-        "fix_strategy": "add_tests",
-        "crap": 56,
-        "complexity": 7
-      },
-      {
-        "function": "OSCALResultProduced",
-        "package": "behavioral",
-        "file": "tests/behavioral/audit.go",
-        "line": 48,
+        "function": "(*Cache).ListPolicies",
+        "package": "cache",
+        "file": "internal/cache/cache.go",
+        "line": 50,
         "fix_strategy": "add_tests",
         "crap": 56,
         "complexity": 7
@@ -3997,10 +4016,28 @@
         "complexity": 7
       },
       {
-        "function": "(*Cache).ListPolicies",
-        "package": "cache",
-        "file": "internal/cache/cache.go",
-        "line": 50,
+        "function": "InstallTestPlugin",
+        "package": "behavioral",
+        "file": "tests/behavioral/reusable_steps.go",
+        "line": 57,
+        "fix_strategy": "add_tests",
+        "crap": 56,
+        "complexity": 7
+      },
+      {
+        "function": "PluginBinaryIntegrityCheck",
+        "package": "behavioral",
+        "file": "tests/behavioral/plugin_security.go",
+        "line": 67,
+        "fix_strategy": "add_tests",
+        "crap": 56,
+        "complexity": 7
+      },
+      {
+        "function": "OSCALResultProduced",
+        "package": "behavioral",
+        "file": "tests/behavioral/audit.go",
+        "line": 48,
         "fix_strategy": "add_tests",
         "crap": 56,
         "complexity": 7
@@ -4015,19 +4052,19 @@
         "complexity": 6
       },
       {
-        "function": "(*Client).fetchVersion",
-        "package": "registry",
-        "file": "internal/registry/client.go",
-        "line": 118,
+        "function": "HTTPSchemeRejected",
+        "package": "behavioral",
+        "file": "tests/behavioral/transport_security.go",
+        "line": 17,
         "fix_strategy": "add_tests",
         "crap": 42,
         "complexity": 6
       },
       {
-        "function": "HTTPSchemeRejected",
-        "package": "behavioral",
-        "file": "tests/behavioral/transport_security.go",
-        "line": 17,
+        "function": "(*Client).fetchVersion",
+        "package": "registry",
+        "file": "internal/registry/client.go",
+        "line": 118,
         "fix_strategy": "add_tests",
         "crap": 42,
         "complexity": 6
@@ -4051,28 +4088,19 @@
         "complexity": 6
       },
       {
-        "function": "findFile",
+        "function": "UnsetEnvVarFails",
         "package": "behavioral",
-        "file": "tests/behavioral/audit.go",
-        "line": 76,
+        "file": "tests/behavioral/credential_protection.go",
+        "line": 17,
         "fix_strategy": "add_tests",
         "crap": 30,
         "complexity": 5
       },
       {
-        "function": "EvaluatorMismatchRejected",
-        "package": "behavioral",
-        "file": "tests/behavioral/plugin_security.go",
-        "line": 36,
-        "fix_strategy": "add_tests",
-        "crap": 30,
-        "complexity": 5
-      },
-      {
-        "function": "HTTPSSchemeNoPlainHTTP",
-        "package": "behavioral",
-        "file": "tests/behavioral/transport_security.go",
-        "line": 48,
+        "function": "internalConfidenceToProto",
+        "package": "provider",
+        "file": "pkg/provider/server.go",
+        "line": 148,
         "fix_strategy": "add_tests",
         "crap": 30,
         "complexity": 5
@@ -4082,6 +4110,15 @@
         "package": "behavioral",
         "file": "tests/behavioral/log_security.go",
         "line": 16,
+        "fix_strategy": "add_tests",
+        "crap": 30,
+        "complexity": 5
+      },
+      {
+        "function": "EnvVarResolution",
+        "package": "behavioral",
+        "file": "tests/behavioral/credential_protection.go",
+        "line": 54,
         "fix_strategy": "add_tests",
         "crap": 30,
         "complexity": 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,15 @@
   `test-k8s-deployment` target in workspace configuration. OPA command
   reference added to `docs/TESTING_ENVIRONMENT.md`.
 
+### Deprecated
+
+- The `@version` notation for policy URLs (e.g., `registry.com/repo@v1.0`)
+  is deprecated. Use standard OCI `:tag` syntax instead (e.g.,
+  `registry.com/repo:v1.0`). In the OCI Distribution Spec, `@` is
+  exclusively a digest separator. A deprecation warning is now emitted
+  when `@version` syntax is detected. `@version` support will be removed
+  in a future release. (#600)
+
 ### Changed
 
 - All commands now accept `--workspace` flag to specify workspace directory
@@ -61,6 +70,11 @@
   (`@sha256:...`) are also supported. Invalid OCI references in
   `complytime.yaml` are now detected at config load time with clear
   error messages. (#594)
+- `complyctl doctor` now reports invalid policy references in
+  `CheckPolicyActivePeriod` and `CheckComplypacks` as explicit
+  failures instead of silently skipping them. `CheckVariables`
+  now surfaces per-policy resolution errors with specific messages
+  instead of a silent counter. (#600)
 - Scan reports now resolve assessment plan IDs to requirement IDs,
   ensuring output displays meaningful identifiers instead of internal
   plan references. Affects EvaluationLog, OSCAL, SARIF, and Markdown

--- a/cmd/complyctl/cli/get.go
+++ b/cmd/complyctl/cli/get.go
@@ -155,7 +155,7 @@ func syncSinglePolicy(ctx context.Context, cacheMgr *cache.Cache, state *cache.S
 	if err != nil {
 		return fmt.Errorf("invalid policy reference %q: %w", entry.URL, err)
 	}
-	version := ref.Version
+	version := ref.VersionString()
 
 	client := registry.NewClient(ref.Registry, credFunc)
 	source := cache.NewRegistrySource(client)
@@ -209,7 +209,7 @@ func syncSingleComplypack(ctx context.Context, state *cache.State, credFunc auth
 	if err != nil {
 		return fmt.Errorf("invalid complypack reference %q: %w", entry.URL, err)
 	}
-	version := ref.Version
+	version := ref.VersionString()
 
 	client := registry.NewClient(ref.Registry, credFunc)
 	source := cache.NewRegistryComplypackSource(client)

--- a/cmd/complyctl/cli/scan.go
+++ b/cmd/complyctl/cli/scan.go
@@ -320,7 +320,7 @@ func resolveVersionAndGraph(cacheDir string, ref complytime.PolicyRef) (string, 
 	loader := policy.NewLoader(cacheMgr)
 	resolver := policy.NewResolver(loader)
 
-	version, err := loader.ResolveVersion(ref.Repository, ref.Version)
+	version, err := loader.ResolveVersion(ref.Repository, ref.VersionString())
 	if err != nil {
 		return "", nil, err
 	}

--- a/internal/cache/complypack_sync.go
+++ b/internal/cache/complypack_sync.go
@@ -44,7 +44,8 @@ func (s *ComplypackSync) SyncComplypack(ctx context.Context, repository, version
 		return false, fmt.Errorf("complypack repository cannot be empty")
 	}
 
-	lookupRef := BuildLookupRef(repository, version)
+	tag, digest := classifyVersion(version)
+	lookupRef := BuildLookupRef(repository, tag, digest)
 
 	remoteDigest, remoteVersion, err := s.source.DefinitionVersion(ctx, lookupRef)
 	if err != nil {

--- a/internal/cache/sync.go
+++ b/internal/cache/sync.go
@@ -6,23 +6,37 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
+
+	"github.com/opencontainers/go-digest"
 
 	"github.com/complytime/complyctl/internal/registry"
 )
 
-// BuildLookupRef constructs an OCI lookup reference from a repository and
-// version string. For digest versions (sha256:, sha512:) it uses "@" as
-// the separator; for tag versions it uses ":". If the version is empty or
-// "latest", the bare repository is returned so oras resolves the default tag.
-func BuildLookupRef(repository, version string) string {
-	if version == "" || version == "latest" {
+// BuildLookupRef constructs an OCI lookup reference from a repository with
+// separate tag and digest fields. When digest is non-empty it uses "@" as
+// the separator; when tag is non-empty (and not "latest") it uses ":".
+// If both are empty or tag is "latest", the bare repository is returned so
+// oras resolves the default tag.
+func BuildLookupRef(repository, tag, digest string) string {
+	if digest != "" {
+		return repository + "@" + digest
+	}
+	if tag == "" || tag == "latest" {
 		return repository
 	}
-	if strings.HasPrefix(version, "sha256:") || strings.HasPrefix(version, "sha512:") {
-		return repository + "@" + version
+	return repository + ":" + tag
+}
+
+// classifyVersion splits a version string into tag and digest components.
+// It delegates to go-digest's Parse to determine whether the string is a
+// valid OCI digest (sha256, sha384, sha512). This is a convenience for
+// callers that receive an untyped version string and need to call
+// BuildLookupRef.
+func classifyVersion(version string) (tag string, dgst string) {
+	if _, err := digest.Parse(version); err == nil {
+		return "", version
 	}
-	return repository + ":" + version
+	return version, ""
 }
 
 // Sync provides incremental sync using oras.Copy() for remote-to-local transfer.
@@ -48,7 +62,8 @@ func (s *Sync) SyncPolicy(ctx context.Context, policyID, version string) error {
 		return fmt.Errorf("policy ID cannot be empty")
 	}
 
-	lookupRef := BuildLookupRef(policyID, version)
+	tag, digest := classifyVersion(version)
+	lookupRef := BuildLookupRef(policyID, tag, digest)
 
 	remoteDigest, remoteVersion, err := s.source.DefinitionVersion(ctx, lookupRef)
 	if err != nil {

--- a/internal/cache/sync_test.go
+++ b/internal/cache/sync_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -246,21 +247,64 @@ func TestBuildLookupRef(t *testing.T) {
 	tests := []struct {
 		name       string
 		repository string
-		version    string
+		tag        string
+		digest     string
 		want       string
 	}{
-		{"tag version", "org/policy", "v1.0", "org/policy:v1.0"},
-		{"sha256 digest", "org/policy", "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", "org/policy@sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"},
-		{"sha512 digest", "org/policy", "sha512:def456", "org/policy@sha512:def456"},
-		{"empty version", "org/policy", "", "org/policy"},
-		{"latest version", "org/policy", "latest", "org/policy"},
+		{"tag version", "org/policy", "v1.0", "", "org/policy:v1.0"},
+		{"sha256 digest", "org/policy", "", "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", "org/policy@sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"},
+		{"sha512 digest", "org/policy", "", "sha512:def456", "org/policy@sha512:def456"},
+		{"empty version", "org/policy", "", "", "org/policy"},
+		{"latest version", "org/policy", "latest", "", "org/policy"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := cache.BuildLookupRef(tt.repository, tt.version)
+			got := cache.BuildLookupRef(tt.repository, tt.tag, tt.digest)
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestBuildLookupRef_DigestPrecedence verifies that when both tag and
+// digest are provided, digest takes precedence (OCI convention).
+func TestBuildLookupRef_DigestPrecedence(t *testing.T) {
+	got := cache.BuildLookupRef("org/policy", "v1.0", "sha256:abc123")
+	assert.Equal(t, "org/policy@sha256:abc123", got)
+}
+
+// TestBuildLookupRef_SHA384Digest verifies sha384 digests are handled
+// correctly through the typed fields.
+func TestBuildLookupRef_SHA384Digest(t *testing.T) {
+	sha384Digest := "sha384:" + "a" + strings.Repeat("b", 95)
+	got := cache.BuildLookupRef("org/policy", "", sha384Digest)
+	assert.Equal(t, "org/policy@"+sha384Digest, got)
+}
+
+// TestSync_SHA384Digest verifies that a sha384 digest version string is
+// correctly classified and used as a digest (not a tag) in the sync path.
+func TestSync_SHA384Digest(t *testing.T) {
+	tmpDir := t.TempDir()
+	cacheDir := filepath.Join(tmpDir, "cache")
+	require.NoError(t, os.MkdirAll(cacheDir, 0755))
+
+	sha384Digest := "sha384:" + "a" + strings.Repeat("b", 95)
+	mock := cachetest.NewMockPolicySource()
+	mock.SeedPolicy("test-policy", "v1.0.0", "sha256:abc123")
+
+	cacheMgr := cache.NewCache(cacheDir)
+	state, err := cache.LoadState(cacheDir)
+	require.NoError(t, err)
+
+	sync := cache.NewSync(cacheMgr, state, mock)
+
+	// Pass a sha384 digest as the version string. classifyVersion must
+	// detect it as a digest and BuildLookupRef must use "@" separator.
+	_ = sync.SyncPolicy(context.Background(), "test-policy", sha384Digest)
+
+	assert.Contains(t, mock.LastLookupRef, "@"+sha384Digest,
+		"sha384 digest must use @ separator, not : separator")
+	assert.NotContains(t, mock.LastLookupRef, ":"+sha384Digest,
+		"sha384 digest must not be treated as a tag")
 }
 
 // TestBuildLookupRef_Regression_NoDoubleTag verifies that the original
@@ -268,9 +312,9 @@ func TestBuildLookupRef(t *testing.T) {
 // produce a double-tagged reference like "repo:v0.4.0:v0.4.0".
 func TestBuildLookupRef_Regression_NoDoubleTag(t *testing.T) {
 	// When ParsePolicyRef correctly extracts the tag, Repository
-	// will be "complytime/complypack-ampel-bp" and Version "v0.4.0".
+	// will be "complytime/complypack-ampel-bp" and Tag "v0.4.0".
 	// BuildLookupRef should produce a single-tagged reference.
-	lookupRef := cache.BuildLookupRef("complytime/complypack-ampel-bp", "v0.4.0")
+	lookupRef := cache.BuildLookupRef("complytime/complypack-ampel-bp", "v0.4.0", "")
 	assert.Equal(t, "complytime/complypack-ampel-bp:v0.4.0", lookupRef)
 	assert.NotContains(t, lookupRef, ":v0.4.0:v0.4.0")
 }

--- a/internal/complytime/config.go
+++ b/internal/complytime/config.go
@@ -7,8 +7,10 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/goccy/go-yaml"
+	godigest "github.com/opencontainers/go-digest"
 	orasreg "oras.land/oras-go/v2/registry"
 )
 
@@ -17,6 +19,13 @@ var envVarPattern = regexp.MustCompile(`\$\{([^}]+)\}`)
 // unsafeRefChars matches characters that should never appear in an OCI reference
 // and are commonly used for shell injection.
 var unsafeRefChars = regexp.MustCompile("[;|&$`!><(){}\\[\\]\\\\]")
+
+// deprecationWarned tracks which @version URLs have already emitted a
+// deprecation warning to avoid duplicating the message across callers.
+var (
+	deprecationWarned   = make(map[string]bool)
+	deprecationWarnedMu sync.Mutex
+)
 
 // ValidateOCIRef checks that raw looks like a valid OCI reference
 // (registry/repository with optional :tag or @version). It rejects empty
@@ -114,11 +123,24 @@ type PolicyRef struct {
 	// "policies/nist-800-53-r5"). For bare policy IDs, this is the
 	// identifier itself.
 	Repository string
-	// Version is the tag, digest, or empty string. For :tag and @version
-	// inputs it holds the version string (e.g., "v1.0"). For digest inputs
-	// it holds the full algorithm:hex string (e.g., "sha256:9f86d...").
-	// Empty when no version or tag was specified.
-	Version string
+	// Tag is the tag portion of the reference (e.g., "v1.0", "latest").
+	// Populated when the reference uses :tag or @version (complytime
+	// convention) syntax. Empty when a digest or no version was specified.
+	Tag string
+	// Digest is the digest portion of the reference (e.g.,
+	// "sha256:9f86d..."). Populated when the reference uses @algorithm:hex
+	// syntax. Empty when a tag or no version was specified.
+	Digest string
+}
+
+// VersionString returns the tag if non-empty, otherwise the digest.
+// Intended for APIs that accept an untyped version string (e.g.,
+// ResolveVersion). Returns an empty string when neither is set.
+func (r PolicyRef) VersionString() string {
+	if r.Tag != "" {
+		return r.Tag
+	}
+	return r.Digest
 }
 
 // ParsePolicyRef parses a full OCI reference into its components.
@@ -151,10 +173,17 @@ func ParsePolicyRef(raw string) (PolicyRef, error) {
 
 	// Bare policy IDs (no slash) are convention-based identifiers, not OCI
 	// references. Handle them directly: extract an optional @version suffix
-	// and treat the rest as the repository.
+	// and treat the rest as the repository. Classify the suffix as a digest
+	// when it matches the OCI digest format (sha256:, sha384:, sha512:);
+	// otherwise treat it as a tag (complytime convention for pinning).
 	if !strings.Contains(s, "/") {
 		if idx := strings.LastIndex(s, "@"); idx > 0 && idx < len(s)-1 {
-			ref.Version = s[idx+1:]
+			suffix := s[idx+1:]
+			if _, digestErr := godigest.Parse(suffix); digestErr == nil {
+				ref.Digest = suffix
+			} else {
+				ref.Tag = suffix
+			}
 			s = s[:idx]
 		}
 		ref.Repository = s
@@ -168,6 +197,17 @@ func ParsePolicyRef(raw string) (PolicyRef, error) {
 		suffix := s[idx+1:]
 		if !strings.HasPrefix(suffix, "sha256:") && !strings.HasPrefix(suffix, "sha512:") {
 			// Non-digest @version — convert to :tag for oras-go.
+			deprecationWarnedMu.Lock()
+			warned := deprecationWarned[raw]
+			if !warned {
+				deprecationWarned[raw] = true
+			}
+			deprecationWarnedMu.Unlock()
+			if !warned {
+				fmt.Fprintf(os.Stderr, "DEPRECATED: @version notation in policy URL %q. "+
+					"Use \":tag\" syntax instead (e.g., \"registry.com/repo:v1.0\"). "+
+					"@version support will be removed in a future release.\n", raw)
+			}
 			s = s[:idx] + ":" + suffix
 		}
 	}
@@ -180,7 +220,17 @@ func ParsePolicyRef(raw string) (PolicyRef, error) {
 
 	ref.Registry = scheme + orasRef.Registry
 	ref.Repository = orasRef.Repository
-	ref.Version = orasRef.Reference
+
+	// Classify the reference as tag or digest. oras-go's Digest() method
+	// returns a parsed digest when the reference is a valid digest string;
+	// otherwise it is a tag.
+	if orasRef.Reference != "" {
+		if _, digestErr := orasRef.Digest(); digestErr == nil {
+			ref.Digest = orasRef.Reference
+		} else {
+			ref.Tag = orasRef.Reference
+		}
+	}
 
 	return ref, nil
 }

--- a/internal/complytime/config_test.go
+++ b/internal/complytime/config_test.go
@@ -3,6 +3,7 @@
 package complytime_test
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,7 +19,8 @@ func TestParsePolicyRef_FullReference(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "registry.com", ref.Registry)
 	assert.Equal(t, "policies/nist-800-53-r5", ref.Repository)
-	assert.Equal(t, "v1.2.3", ref.Version)
+	assert.Equal(t, "v1.2.3", ref.Tag)
+	assert.Empty(t, ref.Digest)
 }
 
 func TestParsePolicyRef_NoVersion(t *testing.T) {
@@ -26,7 +28,8 @@ func TestParsePolicyRef_NoVersion(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "registry.com", ref.Registry)
 	assert.Equal(t, "policies/nist-800-53-r5", ref.Repository)
-	assert.Empty(t, ref.Version)
+	assert.Empty(t, ref.Tag)
+	assert.Empty(t, ref.Digest)
 }
 
 func TestParsePolicyRef_WithHTTPScheme(t *testing.T) {
@@ -34,7 +37,8 @@ func TestParsePolicyRef_WithHTTPScheme(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "http://localhost:5000", ref.Registry)
 	assert.Equal(t, "policies/test", ref.Repository)
-	assert.Equal(t, "v1.0", ref.Version)
+	assert.Equal(t, "v1.0", ref.Tag)
+	assert.Empty(t, ref.Digest)
 }
 
 func TestParsePolicyRef_WithHTTPSScheme(t *testing.T) {
@@ -42,7 +46,8 @@ func TestParsePolicyRef_WithHTTPSScheme(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "https://ghcr.io", ref.Registry)
 	assert.Equal(t, "org/policy", ref.Repository)
-	assert.Equal(t, "latest", ref.Version)
+	assert.Equal(t, "latest", ref.Tag)
+	assert.Empty(t, ref.Digest)
 }
 
 func TestParsePolicyRef_NoRegistry(t *testing.T) {
@@ -50,7 +55,8 @@ func TestParsePolicyRef_NoRegistry(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, ref.Registry)
 	assert.Equal(t, "nist-800-53-r5", ref.Repository)
-	assert.Equal(t, "v1.0", ref.Version)
+	assert.Equal(t, "v1.0", ref.Tag)
+	assert.Empty(t, ref.Digest)
 }
 
 func TestParsePolicyRef_BareID(t *testing.T) {
@@ -58,7 +64,18 @@ func TestParsePolicyRef_BareID(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, ref.Registry)
 	assert.Equal(t, "nist-800-53-r5", ref.Repository)
-	assert.Empty(t, ref.Version)
+	assert.Empty(t, ref.Tag)
+	assert.Empty(t, ref.Digest)
+}
+
+func TestParsePolicyRef_BareIDWithDigest(t *testing.T) {
+	dgst := "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+	ref, err := complytime.ParsePolicyRef("my-policy@" + dgst)
+	require.NoError(t, err)
+	assert.Empty(t, ref.Registry)
+	assert.Equal(t, "my-policy", ref.Repository)
+	assert.Empty(t, ref.Tag)
+	assert.Equal(t, dgst, ref.Digest)
 }
 
 func TestParsePolicyRef_PortInRegistry(t *testing.T) {
@@ -66,7 +83,8 @@ func TestParsePolicyRef_PortInRegistry(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "localhost:5000", ref.Registry)
 	assert.Equal(t, "policy", ref.Repository)
-	assert.Equal(t, "v2", ref.Version)
+	assert.Equal(t, "v2", ref.Tag)
+	assert.Empty(t, ref.Digest)
 }
 
 func TestParsePolicyRef_ColonTag(t *testing.T) {
@@ -74,7 +92,8 @@ func TestParsePolicyRef_ColonTag(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "quay.io", ref.Registry)
 	assert.Equal(t, "complytime/complypack-ampel-bp", ref.Repository)
-	assert.Equal(t, "v0.4.0", ref.Version)
+	assert.Equal(t, "v0.4.0", ref.Tag)
+	assert.Empty(t, ref.Digest)
 }
 
 func TestParsePolicyRef_ColonLatest(t *testing.T) {
@@ -82,16 +101,18 @@ func TestParsePolicyRef_ColonLatest(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "quay.io", ref.Registry)
 	assert.Equal(t, "complytime/complypack-ampel-bp", ref.Repository)
-	assert.Equal(t, "latest", ref.Version)
+	assert.Equal(t, "latest", ref.Tag)
+	assert.Empty(t, ref.Digest)
 }
 
 func TestParsePolicyRef_Digest(t *testing.T) {
-	digest := "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
-	ref, err := complytime.ParsePolicyRef("quay.io/complytime/complypack-ampel-bp@" + digest)
+	dgst := "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+	ref, err := complytime.ParsePolicyRef("quay.io/complytime/complypack-ampel-bp@" + dgst)
 	require.NoError(t, err)
 	assert.Equal(t, "quay.io", ref.Registry)
 	assert.Equal(t, "complytime/complypack-ampel-bp", ref.Repository)
-	assert.Equal(t, digest, ref.Version)
+	assert.Empty(t, ref.Tag)
+	assert.Equal(t, dgst, ref.Digest)
 }
 
 func TestParsePolicyRef_HTTPSchemeWithColonTag(t *testing.T) {
@@ -99,7 +120,23 @@ func TestParsePolicyRef_HTTPSchemeWithColonTag(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "http://localhost:5000", ref.Registry)
 	assert.Equal(t, "policies/test", ref.Repository)
-	assert.Equal(t, "v1.0", ref.Version)
+	assert.Equal(t, "v1.0", ref.Tag)
+	assert.Empty(t, ref.Digest)
+}
+
+func TestPolicyRef_VersionString_Tag(t *testing.T) {
+	ref := complytime.PolicyRef{Tag: "v1.0"}
+	assert.Equal(t, "v1.0", ref.VersionString())
+}
+
+func TestPolicyRef_VersionString_Digest(t *testing.T) {
+	ref := complytime.PolicyRef{Digest: "sha256:abc123"}
+	assert.Equal(t, "sha256:abc123", ref.VersionString())
+}
+
+func TestPolicyRef_VersionString_Empty(t *testing.T) {
+	ref := complytime.PolicyRef{}
+	assert.Empty(t, ref.VersionString())
 }
 
 func TestParsePolicyRef_ErrorOnEmpty(t *testing.T) {
@@ -112,6 +149,73 @@ func TestParsePolicyRef_ErrorOnWhitespace(t *testing.T) {
 	_, err := complytime.ParsePolicyRef("   ")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot be empty")
+}
+
+func TestParsePolicyRef_DeprecationWarning_AtVersion(t *testing.T) {
+	// Reset deduplication state so the warning fires for this test URL.
+	complytime.ResetDeprecationWarnings()
+
+	// Capture stderr to verify the deprecation warning.
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+	defer func() { os.Stderr = origStderr }()
+
+	ref, parseErr := complytime.ParsePolicyRef("registry.example.com/policies/nist@v1.0")
+
+	w.Close()
+	output, readErr := io.ReadAll(r)
+	r.Close()
+	require.NoError(t, readErr)
+
+	require.NoError(t, parseErr)
+	assert.Equal(t, "v1.0", ref.Tag)
+	assert.Empty(t, ref.Digest)
+	assert.Contains(t, string(output), "DEPRECATED")
+	assert.Contains(t, string(output), "registry.example.com/policies/nist@v1.0")
+	assert.Contains(t, string(output), ":tag")
+}
+
+func TestParsePolicyRef_NoDeprecationWarning_Digest(t *testing.T) {
+	dgst := "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+	defer func() { os.Stderr = origStderr }()
+
+	ref, parseErr := complytime.ParsePolicyRef("registry.example.com/policies/nist@" + dgst)
+
+	w.Close()
+	output, readErr := io.ReadAll(r)
+	r.Close()
+	require.NoError(t, readErr)
+
+	require.NoError(t, parseErr)
+	assert.Equal(t, dgst, ref.Digest)
+	assert.Empty(t, ref.Tag)
+	assert.Empty(t, string(output), "no deprecation warning expected for digest reference")
+}
+
+func TestParsePolicyRef_NoDeprecationWarning_BareID(t *testing.T) {
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+	defer func() { os.Stderr = origStderr }()
+
+	ref, parseErr := complytime.ParsePolicyRef("my-policy@v2.0")
+
+	w.Close()
+	output, readErr := io.ReadAll(r)
+	r.Close()
+	require.NoError(t, readErr)
+
+	require.NoError(t, parseErr)
+	assert.Equal(t, "v2.0", ref.Tag)
+	assert.Empty(t, ref.Digest)
+	assert.Empty(t, string(output), "no deprecation warning expected for bare policy ID")
 }
 
 func TestPolicyEntry_EffectiveID_ExplicitID(t *testing.T) {

--- a/internal/complytime/export_test.go
+++ b/internal/complytime/export_test.go
@@ -4,3 +4,11 @@ package complytime
 
 // ResolveEnvVars is exported for testing.
 var ResolveEnvVars = resolveEnvVars
+
+// ResetDeprecationWarnings clears the deduplication state so tests can
+// verify warning output without interference from earlier calls.
+func ResetDeprecationWarnings() {
+	deprecationWarnedMu.Lock()
+	deprecationWarned = make(map[string]bool)
+	deprecationWarnedMu.Unlock()
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -280,8 +280,9 @@ func CheckPolicyVersions(cfg *complytime.WorkspaceConfig, cacheDir string, versi
 
 		cachedVersion := cachedState.Version
 
-		if ref.Version != "" {
-			if cachedVersion == ref.Version {
+		pinnedVersion := ref.VersionString()
+		if pinnedVersion != "" {
+			if cachedVersion == pinnedVersion {
 				msg := fmt.Sprintf("%s (pinned)", cachedVersion)
 				if latestVersion != cachedVersion {
 					msg = fmt.Sprintf("%s (pinned — latest available: %s)", cachedVersion, latestVersion)
@@ -296,7 +297,7 @@ func CheckPolicyVersions(cfg *complytime.WorkspaceConfig, cacheDir string, versi
 				results = append(results, CheckResult{
 					Name:     fmt.Sprintf("policy/%s", eid),
 					Status:   StatusWarn,
-					Message:  fmt.Sprintf("cached %s does not match configured pin @%s — run complyctl get", cachedVersion, ref.Version),
+					Message:  fmt.Sprintf("cached %s does not match configured pin @%s — run complyctl get", cachedVersion, pinnedVersion),
 					Blocking: false,
 				})
 			}
@@ -329,8 +330,9 @@ func resolvePinnedFallback(
 	eid, cachedVersion string,
 	latestErr error,
 ) CheckResult {
-	if ref.Version != "" {
-		_, pinnedErr := resolver.ResolveVersion(ref.Registry, ref.Repository, ref.Version)
+	pinnedVersion := ref.VersionString()
+	if pinnedVersion != "" {
+		_, pinnedErr := resolver.ResolveVersion(ref.Registry, ref.Repository, pinnedVersion)
 		if pinnedErr == nil {
 			return CheckResult{
 				Name:     fmt.Sprintf("policy/%s", eid),
@@ -343,8 +345,8 @@ func resolvePinnedFallback(
 
 	if errors.Is(latestErr, registry.ErrVersionNotFound) {
 		msg := "latest tag not found — pin a specific version with @<tag>"
-		if ref.Version != "" {
-			msg = fmt.Sprintf("version %q not found in registry", ref.Version)
+		if pinnedVersion != "" {
+			msg = fmt.Sprintf("version %q not found in registry", pinnedVersion)
 		}
 		return CheckResult{
 			Name:     fmt.Sprintf("policy/%s", eid),
@@ -436,27 +438,52 @@ func CheckVariables(cfg *complytime.WorkspaceConfig, healthData []ProviderHealth
 
 	evaluatorTargets := make(map[string][]complytime.TargetConfig)
 	resolveFailures := 0
+	var resolveResults []CheckResult
 	if resolver != nil {
 		for _, target := range cfg.Targets {
 			for _, pid := range target.Policies {
 				entry, found := complytime.FindPolicy(cfg.Policies, pid)
 				if !found {
 					resolveFailures++
+					resolveResults = append(resolveResults, CheckResult{
+						Name:     fmt.Sprintf("variables/resolve/%s", pid),
+						Status:   StatusWarn,
+						Message:  fmt.Sprintf("policy %q referenced by target %q not found in config", pid, target.ID),
+						Blocking: false,
+					})
 					continue
 				}
 				ref, refErr := complytime.ParsePolicyRef(entry.URL)
 				if refErr != nil {
 					resolveFailures++
+					resolveResults = append(resolveResults, CheckResult{
+						Name:     fmt.Sprintf("variables/resolve/%s", entry.EffectiveID()),
+						Status:   StatusWarn,
+						Message:  fmt.Sprintf("invalid policy reference for %q: %v", entry.EffectiveID(), refErr),
+						Blocking: false,
+					})
 					continue
 				}
-				version, err := resolver.ResolveVersion(ref.Repository, ref.Version)
+				version, err := resolver.ResolveVersion(ref.Repository, ref.VersionString())
 				if err != nil {
 					resolveFailures++
+					resolveResults = append(resolveResults, CheckResult{
+						Name:     fmt.Sprintf("variables/resolve/%s", entry.EffectiveID()),
+						Status:   StatusWarn,
+						Message:  fmt.Sprintf("cannot resolve version for policy %q: %v", entry.EffectiveID(), err),
+						Blocking: false,
+					})
 					continue
 				}
 				graph, err := resolver.ResolvePolicyGraph(ref.Repository, version)
 				if err != nil {
 					resolveFailures++
+					resolveResults = append(resolveResults, CheckResult{
+						Name:     fmt.Sprintf("variables/resolve/%s", entry.EffectiveID()),
+						Status:   StatusWarn,
+						Message:  fmt.Sprintf("cannot resolve policy graph for %q: %v", entry.EffectiveID(), err),
+						Blocking: false,
+					})
 					continue
 				}
 				configs := policy.ExtractAssessmentConfigs(ref.Repository, graph)
@@ -471,6 +498,7 @@ func CheckVariables(cfg *complytime.WorkspaceConfig, healthData []ProviderHealth
 	effectiveGlobalVars := effectiveGlobals(cfg.Variables)
 
 	var results []CheckResult
+	results = append(results, resolveResults...)
 
 	for _, ph := range healthData {
 		globalResolved, globalTotal := countResolved(ph.RequiredGlobalVariables, effectiveGlobalVars)
@@ -603,11 +631,17 @@ func CheckPolicyActivePeriod(cfg *complytime.WorkspaceConfig, resolver PolicyGra
 	for _, p := range cfg.Policies {
 		ref, refErr := complytime.ParsePolicyRef(p.URL)
 		if refErr != nil {
+			results = append(results, CheckResult{
+				Name:     fmt.Sprintf("policy/%s/active-period", p.EffectiveID()),
+				Status:   StatusFail,
+				Message:  fmt.Sprintf("invalid policy reference: %v", refErr),
+				Blocking: true,
+			})
 			continue
 		}
 		eid := p.EffectiveID()
 
-		version, err := resolver.ResolveVersion(ref.Repository, ref.Version)
+		version, err := resolver.ResolveVersion(ref.Repository, ref.VersionString())
 		if err != nil {
 			continue
 		}
@@ -785,12 +819,19 @@ func CheckComplypacks(cfg *complytime.WorkspaceConfig, cacheDir string, resolver
 	// Collect unique evaluator-ids from all policies via the dependency graph,
 	// following the same resolution pattern as CheckVariables.
 	evaluatorIDs := make(map[string]bool)
+	var results []CheckResult
 	for _, p := range cfg.Policies {
 		ref, refErr := complytime.ParsePolicyRef(p.URL)
 		if refErr != nil {
+			results = append(results, CheckResult{
+				Name:     fmt.Sprintf("complypacks/%s", p.EffectiveID()),
+				Status:   StatusFail,
+				Message:  fmt.Sprintf("invalid policy reference: %v", refErr),
+				Blocking: true,
+			})
 			continue
 		}
-		version, err := resolver.ResolveVersion(ref.Repository, ref.Version)
+		version, err := resolver.ResolveVersion(ref.Repository, ref.VersionString())
 		if err != nil {
 			continue
 		}
@@ -805,7 +846,6 @@ func CheckComplypacks(cfg *complytime.WorkspaceConfig, cacheDir string, resolver
 		}
 	}
 
-	var results []CheckResult
 	allPresent := true
 	for evalID := range evaluatorIDs {
 		contentPath, _, err := cpCache.LookupByEvaluatorID(evalID)

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -753,17 +753,32 @@ func TestCheckVariables_UnmappedTargetVars_ResolverFails(t *testing.T) {
 	resolver := newMockPolicyGraphResolver()
 
 	results := CheckVariables(cfg, health, resolver, false)
-	if len(results) != 1 {
-		t.Fatalf("expected 1 result, got %d", len(results))
+	// Expect 2 results: a resolve warning + the summary.
+	if len(results) < 2 {
+		t.Fatalf("expected at least 2 results, got %d: %+v", len(results), results)
 	}
-	if results[0].Status != StatusFail {
-		t.Errorf("expected fail, got %s: %s", results[0].Status, results[0].Message)
+
+	// First result: resolve failure warning.
+	foundResolveWarn := false
+	for _, r := range results {
+		if r.Status == StatusWarn && strings.Contains(r.Name, "variables/resolve/") {
+			foundResolveWarn = true
+		}
 	}
-	if !strings.Contains(results[0].Message, "target vars not validated") {
-		t.Errorf("expected 'target vars not validated' in message, got %q", results[0].Message)
+	if !foundResolveWarn {
+		t.Error("expected a resolve failure warning result")
 	}
-	if !strings.Contains(results[0].Message, "policy graph unresolved") {
-		t.Errorf("expected 'policy graph unresolved' in message, got %q", results[0].Message)
+
+	// Last result: summary with target vars not validated.
+	last := results[len(results)-1]
+	if last.Status != StatusFail {
+		t.Errorf("expected fail, got %s: %s", last.Status, last.Message)
+	}
+	if !strings.Contains(last.Message, "target vars not validated") {
+		t.Errorf("expected 'target vars not validated' in message, got %q", last.Message)
+	}
+	if !strings.Contains(last.Message, "policy graph unresolved") {
+		t.Errorf("expected 'policy graph unresolved' in message, got %q", last.Message)
 	}
 }
 
@@ -909,6 +924,125 @@ func TestCheckVariables_WorkspaceAutoInjected_Verbose(t *testing.T) {
 	}
 	if !foundOutputDirFailed {
 		t.Error("expected verbose detail showing output_dir as failed")
+	}
+}
+
+// --- CheckVariables Resolution Failure Tests ---
+
+func TestCheckVariables_ResolveFailure_PolicyNotFound(t *testing.T) {
+	cfg := &complytime.WorkspaceConfig{
+		Variables: map[string]string{},
+		Policies:  []complytime.PolicyEntry{{URL: "reg.io/policies/nist@v1.0.0"}},
+		Targets: []complytime.TargetConfig{{
+			ID:       "host1",
+			Policies: []string{"nonexistent-policy"},
+		}},
+	}
+	health := []ProviderHealth{{
+		EvaluatorID:             "openscap",
+		RequiredGlobalVariables: []string{},
+	}}
+
+	resolver := newMockPolicyGraphResolver()
+	results := CheckVariables(cfg, health, resolver, false)
+
+	foundResolveWarn := false
+	for _, r := range results {
+		if r.Status == StatusWarn && strings.Contains(r.Message, "nonexistent-policy") &&
+			strings.Contains(r.Message, "not found in config") {
+			foundResolveWarn = true
+		}
+	}
+	if !foundResolveWarn {
+		t.Errorf("expected StatusWarn result for missing policy, results: %+v", results)
+	}
+}
+
+func TestCheckVariables_ResolveFailure_InvalidRef(t *testing.T) {
+	cfg := &complytime.WorkspaceConfig{
+		Variables: map[string]string{},
+		Policies:  []complytime.PolicyEntry{{URL: "", ID: "bad"}},
+		Targets: []complytime.TargetConfig{{
+			ID:       "host1",
+			Policies: []string{"bad"},
+		}},
+	}
+	health := []ProviderHealth{{
+		EvaluatorID:             "openscap",
+		RequiredGlobalVariables: []string{},
+	}}
+
+	resolver := newMockPolicyGraphResolver()
+	results := CheckVariables(cfg, health, resolver, false)
+
+	foundResolveWarn := false
+	for _, r := range results {
+		if r.Status == StatusWarn && strings.Contains(r.Message, "invalid policy reference") {
+			foundResolveWarn = true
+		}
+	}
+	if !foundResolveWarn {
+		t.Errorf("expected StatusWarn result for invalid policy reference, results: %+v", results)
+	}
+}
+
+func TestCheckVariables_ResolveFailure_VersionNotFound(t *testing.T) {
+	cfg := &complytime.WorkspaceConfig{
+		Variables: map[string]string{},
+		Policies:  []complytime.PolicyEntry{{URL: "reg.io/policies/nist@v1.0.0"}},
+		Targets: []complytime.TargetConfig{{
+			ID:       "host1",
+			Policies: []string{"nist"},
+		}},
+	}
+	health := []ProviderHealth{{
+		EvaluatorID:             "openscap",
+		RequiredGlobalVariables: []string{},
+	}}
+
+	// Resolver with no versions configured — ResolveVersion will fail.
+	resolver := newMockPolicyGraphResolver()
+	results := CheckVariables(cfg, health, resolver, false)
+
+	foundResolveWarn := false
+	for _, r := range results {
+		if r.Status == StatusWarn && strings.Contains(r.Message, "cannot resolve version") {
+			foundResolveWarn = true
+		}
+	}
+	if !foundResolveWarn {
+		t.Errorf("expected StatusWarn result for version resolution failure, results: %+v", results)
+	}
+}
+
+func TestCheckVariables_ResolveFailure_GraphNotFound(t *testing.T) {
+	cfg := &complytime.WorkspaceConfig{
+		Variables: map[string]string{},
+		Policies:  []complytime.PolicyEntry{{URL: "reg.io/policies/nist@v1.0.0"}},
+		Targets: []complytime.TargetConfig{{
+			ID:       "host1",
+			Policies: []string{"nist"},
+		}},
+	}
+	health := []ProviderHealth{{
+		EvaluatorID:             "openscap",
+		RequiredGlobalVariables: []string{},
+	}}
+
+	// Resolver with version but no graph — ResolvePolicyGraph will fail.
+	resolver := newMockPolicyGraphResolver()
+	resolver.versions["policies/nist@v1.0.0"] = "v1.0.0"
+
+	results := CheckVariables(cfg, health, resolver, false)
+
+	foundResolveWarn := false
+	for _, r := range results {
+		if r.Status == StatusWarn && strings.Contains(r.Message, "cannot resolve policy graph") {
+			foundResolveWarn = true
+		}
+	}
+	if !foundResolveWarn {
+		t.Errorf("expected StatusWarn result for graph resolution failure, results: %+v", results)
 	}
 }
 
@@ -1134,6 +1268,27 @@ func TestCheckPolicyActivePeriod_UnparseableDate(t *testing.T) {
 	}
 	if !strings.Contains(results[0].Message, "unparseable") {
 		t.Errorf("expected 'unparseable' in message, got %q", results[0].Message)
+	}
+}
+
+func TestCheckPolicyActivePeriod_InvalidPolicyRef(t *testing.T) {
+	cfg := &complytime.WorkspaceConfig{
+		Policies: []complytime.PolicyEntry{{URL: ""}},
+	}
+	resolver := newMockPolicyGraphResolver()
+
+	results := CheckPolicyActivePeriod(cfg, resolver, false)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Status != StatusFail {
+		t.Errorf("expected fail for invalid ref, got %s: %s", results[0].Status, results[0].Message)
+	}
+	if !results[0].Blocking {
+		t.Error("expected blocking for invalid policy reference")
+	}
+	if !strings.Contains(results[0].Message, "invalid policy reference") {
+		t.Errorf("expected 'invalid policy reference' in message, got %q", results[0].Message)
 	}
 }
 
@@ -1496,5 +1651,40 @@ func TestCheckComplypacks_NoComplypacks(t *testing.T) {
 	results := CheckComplypacks(cfg, "/tmp", newMockPolicyGraphResolver())
 	if results != nil {
 		t.Errorf("expected nil results for empty complypacks, got %d", len(results))
+	}
+}
+
+func TestCheckComplypacks_InvalidPolicyRef(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cfg := &complytime.WorkspaceConfig{
+		Policies: []complytime.PolicyEntry{
+			{URL: ""},
+		},
+		Complypacks: []complytime.PolicyEntry{
+			{URL: "reg.io/complypacks/openscap@v1.0.0"},
+		},
+	}
+
+	resolver := newMockPolicyGraphResolver()
+
+	results := CheckComplypacks(cfg, tmpDir, resolver)
+	// Expect fail result for invalid ref; may also include a pass result
+	// for the evaluator cache summary when no evaluators were resolved.
+	if len(results) < 1 {
+		t.Fatalf("expected at least 1 result, got %d: %+v", len(results), results)
+	}
+
+	foundFail := false
+	for _, r := range results {
+		if r.Status == StatusFail && strings.Contains(r.Message, "invalid policy reference") {
+			foundFail = true
+			if !r.Blocking {
+				t.Error("expected blocking for invalid policy reference")
+			}
+		}
+	}
+	if !foundFail {
+		t.Errorf("expected a StatusFail result for invalid policy reference, results: %+v", results)
 	}
 }

--- a/openspec/changes/align-policyref-oci-semantics/.openspec.yaml
+++ b/openspec/changes/align-policyref-oci-semantics/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-22

--- a/openspec/changes/align-policyref-oci-semantics/design.md
+++ b/openspec/changes/align-policyref-oci-semantics/design.md
@@ -1,0 +1,159 @@
+## Context
+
+PR #595 rewrote `ParsePolicyRef` to delegate OCI reference parsing
+to oras-go and the follow-up work on `opsx/fix-complypack-oci-ref`
+split `PolicyRef.Version` into typed `Tag`/`Digest` fields. Two
+gaps remain (issue #600):
+
+1. `ParsePolicyRef` silently converts the legacy `@version`
+   notation to `:tag` before delegating to oras-go. No deprecation
+   signal reaches the user. In the OCI Distribution Spec, `@` is
+   exclusively a digest separator; using it for tags is ambiguous.
+
+2. Three `complyctl doctor` check functions (`CheckPolicyActivePeriod`,
+   `CheckComplypacks`, `CheckVariables`) silently `continue` when
+   `ParsePolicyRef` returns an error, producing no diagnostic output.
+   `CheckPolicyVersions` already reports these as
+   `StatusFail, Blocking: true` results -- the other functions
+   should follow the same pattern.
+
+### Current deprecation pattern
+
+The codebase uses `fmt.Fprintf(os.Stderr, "WARNING: ...")` for
+warnings (see `workspace.go:printDeprecationWarning`,
+`get.go:235`, `scan.go:308`). A `DEPRECATED:` prefix variant
+will distinguish deprecation from general warnings.
+
+### Current error-reporting pattern in doctor.go
+
+`CheckPolicyVersions` (lines 244-253) reports `ParsePolicyRef`
+failures as:
+```go
+CheckResult{
+    Name:     fmt.Sprintf("policy/%s", p.EffectiveID()),
+    Status:   StatusFail,
+    Message:  fmt.Sprintf("invalid policy reference: %v", err),
+    Blocking: true,
+}
+```
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Warn users that `@version` syntax is deprecated so they can
+  migrate to `:tag` syntax before removal.
+- Surface `ParsePolicyRef` errors in all `complyctl doctor` checks
+  so configuration problems are visible to the user.
+- Surface resolution errors in `CheckVariables` with specific
+  error messages instead of a silent counter.
+
+**Non-Goals:**
+
+- Removing `@version` support -- this change adds the deprecation
+  warning only. Removal is deferred to a future release.
+- Changing `ParsePolicyRef` return values or signature -- the
+  function continues to accept `@version` and produce correct
+  output; only a stderr warning is added.
+- Adding deprecation warnings for bare policy IDs with `@version`
+  -- bare IDs (no slash) are a complytime convention, not OCI
+  references, so the `@` separator is unambiguous there.
+
+## Decisions
+
+### D1: Deprecation warning location
+
+**Decision**: Emit the warning inside `ParsePolicyRef` itself,
+at the point where `@version` is converted to `:tag`.
+
+**Rationale**: This is the single code path that handles the
+conversion. Placing the warning here ensures every caller
+benefits without duplicating logic. The warning writes to
+`os.Stderr` matching existing patterns.
+
+**Alternative considered**: Return a structured warning alongside
+the result. Rejected because it would change the function
+signature (`(PolicyRef, []Warning, error)`) and require all 10+
+callers to handle a new return value for a temporary deprecation.
+
+### D2: Warning deduplication
+
+**Decision**: Deduplicate warnings by raw URL using a
+package-level `map[string]bool` protected by `sync.Mutex`.
+Each unique policy URL with `@version` emits one warning per
+process invocation regardless of how many callers invoke
+`ParsePolicyRef`.
+
+**Rationale**: `ParsePolicyRef` is called by many code paths
+(`EffectiveID`, `validatePolicyRefs`, `CheckPolicyVersions`,
+`CheckPolicyActivePeriod`, `CheckComplypacks`, `CheckVariables`,
+and CLI commands). Without deduplication, a single `@version`
+policy could emit 10+ identical warnings per CLI invocation,
+creating noise that obscures real diagnostic output.
+
+### D3: Doctor error reporting -- StatusFail with Blocking: true
+
+**Decision**: `CheckPolicyActivePeriod` and `CheckComplypacks`
+report `ParsePolicyRef` failures as
+`StatusFail, Blocking: true`, matching `CheckPolicyVersions`.
+
+**Rationale**: A malformed policy URL is a configuration error
+that prevents the check from running. `StatusFail` with
+`Blocking: true` is the established pattern for this case.
+
+**Alternative considered**: `StatusWarn, Blocking: false`.
+Rejected because a parse failure is not a soft concern -- the
+check cannot proceed, and the user must fix their config.
+
+### D4: CheckVariables resolution error messages
+
+**Decision**: Replace the silent `resolveFailures++` counter with
+per-failure `CheckResult{Status: StatusWarn, Blocking: false}`
+results that include the policy ID and error description.
+
+**Rationale**: The user currently sees no indication that a
+policy failed to resolve. Per-failure results surface the
+specific broken policy and the reason (parse error, version not
+found, graph resolution failure, or policy not found in config).
+
+**Status**: `StatusWarn` rather than `StatusFail` because
+variable checking can still proceed for other policies. The
+`resolveFailures` counter is retained for the downstream
+unmapped-target-vars control flow (`unmappedReason`), while
+per-failure results are added for user visibility.
+
+### D5: Deprecation warning message format
+
+**Decision**: Use the format:
+```
+DEPRECATED: @version notation in policy URL "<raw>".
+Use ":tag" syntax instead (e.g., "registry.com/repo:v1.0").
+@version support will be removed in a future release.
+```
+
+**Rationale**: Three-line message clearly identifies the problem,
+the fix, and the timeline. The `DEPRECATED:` prefix distinguishes
+it from operational `WARNING:` messages.
+
+## Risks / Trade-offs
+
+- **[Risk]** Deprecation warning on stderr may be noisy in
+  automated pipelines.
+  **Mitigation**: Warning is emitted per-URL, not per-call.
+  Pipelines can redirect stderr or migrate URLs.
+
+- **[Risk]** `CheckVariables` producing per-failure results
+  changes doctor output for users with broken configs.
+  **Mitigation**: Previously these failures were invisible.
+  Surfacing them is strictly an improvement -- users with
+  valid configs see no change.
+
+- **[Risk]** `Blocking: true` on parse failures in
+  `CheckPolicyActivePeriod`/`CheckComplypacks` may cause
+  `complyctl doctor` to report blocking issues where it
+  previously reported none.
+  **Mitigation**: The parse failure would also be reported
+  by `CheckPolicyVersions` (which already has this behavior),
+  so the user would already see a blocking error. The
+  additional results provide context about which checks were
+  affected.

--- a/openspec/changes/align-policyref-oci-semantics/proposal.md
+++ b/openspec/changes/align-policyref-oci-semantics/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+PR #595 improved OCI reference parsing by delegating to oras-go and
+PR branch `opsx/fix-complypack-oci-ref` split `PolicyRef.Version`
+into typed `Tag` and `Digest` fields. Two follow-up improvements
+remain to complete alignment with OCI Distribution Spec semantics
+(tracked in issue #600):
+
+1. The `@version` notation (e.g., `registry.com/repo@v1.0`) silently
+   converts to `:tag` syntax without warning users. In OCI semantics,
+   `@` is exclusively a digest separator. Users familiar with OCI
+   tooling may find this ambiguous.
+2. Three `complyctl doctor` check functions silently skip policies
+   that fail to parse or resolve, producing no diagnostic output.
+   This hides configuration errors from users.
+
+## What Changes
+
+- Emit a deprecation warning to stderr when `ParsePolicyRef`
+  encounters a non-digest `@` suffix on a full OCI reference
+  (e.g., `@v1.0`), advising the user to switch to `:tag` syntax.
+- Update `CheckPolicyActivePeriod` to report `ParsePolicyRef`
+  failures as `CheckResult{Status: StatusFail}`, matching the
+  error-reporting pattern established in `CheckPolicyVersions`.
+- Update `CheckComplypacks` to report `ParsePolicyRef` failures
+  as `CheckResult{Status: StatusFail}`, matching the same pattern.
+- Update `CheckVariables` to include specific error messages when
+  policy resolution fails, instead of silently incrementing a
+  counter.
+
+## Capabilities
+
+### New Capabilities
+
+- `deprecation-at-version`: Deprecation warning for the non-standard
+  `@version` notation on OCI references, guiding users toward
+  standard `:tag` syntax.
+
+### Modified Capabilities
+
+- `oci-ref-parsing`: `ParsePolicyRef` gains a deprecation warning
+  side-effect for `@version` notation on full OCI references.
+
+## Impact
+
+- `internal/complytime/config.go` — `ParsePolicyRef` emits
+  deprecation warning to stderr for non-digest `@` suffixes
+- `internal/complytime/config_test.go` — tests for deprecation
+  warning output
+- `internal/doctor/doctor.go` — `CheckPolicyActivePeriod`,
+  `CheckComplypacks`, and `CheckVariables` gain explicit error
+  reporting for parse and resolve failures
+- `internal/doctor/doctor_test.go` — tests for new error-reporting
+  paths
+- `docs/` — document the `@version` deprecation
+- `CHANGELOG.md` — deprecation entry

--- a/openspec/changes/align-policyref-oci-semantics/specs/deprecation-at-version/spec.md
+++ b/openspec/changes/align-policyref-oci-semantics/specs/deprecation-at-version/spec.md
@@ -1,0 +1,91 @@
+## ADDED Requirements
+
+### Requirement: Deprecation warning for @version notation
+`ParsePolicyRef` SHALL emit a deprecation warning to stderr when
+a full OCI reference (containing at least one `/`) uses a
+non-digest `@` suffix. The warning SHALL identify the offending
+URL, advise switching to `:tag` syntax, and note that `@version`
+support will be removed in a future release.
+
+Bare policy IDs (no `/` in the input) are exempt from this warning
+because the `@` separator is a complytime convention unrelated to
+OCI digest semantics.
+
+#### Scenario: Full OCI reference with @version emits warning
+- **WHEN** `ParsePolicyRef` is called with
+  `"registry.example.com/policies/nist@v1.0"`
+- **THEN** a deprecation warning is written to stderr containing
+  the original URL and recommending `:tag` syntax
+- **AND** the function returns a valid `PolicyRef` with
+  `Tag == "v1.0"` (backwards-compatible behavior preserved)
+
+#### Scenario: Full OCI reference with @digest does not warn
+- **WHEN** `ParsePolicyRef` is called with
+  `"registry.example.com/policies/nist@sha256:abc123..."`
+- **THEN** no deprecation warning is emitted
+- **AND** the function returns a valid `PolicyRef` with the
+  `Digest` field populated
+
+#### Scenario: Bare policy ID with @version does not warn
+- **WHEN** `ParsePolicyRef` is called with `"my-policy@v2.0"`
+- **THEN** no deprecation warning is emitted
+- **AND** the function returns a valid `PolicyRef` with
+  `Tag == "v2.0"`
+
+### Requirement: CheckPolicyActivePeriod reports parse failures
+`CheckPolicyActivePeriod` SHALL report `ParsePolicyRef` failures
+as a `CheckResult` with `Status: StatusFail` and
+`Blocking: true`, matching the error-reporting pattern in
+`CheckPolicyVersions`.
+
+#### Scenario: Malformed policy URL in active period check
+- **WHEN** `CheckPolicyActivePeriod` processes a policy whose
+  URL causes `ParsePolicyRef` to return an error
+- **THEN** the results include a `CheckResult` with
+  `Status == StatusFail`, `Blocking == true`, and a message
+  containing the parse error
+
+### Requirement: CheckComplypacks reports parse failures
+`CheckComplypacks` SHALL report `ParsePolicyRef` failures as a
+`CheckResult` with `Status: StatusFail` and `Blocking: true`,
+matching the error-reporting pattern in `CheckPolicyVersions`.
+
+#### Scenario: Malformed policy URL in complypacks check
+- **WHEN** `CheckComplypacks` processes a policy whose URL
+  causes `ParsePolicyRef` to return an error
+- **THEN** the results include a `CheckResult` with
+  `Status == StatusFail`, `Blocking == true`, and a message
+  containing the parse error
+
+### Requirement: CheckVariables reports resolution failures
+`CheckVariables` SHALL report specific error messages for each
+policy resolution failure instead of silently incrementing a
+counter. Each failure SHALL produce a `CheckResult` with
+`Status: StatusWarn` and `Blocking: false`.
+
+#### Scenario: Policy not found in config during variable check
+- **WHEN** `CheckVariables` processes a target referencing a
+  policy ID that does not exist in `cfg.Policies`
+- **THEN** the results include a `CheckResult` with
+  `Status == StatusWarn` and a message identifying the missing
+  policy ID
+
+#### Scenario: Parse error during variable check
+- **WHEN** `CheckVariables` processes a policy whose URL causes
+  `ParsePolicyRef` to return an error
+- **THEN** the results include a `CheckResult` with
+  `Status == StatusWarn` and a message containing the parse error
+
+#### Scenario: Version resolution failure during variable check
+- **WHEN** `CheckVariables` processes a policy whose version
+  cannot be resolved by the resolver
+- **THEN** the results include a `CheckResult` with
+  `Status == StatusWarn` and a message identifying the policy
+  and the resolution error
+
+#### Scenario: Graph resolution failure during variable check
+- **WHEN** `CheckVariables` processes a policy whose dependency
+  graph cannot be resolved
+- **THEN** the results include a `CheckResult` with
+  `Status == StatusWarn` and a message identifying the policy
+  and the resolution error

--- a/openspec/changes/align-policyref-oci-semantics/tasks.md
+++ b/openspec/changes/align-policyref-oci-semantics/tasks.md
@@ -1,0 +1,28 @@
+## 1. Deprecation Warning for @version Notation
+
+- [x] 1.1 Add deprecation warning in `ParsePolicyRef` (`internal/complytime/config.go`) at the `@version` to `:tag` conversion point (line ~192). Emit to `os.Stderr` with format: `DEPRECATED: @version notation in policy URL "<raw>". Use ":tag" syntax instead. @version support will be removed in a future release.`
+- [x] 1.2 Add unit tests in `internal/complytime/config_test.go` verifying: (a) full OCI ref with `@v1.0` emits deprecation warning and returns correct `Tag`; (b) full OCI ref with `@sha256:...` does not emit warning; (c) bare policy ID with `@v2.0` does not emit warning.
+
+## 2. Doctor Error Reporting -- CheckPolicyActivePeriod
+
+- [x] 2.1 Update `CheckPolicyActivePeriod` in `internal/doctor/doctor.go` to report `ParsePolicyRef` failures as `CheckResult{Status: StatusFail, Blocking: true}` with message `"invalid policy reference: <err>"` instead of silently continuing (lines 607-609).
+- [x] 2.2 Add unit test in `internal/doctor/doctor_test.go` verifying that a malformed policy URL produces a `StatusFail` result with `Blocking: true`.
+
+## 3. Doctor Error Reporting -- CheckComplypacks
+
+- [x] 3.1 Update `CheckComplypacks` in `internal/doctor/doctor.go` to report `ParsePolicyRef` failures as `CheckResult{Status: StatusFail, Blocking: true}` with message `"invalid policy reference: <err>"` instead of silently continuing (lines 792-794).
+- [x] 3.2 Add unit test in `internal/doctor/doctor_test.go` verifying that a malformed policy URL produces a `StatusFail` result with `Blocking: true`.
+
+## 4. Doctor Error Reporting -- CheckVariables
+
+- [x] 4.1 Replace `resolveFailures++` counter in `CheckVariables` (`internal/doctor/doctor.go`, lines 440-470) with per-failure `CheckResult{Status: StatusWarn, Blocking: false}` results. Cover four failure cases: (a) policy not found in config; (b) `ParsePolicyRef` error; (c) version resolution error; (d) graph resolution error. Each result message SHALL identify the policy and the specific error.
+- [x] 4.2 Add unit tests in `internal/doctor/doctor_test.go` verifying each failure case produces a `StatusWarn` result with a descriptive message.
+
+## 5. Documentation and Changelog
+
+- [x] 5.1 Add deprecation notice to `CHANGELOG.md` under the Unreleased section noting the `@version` deprecation and recommended migration to `:tag` syntax.
+
+## 6. Verification
+
+- [x] 6.1 Run `make test-unit` and verify all existing and new tests pass.
+- [x] 6.2 Run `make lint` and verify no linting violations.


### PR DESCRIPTION
## Summary

Addresses [issue #600](https://github.com/complytime/complyctl/issues/600) — follow-up improvements to bring `PolicyRef` into full alignment with OCI Distribution Spec semantics.

### Changes

#### 1. Deprecate `@version` notation
- Emit a deprecation warning to stderr when `ParsePolicyRef` encounters a non-digest `@` suffix on a full OCI reference (e.g., `@v1.0`), advising the user to switch to `:tag` syntax.
- Warning is deduplicated per URL per process invocation to avoid spam from multiple callers (`EffectiveID`, `validatePolicyRefs`, doctor checks, CLI commands).
- Bare policy IDs (no slash) are exempt since `@` is a complytime convention there, not an OCI digest separator.

#### 2. Split `PolicyRef.Version` into `Tag` and `Digest` fields
- Replace the single `Version` field with separate `Tag string` and `Digest string` fields on `PolicyRef`.
- Add `VersionString()` accessor for backward compatibility (prefers `Tag` over `Digest`).
- Update `ParsePolicyRef` to classify references using oras-go and `go-digest`.
- Update `BuildLookupRef` to accept separate tag and digest parameters.
- Update all callers that read `ref.Version` to use `ref.Tag`, `ref.Digest`, or `ref.VersionString()`.

#### 3. Consistent error reporting in `doctor.go`
- `CheckPolicyActivePeriod` and `CheckComplypacks` now report `ParsePolicyRef` failures as `CheckResult{Status: StatusFail, Blocking: true}`, matching the pattern in `CheckPolicyVersions`.
- `CheckVariables` now emits per-failure `CheckResult{Status: StatusWarn, Blocking: false}` results with specific error messages for four failure cases (policy not found, parse error, version resolution, graph resolution) instead of silently incrementing a counter.

## Related Issues

- Closes complytime/complyctl#600

## Review Hints

- 3 new deprecation warning tests (stderr capture via `os.Pipe` with `defer` protection and `io.ReadAll`)
- 6 new doctor error reporting tests + 2 updated existing tests
- All tests pass with `-race` flag
- `make lint` — 0 issues

### Review Council

Reviewed by 5 Divisor agents. All returned APPROVE after iteration 1 fixes:
- **divisor-adversary**: APPROVE (no security concerns)
- **divisor-architect**: APPROVE (9/10 alignment score)
- **divisor-guard**: APPROVE (aligned with issue intent)
- **divisor-testing**: APPROVE (after adding `defer` for stderr restore + `io.ReadAll`)
- **divisor-sre**: APPROVE (after adding warning deduplication)

### OpenSpec Artifacts

Spec artifacts in `openspec/changes/align-policyref-oci-semantics/`:
- `proposal.md` — motivation and scope
- `design.md` — technical decisions (5 decisions documented)
- `specs/deprecation-at-version/spec.md` — 5 requirements, 9 testable scenarios
- `tasks.md` — 11 tasks, all complete
