### PR TITLE
chore: consume complypack from quay.io

### DIFF
--- a/.complytime/complytime.yaml
+++ b/.complytime/complytime.yaml
@@ -6,7 +6,7 @@ policies:
     id: ampel-bp
 
 complypacks:
-  - url: http://localhost:8765/complypacks/ampel-bp@v1.0.0
+  - url: quay.io/complytime/complypack-ampel-branch-protection:latest
     id: ampel-bp-pack
 
 targets:


### PR DESCRIPTION
## Summary

Update the complypack URL in `.complytime/complytime.yaml` to consume the
released complypack artifact from quay.io instead of the local mock registry.

## Changes

- Replace `http://localhost:8765/complypacks/ampel-bp@v1.0.0` with
  `quay.io/complytime/complypack-ampel-branch-protection:latest`
- Uses `:tag` syntax consistent with the policy URL and the new OCI
  reference standard (the `@version` notation is now deprecated per #602)

## Context

The policy URL was already updated to `quay.io` in #525, but the complypack
entry was still pointing to the mock registry (it was added later as part of
the complypack-pull feature). The complypack artifact is published at
`quay.io/complytime/complypack-ampel-branch-protection` with tags
`latest` and `v0.4.0`.