### PR TITLE
docs: document scan exit-code contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
   `DetectManifestShape()`.
 - `complyctl scan` exits non-zero on operational errors from providers.
   `ScanResponse.errors` proto field surfaces provider-side errors.
+- Exit code contract documented in `complyctl scan --help`, the man
+  page (`docs/man/complyctl.md`), and the quick start guide
+  (`docs/QUICK_START.md`). Exit 0 means scan completed; exit 1 means
+  operational error or zero assessed requirements (#608).
 - Devcontainer configuration for interactive CLI testing during PR
   reviews (`.devcontainer/`, `docs/TESTING_ENVIRONMENT.md`,
   `make test-devcontainer`). Supports GitHub Codespaces, DevPod, and

--- a/README.md
+++ b/README.md
@@ -195,10 +195,11 @@ Output written to `./.complytime/scan/`.
 | Exit Code | Meaning |
 |:---|:---|
 | `0` | Scan completed -- all targets evaluated (findings, if any, are in the report) |
-| non-zero | Operational error -- one or more targets could not be evaluated (partial results written before exit) |
+| non-zero | Operational error -- one or more targets could not be evaluated, or zero requirements assessed (partial results written before exit) |
 
 Policy violations (failed requirements) do **not** cause a non-zero exit.
-Operational errors (missing tools, clone failures, auth errors) do.
+Operational errors (missing tools, clone failures, auth errors, zero
+requirements assessed) do.
 
 ### `doctor`
 

--- a/cmd/complyctl/cli/scan.go
+++ b/cmd/complyctl/cli/scan.go
@@ -57,7 +57,14 @@ When no target is given, --policy-id is required and all matching targets are sc
 Set COMPLYTIME_EXPORT_ENABLED=true to export evidence to a Beacon collector
 after the scan completes. Requires a collector section in complytime.yaml.
 Export works alongside any --format flag. The variable must be set in the
-same shell session or CI job step that invokes complyctl scan.`,
+same shell session or CI job step that invokes complyctl scan.
+
+Exit codes:
+  0  Scan completed (findings are reported, not errors)
+  1  Operational error (provider failure, bad config, zero assessed)
+
+Policy findings are data, not errors. To gate a pipeline on compliance
+results, parse the --format output (SARIF, OSCAL) with your policy engine.`,
 		Example: `  # Scan a specific target (policy inferred if target has exactly one)
   complyctl scan prod
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -151,6 +151,12 @@ complyctl scan my-repo
 
 Output written to `./.complytime/scan/`.
 
+> **Exit codes:** `scan` exits 0 on completion regardless of whether controls
+> passed or failed — policy findings are data, not errors. The command exits
+> non-zero only for operational errors (provider failures, bad configuration,
+> or zero requirements assessed). To gate a pipeline on compliance results,
+> parse the `--format` output (SARIF, OSCAL) with your policy engine.
+
 ## Authentication
 
 **OCI registry:** complyctl uses Docker credential helpers via `oras-credentials-go`. No custom configuration needed — if `docker login` works, `complyctl get` works.

--- a/docs/man/complyctl.md
+++ b/docs/man/complyctl.md
@@ -122,6 +122,16 @@ $ complyctl providers
 # List discovered providers, their health status, and cached complypack versions
 ```
 
+# EXIT CODES
+
+**0**
+: Scan completed successfully. Findings (passed, failed, not applicable) are reported in the output but do not affect the exit code. Policy findings are data, not errors.
+
+**1**
+: An operational error occurred. This includes provider failures, invalid configuration, or zero requirements assessed. Reports and summaries are written before the non-zero exit so partial results remain available.
+
+To gate a pipeline on compliance results, parse the scan output (SARIF, OSCAL) with your policy engine rather than relying on the exit code.
+
 # SEE ALSO
 
 See the upstream project at https://github.com/complytime/complyctl for more detailed documentation.


### PR DESCRIPTION
## Summary

Document the `complyctl scan` exit-code contract explicitly. The tool intentionally exits 0 when controls fail (findings are data, not errors), but this was undocumented and surprised users.

## Changes

- **`cmd/complyctl/cli/scan.go`** — Added "Exit codes" section to `--help` long description
- **`docs/man/complyctl.md`** — Added `# EXIT CODES` man page section
- **`docs/QUICK_START.md`** — Added exit code callout after scan example
- **`README.md`** — Updated exit code table to include zero-assessed condition
- **`CHANGELOG.md`** — Added changelog entry

## Contract

| Exit Code | Meaning |
|-----------|---------|
| `0` | Scan completed — findings reported in output, not errors |
| `1` | Operational error — provider failure, bad config, or zero requirements assessed |

Pipeline gating should parse `--format` output (SARIF, OSCAL) rather than relying on exit codes.

## Related Issues

Closes #608