### PR TITLE
docs: clarify assessment plan mapping IDs

### DIFF
--- a/docs/TESTING_ENVIRONMENT.md
+++ b/docs/TESTING_ENVIRONMENT.md
@@ -245,6 +245,12 @@ Note: The OPA provider requires the `complyctl-provider-opa`
 binary in `~/.complytime/providers/` (installed by the
 post-create script from `complytime-providers`).
 
+For OPA complypacks, `complytime-mapping.json` entries use the
+Gemara assessment plan `id` in `requirement_id`. This is the ID
+sent to providers during generation. It is different from the
+assessment plan's `requirement-id`, which complyctl resolves later
+when writing scan results.
+
 ## Private Bundles
 
 The devcontainer can serve private Gemara policies through

--- a/pkg/provider/client.go
+++ b/pkg/provider/client.go
@@ -24,7 +24,10 @@ type GenerateRequest struct {
 	ComplypackContentPath string
 }
 
-// AssessmentConfiguration binds a requirement ID to its plan and parameters.
+// AssessmentConfiguration carries the assessment plan selected for provider
+// generation. RequirementID is the Gemara assessment plan id used for matching
+// provider content; it is resolved back to the Gemara requirement-id in scan
+// output.
 type AssessmentConfiguration struct {
 	PlanID        string
 	RequirementID string


### PR DESCRIPTION
## Summary
- Clarifies that OPA complypack `requirement_id` values use Gemara assessment plan `id` values.
- Updates the provider configuration comment to distinguish provider generation IDs from scan output requirement IDs.

## Related Issues
- Closes #622

## Review Hints
- `go test ./internal/policy ./pkg/provider`
- `make build`
- `make lint`
