### PR TITLE
fix: updates error reporting and exit code

### DIFF
--- a/.gaze/baseline.json
+++ b/.gaze/baseline.json
@@ -710,15 +710,15 @@
       "function": "processScanOutput",
       "file": "cmd/complyctl/cli/scan.go",
       "line": 403,
-      "complexity": 3,
-      "line_coverage": 87.5,
-      "crap": 3.017578125
+      "complexity": 4,
+      "line_coverage": 90,
+      "crap": 4.016
     },
     {
       "package": "cli",
       "function": "reportOperationalWarnings",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 421,
+      "line": 425,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -727,16 +727,25 @@
       "package": "cli",
       "function": "checkOperationalErrors",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 430,
+      "line": 434,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
     },
     {
       "package": "cli",
+      "function": "checkNothingAssessed",
+      "file": "cmd/complyctl/cli/scan.go",
+      "line": 448,
+      "complexity": 2,
+      "line_coverage": 50,
+      "crap": 2.5
+    },
+    {
+      "package": "cli",
       "function": "buildEvaluators",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 441,
+      "line": 456,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -745,7 +754,7 @@
       "package": "cli",
       "function": "filterTargetByID",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 460,
+      "line": 475,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -754,7 +763,7 @@
       "package": "cli",
       "function": "filterTargetsForPolicy",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 469,
+      "line": 484,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -763,7 +772,7 @@
       "package": "cli",
       "function": "checkGenerationFreshness",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 479,
+      "line": 494,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -772,7 +781,7 @@
       "package": "cli",
       "function": "complypackDigestsByEvaluator",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 495,
+      "line": 510,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -781,7 +790,7 @@
       "package": "cli",
       "function": "needsRegeneration",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 505,
+      "line": 520,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -790,7 +799,7 @@
       "package": "cli",
       "function": "evaluatorArtifactsExist",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 522,
+      "line": 537,
       "complexity": 6,
       "line_coverage": 100,
       "crap": 6
@@ -799,7 +808,7 @@
       "package": "cli",
       "function": "runGeneration",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 537,
+      "line": 552,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -808,7 +817,7 @@
       "package": "cli",
       "function": "generateForAllTargets",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 553,
+      "line": 568,
       "complexity": 5,
       "line_coverage": 36.36363636363637,
       "crap": 11.442524417731029
@@ -817,7 +826,7 @@
       "package": "cli",
       "function": "executeScan",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 573,
+      "line": 588,
       "complexity": 1,
       "line_coverage": 0,
       "crap": 2
@@ -826,7 +835,7 @@
       "package": "cli",
       "function": "scanAllTargets",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 581,
+      "line": 596,
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
@@ -836,7 +845,7 @@
       "package": "cli",
       "function": "scanSingleTarget",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 607,
+      "line": 622,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -845,7 +854,7 @@
       "package": "cli",
       "function": "writeScanReports",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 626,
+      "line": 641,
       "complexity": 3,
       "line_coverage": 71.42857142857143,
       "crap": 3.2099125364431487
@@ -854,7 +863,7 @@
       "package": "cli",
       "function": "writeFormatReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 640,
+      "line": 655,
       "complexity": 4,
       "line_coverage": 40,
       "crap": 7.4559999999999995
@@ -863,7 +872,7 @@
       "package": "cli",
       "function": "writePrettyReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 652,
+      "line": 667,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -872,7 +881,7 @@
       "package": "cli",
       "function": "writeSARIFReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 663,
+      "line": 678,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -881,7 +890,7 @@
       "package": "cli",
       "function": "writeOSCALReport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 672,
+      "line": 687,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -890,7 +899,7 @@
       "package": "cli",
       "function": "(*scanOptions).runExport",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 683,
+      "line": 698,
       "complexity": 5,
       "line_coverage": 16.666666666666668,
       "crap": 19.467592592592588,
@@ -900,7 +909,7 @@
       "package": "cli",
       "function": "authRequired",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 709,
+      "line": 724,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -909,7 +918,7 @@
       "package": "cli",
       "function": "validateAuthCredentials",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 713,
+      "line": 728,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -918,7 +927,7 @@
       "package": "cli",
       "function": "resolveCollectorAuth",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 720,
+      "line": 735,
       "complexity": 4,
       "line_coverage": 0,
       "crap": 20,
@@ -928,7 +937,7 @@
       "package": "cli",
       "function": "exportToProviders",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 735,
+      "line": 750,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -937,7 +946,7 @@
       "package": "cli",
       "function": "exportSingleProvider",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 743,
+      "line": 758,
       "complexity": 3,
       "line_coverage": 0,
       "crap": 12
@@ -946,7 +955,7 @@
       "package": "cli",
       "function": "resolveOIDCToken",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 760,
+      "line": 775,
       "complexity": 2,
       "line_coverage": 0,
       "crap": 6
@@ -955,7 +964,7 @@
       "package": "cli",
       "function": "formatExportSummary",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 773,
+      "line": 788,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -964,7 +973,7 @@
       "package": "cli",
       "function": "appendExportRow",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 793,
+      "line": 808,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -973,7 +982,7 @@
       "package": "cli",
       "function": "appendResponseRow",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 807,
+      "line": 822,
       "complexity": 3,
       "line_coverage": 85.71428571428571,
       "crap": 3.0262390670553936
@@ -982,7 +991,7 @@
       "package": "cli",
       "function": "exportResponseStatus",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 820,
+      "line": 835,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -991,7 +1000,7 @@
       "package": "cli",
       "function": "countExportFailures",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 842,
+      "line": 857,
       "complexity": 7,
       "line_coverage": 100,
       "crap": 7
@@ -1000,7 +1009,7 @@
       "package": "cli",
       "function": "injectWorkspaceIntoTargets",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 863,
+      "line": 878,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -1009,7 +1018,7 @@
       "package": "cli",
       "function": "extractReqToControlMap",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 874,
+      "line": 889,
       "complexity": 6,
       "line_coverage": 90,
       "crap": 6.036
@@ -1018,7 +1027,7 @@
       "package": "cli",
       "function": "extractPlanToReqMap",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 895,
+      "line": 910,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4
@@ -1027,7 +1036,7 @@
       "package": "cli",
       "function": "resolveAssessmentIDs",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 910,
+      "line": 925,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -1036,7 +1045,7 @@
       "package": "cli",
       "function": "reverseMap",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 920,
+      "line": 935,
       "complexity": 3,
       "line_coverage": 83.33333333333333,
       "crap": 3.0416666666666665
@@ -1045,7 +1054,7 @@
       "package": "cli",
       "function": "buildReqToComplypackRef",
       "file": "cmd/complyctl/cli/scan.go",
-      "line": 941,
+      "line": 956,
       "complexity": 11,
       "line_coverage": 82.6086956521739,
       "crap": 11.636475712994166
@@ -2328,15 +2337,15 @@
       "function": "(*Evaluator).GemaraLog",
       "file": "internal/output/evaluator.go",
       "line": 97,
-      "complexity": 3,
+      "complexity": 4,
       "line_coverage": 100,
-      "crap": 3
+      "crap": 4
     },
     {
       "package": "output",
       "function": "(*Evaluator).Write",
       "file": "internal/output/evaluator.go",
-      "line": 134,
+      "line": 140,
       "complexity": 4,
       "line_coverage": 75,
       "crap": 4.25
@@ -2345,7 +2354,7 @@
       "package": "output",
       "function": "(*Evaluator).resolveControl",
       "file": "internal/output/evaluator.go",
-      "line": 157,
+      "line": 163,
       "complexity": 2,
       "line_coverage": 100,
       "crap": 2
@@ -2354,7 +2363,7 @@
       "package": "output",
       "function": "(*Evaluator).providerToGemaraAssessment",
       "file": "internal/output/evaluator.go",
-      "line": 164,
+      "line": 170,
       "complexity": 8,
       "line_coverage": 100,
       "crap": 8
@@ -2363,7 +2372,7 @@
       "package": "output",
       "function": "providerStepToGemara",
       "file": "internal/output/evaluator.go",
-      "line": 218,
+      "line": 224,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1
@@ -2372,7 +2381,7 @@
       "package": "output",
       "function": "providerStepsToGemara",
       "file": "internal/output/evaluator.go",
-      "line": 228,
+      "line": 234,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -2381,7 +2390,7 @@
       "package": "output",
       "function": "providerConfidenceToGemara",
       "file": "internal/output/evaluator.go",
-      "line": 239,
+      "line": 245,
       "complexity": 5,
       "line_coverage": 83.33333333333333,
       "crap": 5.1157407407407405
@@ -2390,7 +2399,7 @@
       "package": "output",
       "function": "formatStepIdentity",
       "file": "internal/output/evaluator.go",
-      "line": 291,
+      "line": 297,
       "complexity": 3,
       "line_coverage": 100,
       "crap": 3
@@ -2399,7 +2408,7 @@
       "package": "output",
       "function": "(*Evaluator).resolveComplypackRef",
       "file": "internal/output/evaluator.go",
-      "line": 300,
+      "line": 306,
       "complexity": 1,
       "line_coverage": 100,
       "crap": 1
@@ -2408,7 +2417,7 @@
       "package": "output",
       "function": "(*Evaluator).toSerializable",
       "file": "internal/output/evaluator.go",
-      "line": 306,
+      "line": 312,
       "complexity": 5,
       "line_coverage": 100,
       "crap": 5
@@ -2544,18 +2553,30 @@
       "function": "FormatScanSummary",
       "file": "internal/output/scan_summary.go",
       "line": 59,
-      "complexity": 9,
-      "line_coverage": 88.88888888888889,
-      "crap": 9.11111111111111,
+      "complexity": 10,
+      "line_coverage": 89.47368421052632,
+      "crap": 10.116635077999709,
       "contract_coverage": 100,
-      "gaze_crap": 9,
+      "gaze_crap": 10,
+      "quadrant": "Q1_Safe"
+    },
+    {
+      "package": "output",
+      "function": "NothingAssessed",
+      "file": "internal/output/scan_summary.go",
+      "line": 153,
+      "complexity": 4,
+      "line_coverage": 100,
+      "crap": 4,
+      "contract_coverage": 100,
+      "gaze_crap": 4,
       "quadrant": "Q1_Safe"
     },
     {
       "package": "output",
       "function": "FormatOperationalWarnings",
       "file": "internal/output/scan_summary.go",
-      "line": 144,
+      "line": 166,
       "complexity": 4,
       "line_coverage": 100,
       "crap": 4,
@@ -3804,18 +3825,18 @@
     }
   ],
   "summary": {
-    "total_functions": 392,
-    "avg_complexity": 3.5510204081632653,
-    "avg_line_coverage": 49.163136736891275,
-    "avg_crap": 9.962279098160602,
+    "total_functions": 394,
+    "avg_complexity": 3.5558375634517767,
+    "avg_line_coverage": 49.30211775680969,
+    "avg_crap": 9.93583084345392,
     "crapload": 55,
     "crap_threshold": 15,
     "gaze_crapload": 3,
     "gaze_crap_threshold": 15,
-    "avg_gaze_crap": 5.546948356807511,
-    "avg_contract_coverage": 74.88262910798123,
+    "avg_gaze_crap": 5.539351851851851,
+    "avg_contract_coverage": 75.23148148148148,
     "quadrant_counts": {
-      "Q1_Safe": 67,
+      "Q1_Safe": 68,
       "Q2_ComplexButTested": 1,
       "Q3_SimpleButUnderspecified": 1,
       "Q4_Dangerous": 2
@@ -3837,20 +3858,20 @@
         "fix_strategy": "decompose_and_test"
       },
       {
-        "package": "cli",
-        "function": "promptTargets",
-        "file": "cmd/complyctl/cli/init.go",
-        "line": 153,
+        "package": "terminal",
+        "function": "ShowPlainTable",
+        "file": "internal/terminal/table.go",
+        "line": 19,
         "complexity": 10,
         "line_coverage": 0,
         "crap": 110,
         "fix_strategy": "add_tests"
       },
       {
-        "package": "terminal",
-        "function": "ShowPlainTable",
-        "file": "internal/terminal/table.go",
-        "line": 19,
+        "package": "cli",
+        "function": "promptTargets",
+        "file": "cmd/complyctl/cli/init.go",
+        "line": 153,
         "complexity": 10,
         "line_coverage": 0,
         "crap": 110,

--- a/cmd/complyctl/cli/scan.go
+++ b/cmd/complyctl/cli/scan.go
@@ -413,7 +413,11 @@ func processScanOutput(format string, scanOut *scanOutput, repository string, ma
 	}
 
 	fmt.Println(output.FormatScanSummary(scanOut.assessments, scanOut.assessmentTargets, mappings.reqToControl, eid, targetIDs))
-	return checkOperationalErrors(scanOut.errors)
+
+	if err := checkOperationalErrors(scanOut.errors); err != nil {
+		return err
+	}
+	return checkNothingAssessed(scanOut.assessments)
 }
 
 // reportOperationalWarnings prints provider-reported operational errors as
@@ -434,6 +438,17 @@ func checkOperationalErrors(errors []string) error {
 			noun = "error"
 		}
 		return fmt.Errorf("scan completed with %d operational %s — some targets could not be evaluated", len(errors), noun)
+	}
+	return nil
+}
+
+// checkNothingAssessed returns an error when zero requirements received a
+// definitive pass or fail result. A scan that produces no assessed results
+// is a false-confidence hazard and must be surfaced.
+func checkNothingAssessed(assessments []provider.AssessmentLog) error {
+	if output.NothingAssessed(assessments) {
+		fmt.Fprintf(os.Stderr, "\nWARNING: scan completed but no requirements were assessed — all may be not applicable for this target\n")
+		return fmt.Errorf("scan completed with zero assessed requirements — verify policy and target compatibility")
 	}
 	return nil
 }

--- a/internal/output/evaluator.go
+++ b/internal/output/evaluator.go
@@ -105,6 +105,12 @@ func (e *Evaluator) GemaraLog() *gemara.EvaluationLog {
 		result = gemara.UpdateAggregateResult(result, ce.Result)
 	}
 
+	// A scan that completed with zero evaluations means all controls
+	// were not applicable — distinguish from "scan never ran."
+	if len(evals) == 0 {
+		result = gemara.NotApplicable
+	}
+
 	return &gemara.EvaluationLog{
 		Evaluations: evals,
 		Result:      result,

--- a/internal/output/evaluator_test.go
+++ b/internal/output/evaluator_test.go
@@ -87,6 +87,14 @@ func TestGemaraLog_AggregatesResult(t *testing.T) {
 	}
 }
 
+func TestGemaraLog_NoAssessmentsYieldsNotApplicable(t *testing.T) {
+	eval := output.NewEvaluator("pol", "tgt", nil, nil, nil)
+	eval.AddTarget(nil)
+	log := eval.GemaraLog()
+	assert.Equal(t, gemara.NotApplicable, log.Result)
+	assert.Empty(t, log.Evaluations)
+}
+
 func TestGemaraLog_PopulatesTarget(t *testing.T) {
 	eval := output.NewEvaluator("policy-id", "my-target", nil, nil, nil)
 	eval.AddTarget([]provider.AssessmentLog{

--- a/internal/output/scan_summary.go
+++ b/internal/output/scan_summary.go
@@ -57,7 +57,7 @@ func matchingStepMessage(steps []provider.Step, target gemara.Result) string {
 // Intro text, plain aligned text table of non-passing results, compact totals.
 // See spec.md Session 2026-02-26e.
 func FormatScanSummary(assessments []provider.AssessmentLog, assessmentTargets []string, reqToControl map[string]string, policyID string, targetIDs []string) string {
-	var passCount, failCount, skipCount, errCount int
+	var passCount, failCount, notApplicableCount, skipCount, errCount int
 	var entries []nonPassingEntry
 
 	for i := range assessments {
@@ -87,7 +87,17 @@ func FormatScanSummary(assessments []provider.AssessmentLog, assessmentTargets [
 				emoji:         complytime.StatusFailed,
 				message:       matchingStepMessage(a.Steps, result),
 			})
-		case gemara.NotApplicable, gemara.NotRun:
+		case gemara.NotApplicable:
+			notApplicableCount++
+			entries = append(entries, nonPassingEntry{
+				targetID:      targetID,
+				requirementID: a.RequirementID,
+				controlID:     ctrlID,
+				result:        result,
+				emoji:         complytime.StatusSkipped,
+				message:       matchingStepMessage(a.Steps, result),
+			})
+		case gemara.NotRun:
 			skipCount++
 			entries = append(entries, nonPassingEntry{
 				targetID:      targetID,
@@ -124,8 +134,8 @@ func FormatScanSummary(assessments []provider.AssessmentLog, assessmentTargets [
 		rows = append(rows, []string{e.targetID, e.requirementID, e.controlID, e.emoji, e.message})
 	}
 
-	conclusion := fmt.Sprintf("%d requirements: %d passed, %d failed, %d skipped, %d errors",
-		total, passCount, failCount, skipCount, errCount)
+	conclusion := fmt.Sprintf("%d requirements: %d passed, %d failed, %d not applicable, %d skipped, %d errors",
+		total, passCount, failCount, notApplicableCount, skipCount, errCount)
 
 	var b strings.Builder
 	fmt.Fprintln(&b, intro)
@@ -136,6 +146,18 @@ func FormatScanSummary(assessments []provider.AssessmentLog, assessmentTargets [
 	}
 	fmt.Fprintln(&b, conclusion)
 	return b.String()
+}
+
+// NothingAssessed returns true when no requirements received a definitive
+// pass or fail result, indicating the scan produced no actionable compliance signal.
+func NothingAssessed(assessments []provider.AssessmentLog) bool {
+	for i := range assessments {
+		result := aggregateResultFromSteps(assessments[i].Steps)
+		if result == gemara.Passed || result == gemara.Failed {
+			return false
+		}
+	}
+	return true
 }
 
 // FormatOperationalWarnings formats provider-reported operational errors

--- a/internal/output/scan_summary_test.go
+++ b/internal/output/scan_summary_test.go
@@ -103,7 +103,7 @@ func TestFormatScanSummary_AllPassed(t *testing.T) {
 
 	output := FormatScanSummary(assessments, assessmentTargets, reqToControl, policyID, targetIDs)
 
-	assert.Contains(t, output, "2 requirements: 2 passed, 0 failed, 0 skipped, 0 errors")
+	assert.Contains(t, output, "2 requirements: 2 passed, 0 failed, 0 not applicable, 0 skipped, 0 errors")
 	assert.NotContains(t, output, "TARGET ID")
 }
 
@@ -150,6 +150,70 @@ func TestFormatOperationalWarnings_MultipleErrors(t *testing.T) {
 	assert.Contains(t, result, "WARNING: 2 operational errors during scan")
 	assert.Contains(t, result, "  - target 'staging': clone failed: auth denied")
 	assert.Contains(t, result, "  - target 'dev': missing required tool: conftest")
+}
+
+func TestFormatScanSummary_NotRunCountedAsSkipped(t *testing.T) {
+	assessments := []provider.AssessmentLog{
+		{
+			RequirementID: "REQ-1",
+			Steps:         nil, // no steps → NotRun → counted as skipped
+		},
+		{
+			RequirementID: "REQ-2",
+			Steps:         []provider.Step{{Result: provider.ResultPassed, Message: "OK"}},
+		},
+	}
+	assessmentTargets := []string{"target1", "target1"}
+	reqToControl := map[string]string{}
+	policyID := "test"
+	targetIDs := []string{"target1"}
+
+	result := FormatScanSummary(assessments, assessmentTargets, reqToControl, policyID, targetIDs)
+
+	assert.Contains(t, result, "1 skipped")
+	assert.Contains(t, result, "1 passed")
+	assert.Contains(t, result, "0 not applicable")
+}
+
+func TestFormatScanSummary_ZeroAssessments(t *testing.T) {
+	result := FormatScanSummary(nil, nil, map[string]string{}, "test", []string{"target1"})
+
+	assert.Contains(t, result, "0 requirements: 0 passed, 0 failed, 0 not applicable, 0 skipped, 0 errors")
+}
+
+func TestNothingAssessed_EmptyAssessments(t *testing.T) {
+	assert.True(t, NothingAssessed(nil))
+	assert.True(t, NothingAssessed([]provider.AssessmentLog{}))
+}
+
+func TestNothingAssessed_AllNotRun(t *testing.T) {
+	assessments := []provider.AssessmentLog{
+		{
+			RequirementID: "REQ-1",
+			Steps:         nil, // no steps → NotRun → nothing assessed
+		},
+	}
+	assert.True(t, NothingAssessed(assessments))
+}
+
+func TestNothingAssessed_WithPassedResult(t *testing.T) {
+	assessments := []provider.AssessmentLog{
+		{
+			RequirementID: "REQ-1",
+			Steps:         []provider.Step{{Result: provider.ResultPassed, Message: "OK"}},
+		},
+	}
+	assert.False(t, NothingAssessed(assessments))
+}
+
+func TestNothingAssessed_WithFailedResult(t *testing.T) {
+	assessments := []provider.AssessmentLog{
+		{
+			RequirementID: "REQ-1",
+			Steps:         []provider.Step{{Result: provider.ResultFailed, Message: "Fail"}},
+		},
+	}
+	assert.False(t, NothingAssessed(assessments))
 }
 
 func TestFormatScanSummary_ControlIDMissing(t *testing.T) {


### PR DESCRIPTION
## Summary

The PR fixes the complyctl reporting error of nothing actually assessed. This change adds a visible `notapplicable` count, and a prominent warning.

## Related Issues
_Inform any issues relevant to this PR. For example:_

- Closes #609 

## Review Hints
