### PR TITLE
fix: separate assessment plan and requirement IDs

### DIFF
--- a/cmd/complyctl/cli/cli_test.go
+++ b/cmd/complyctl/cli/cli_test.go
@@ -1621,7 +1621,7 @@ func TestBuildReqToComplypackRef_NoCacheState(t *testing.T) {
 	groups := map[string]policy.EvaluatorGroup{
 		"opa": {
 			EvaluatorID: "opa",
-			Configs:     []provider.AssessmentConfiguration{{RequirementID: "req-1"}},
+			Configs:     []provider.AssessmentConfiguration{{PlanID: "plan-1", RequirementID: "req-1"}},
 		},
 	}
 	m := buildReqToComplypackRef(t.TempDir(), groups)
@@ -1648,8 +1648,8 @@ func TestBuildReqToComplypackRef_ResolvesRequirements(t *testing.T) {
 		"opa": {
 			EvaluatorID: "opa",
 			Configs: []provider.AssessmentConfiguration{
-				{RequirementID: "req-1"},
-				{RequirementID: "req-2"},
+				{PlanID: "plan-1", RequirementID: "req-1"},
+				{PlanID: "plan-2", RequirementID: "req-2"},
 			},
 		},
 		"kyverno": {
@@ -1660,8 +1660,8 @@ func TestBuildReqToComplypackRef_ResolvesRequirements(t *testing.T) {
 		},
 	}
 	m := buildReqToComplypackRef(cacheDir, groups)
-	assert.Equal(t, "registry.example.com/complypacks/opa@sha256:abc123", m["req-1"])
-	assert.Equal(t, "registry.example.com/complypacks/opa@sha256:abc123", m["req-2"])
+	assert.Equal(t, "registry.example.com/complypacks/opa@sha256:abc123", m["plan-1"])
+	assert.Equal(t, "registry.example.com/complypacks/opa@sha256:abc123", m["plan-2"])
 	assert.Equal(t, "registry.example.com/complypacks/kyverno@sha256:def456", m["req-3"])
 }
 
@@ -1680,7 +1680,7 @@ func TestBuildReqToComplypackRef_SkipsMissingDigest(t *testing.T) {
 	groups := map[string]policy.EvaluatorGroup{
 		"opa": {
 			EvaluatorID: "opa",
-			Configs:     []provider.AssessmentConfiguration{{RequirementID: "req-1"}},
+			Configs:     []provider.AssessmentConfiguration{{PlanID: "plan-1", RequirementID: "req-1"}},
 		},
 	}
 	m := buildReqToComplypackRef(cacheDir, groups)

--- a/cmd/complyctl/cli/generate.go
+++ b/cmd/complyctl/cli/generate.go
@@ -111,7 +111,7 @@ func (o *generateOptions) generatePolicy(ctx context.Context, cfg *complytime.Wo
 	}
 	defer mgr.Cleanup()
 
-	configs := policy.ExtractAssessmentConfigs(ref.Repository, graph)
+	configs := policy.ExtractAssessmentConfigs(graph)
 	groups := policy.GroupByEvaluator(configs, graph)
 	policyTargets := filterTargetsForPolicy(cfg.Targets, eid)
 

--- a/cmd/complyctl/cli/scan.go
+++ b/cmd/complyctl/cli/scan.go
@@ -951,15 +951,16 @@ func reverseMap(m map[string]string) map[string]string {
 	return r
 }
 
-// buildReqToComplypackRef produces a pre-resolved requirement-ID →
+// buildReqToComplypackRef produces a pre-resolved match-ID →
 // OCI reference (repository@digest) map by composing two lookups:
 //
 //  1. state.Complypacks: evaluator-ID → repository@digest
-//  2. evaluator groups: requirement-ID → evaluator-ID
+//  2. evaluator groups: match-ID → evaluator-ID
 //
-// Resolving the chain here keeps the Evaluator free of evaluator-ID
-// routing concerns and makes it easier to change selection logic later
-// (e.g., per-requirement complypack selection).
+// The match-ID is cfg.MatchID(), which prefers PlanID and falls back to
+// RequirementID. Resolving the chain here keeps the Evaluator free of
+// evaluator-ID routing concerns and makes it easier to change selection
+// logic later (e.g., per-requirement complypack selection).
 func buildReqToComplypackRef(cacheDir string, groups map[string]policy.EvaluatorGroup) map[string]string {
 	m := make(map[string]string)
 	if len(groups) == 0 {

--- a/cmd/complyctl/cli/scan.go
+++ b/cmd/complyctl/cli/scan.go
@@ -992,7 +992,7 @@ func buildReqToComplypackRef(cacheDir string, groups map[string]policy.Evaluator
 			continue
 		}
 		for _, cfg := range group.Configs {
-			m[cfg.RequirementID] = ref
+			m[cfg.MatchID()] = ref
 		}
 	}
 	return m

--- a/cmd/complyctl/cli/scan.go
+++ b/cmd/complyctl/cli/scan.go
@@ -271,7 +271,7 @@ func (o *scanOptions) scanPolicy(ctx context.Context, cfg *complytime.WorkspaceC
 	}
 	fmt.Fprintf(os.Stderr, "Resolved %s version: %s\n", ref.Repository, version)
 
-	assessmentConfigs := policy.ExtractAssessmentConfigs(ref.Repository, graph)
+	assessmentConfigs := policy.ExtractAssessmentConfigs(graph)
 	groups := policy.GroupByEvaluator(assessmentConfigs, graph)
 
 	mgr, err := loadProviders(o.providerDir)
@@ -955,7 +955,7 @@ func reverseMap(m map[string]string) map[string]string {
 // OCI reference (repository@digest) map by composing two lookups:
 //
 //  1. state.Complypacks: evaluator-ID → repository@digest
-//  2. evaluator groups:  requirement-ID → evaluator-ID
+//  2. evaluator groups: requirement-ID → evaluator-ID
 //
 // Resolving the chain here keeps the Evaluator free of evaluator-ID
 // routing concerns and makes it easier to change selection logic later

--- a/cmd/test-provider/main.go
+++ b/cmd/test-provider/main.go
@@ -47,7 +47,7 @@ func (t *testEvaluator) Describe(_ context.Context, _ *provider.DescribeRequest)
 func (t *testEvaluator) Generate(_ context.Context, req *provider.GenerateRequest) (*provider.GenerateResponse, error) {
 	t.requirementIDs = make([]string, 0, len(req.Configuration))
 	for _, cfg := range req.Configuration {
-		t.requirementIDs = append(t.requirementIDs, cfg.RequirementID)
+		t.requirementIDs = append(t.requirementIDs, cfg.PlanID)
 	}
 
 	// Log complypack content path receipt for E2E test observability.

--- a/cmd/test-provider/main.go
+++ b/cmd/test-provider/main.go
@@ -47,7 +47,7 @@ func (t *testEvaluator) Describe(_ context.Context, _ *provider.DescribeRequest)
 func (t *testEvaluator) Generate(_ context.Context, req *provider.GenerateRequest) (*provider.GenerateResponse, error) {
 	t.requirementIDs = make([]string, 0, len(req.Configuration))
 	for _, cfg := range req.Configuration {
-		t.requirementIDs = append(t.requirementIDs, cfg.PlanID)
+		t.requirementIDs = append(t.requirementIDs, cfg.MatchID())
 	}
 
 	// Log complypack content path receipt for E2E test observability.

--- a/internal/cache/complypack_pipeline_test.go
+++ b/internal/cache/complypack_pipeline_test.go
@@ -245,7 +245,7 @@ func (p *capturingProvider) Generate(_ context.Context, req *provider.GenerateRe
 	p.receivedComplypackPath = req.ComplypackContentPath
 	p.requirementIDs = make([]string, 0, len(req.Configuration))
 	for _, cfg := range req.Configuration {
-		p.requirementIDs = append(p.requirementIDs, cfg.PlanID)
+		p.requirementIDs = append(p.requirementIDs, cfg.MatchID())
 	}
 	return &provider.GenerateResponse{Success: true}, nil
 }

--- a/internal/cache/complypack_pipeline_test.go
+++ b/internal/cache/complypack_pipeline_test.go
@@ -245,7 +245,7 @@ func (p *capturingProvider) Generate(_ context.Context, req *provider.GenerateRe
 	p.receivedComplypackPath = req.ComplypackContentPath
 	p.requirementIDs = make([]string, 0, len(req.Configuration))
 	for _, cfg := range req.Configuration {
-		p.requirementIDs = append(p.requirementIDs, cfg.RequirementID)
+		p.requirementIDs = append(p.requirementIDs, cfg.PlanID)
 	}
 	return &provider.GenerateResponse{Success: true}, nil
 }

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -486,7 +486,7 @@ func CheckVariables(cfg *complytime.WorkspaceConfig, healthData []ProviderHealth
 					})
 					continue
 				}
-				configs := policy.ExtractAssessmentConfigs(ref.Repository, graph)
+				configs := policy.ExtractAssessmentConfigs(graph)
 				groups := policy.GroupByEvaluator(configs, graph)
 				for evalID := range groups {
 					evaluatorTargets[evalID] = append(evaluatorTargets[evalID], target)
@@ -839,7 +839,7 @@ func CheckComplypacks(cfg *complytime.WorkspaceConfig, cacheDir string, resolver
 		if err != nil {
 			continue
 		}
-		configs := policy.ExtractAssessmentConfigs(ref.Repository, graph)
+		configs := policy.ExtractAssessmentConfigs(graph)
 		groups := policy.GroupByEvaluator(configs, graph)
 		for evalID := range groups {
 			evaluatorIDs[evalID] = true

--- a/internal/policy/assessment.go
+++ b/internal/policy/assessment.go
@@ -16,13 +16,13 @@ type EvaluatorGroup struct {
 // AssessmentConfiguration entries. EvaluatorID is set as a routing field
 // on the struct — it is not injected into Parameters. Parameters should
 // only carry per-requirement variable overrides for the provider.
-func ExtractAssessmentConfigs(policyID string, graph *DependencyGraph) []provider.AssessmentConfiguration {
+func ExtractAssessmentConfigs(graph *DependencyGraph) []provider.AssessmentConfiguration {
 	configs := make([]provider.AssessmentConfiguration, 0, len(graph.Assessments))
 
 	for _, a := range graph.Assessments {
 		configs = append(configs, provider.AssessmentConfiguration{
-			PlanID:        policyID,
-			RequirementID: a.ID,
+			PlanID:        a.ID,
+			RequirementID: a.RequirementID,
 			Parameters:    a.Parameters,
 			EvaluatorID:   a.EvaluatorID,
 		})

--- a/internal/policy/assessment_test.go
+++ b/internal/policy/assessment_test.go
@@ -17,7 +17,7 @@ func TestExtractAssessmentConfigs_EmptyGraph(t *testing.T) {
 		PolicyID:    "test",
 		Assessments: []Assessment{},
 	}
-	configs := ExtractAssessmentConfigs("test", graph)
+	configs := ExtractAssessmentConfigs(graph)
 	assert.Empty(t, configs)
 }
 
@@ -30,15 +30,16 @@ func TestExtractAssessmentConfigs_ThreeAssessments(t *testing.T) {
 			{ID: "ap-3", RequirementID: "req-3", EvaluatorID: "kube-eval"},
 		},
 	}
-	configs := ExtractAssessmentConfigs("nist", graph)
+	configs := ExtractAssessmentConfigs(graph)
 	require.Len(t, configs, 3)
 
-	assert.Equal(t, "nist", configs[0].PlanID)
-	assert.Equal(t, "ap-1", configs[0].RequirementID, "providers receive plan ID, not requirement ID")
+	assert.Equal(t, "ap-1", configs[0].PlanID)
+	assert.Equal(t, "req-1", configs[0].RequirementID)
 	assert.Equal(t, "openscap", configs[0].EvaluatorID)
 	assert.Equal(t, "xccdf_ssg", configs[0].Parameters["profile"])
 
-	assert.Equal(t, "ap-2", configs[1].RequirementID)
+	assert.Equal(t, "ap-2", configs[1].PlanID)
+	assert.Equal(t, "req-2", configs[1].RequirementID)
 	assert.Equal(t, "kube-eval", configs[2].EvaluatorID)
 }
 

--- a/pkg/provider/client.go
+++ b/pkg/provider/client.go
@@ -37,6 +37,16 @@ type AssessmentConfiguration struct {
 	EvaluatorID string
 }
 
+// MatchID returns the identifier providers should use to match generated
+// content. Assessment plan IDs take precedence when present; global evaluator
+// configurations can fall back to requirement IDs.
+func (c AssessmentConfiguration) MatchID() string {
+	if c.PlanID != "" {
+		return c.PlanID
+	}
+	return c.RequirementID
+}
+
 // GenerateResponse confirms whether policy preparation succeeded.
 type GenerateResponse struct {
 	Success      bool

--- a/pkg/provider/client.go
+++ b/pkg/provider/client.go
@@ -24,10 +24,10 @@ type GenerateRequest struct {
 	ComplypackContentPath string
 }
 
-// AssessmentConfiguration carries the assessment plan selected for provider
-// generation. RequirementID is the Gemara assessment plan id used for matching
-// provider content; it is resolved back to the Gemara requirement-id in scan
-// output.
+// AssessmentConfiguration carries one Gemara assessment plan selected for
+// provider generation. PlanID is the assessment plan id used by providers for
+// matching provider content. RequirementID is the Gemara requirement-id used
+// later for report output.
 type AssessmentConfiguration struct {
 	PlanID        string
 	RequirementID string

--- a/pkg/provider/client_test.go
+++ b/pkg/provider/client_test.go
@@ -12,6 +12,16 @@ import (
 	"github.com/complytime/complyctl/pkg/provider"
 )
 
+func TestAssessmentConfiguration_MatchID(t *testing.T) {
+	assert.Equal(t, "plan-1", provider.AssessmentConfiguration{
+		PlanID:        "plan-1",
+		RequirementID: "req-1",
+	}.MatchID())
+	assert.Equal(t, "req-1", provider.AssessmentConfiguration{
+		RequirementID: "req-1",
+	}.MatchID())
+}
+
 func TestMockClient_Describe(t *testing.T) {
 	mock := newMockClient()
 
@@ -43,7 +53,7 @@ func TestMockClient_Scan(t *testing.T) {
 	genReq := &provider.GenerateRequest{
 		Configuration: []provider.AssessmentConfiguration{
 			{PlanID: "plan-1", RequirementID: "req-1"},
-			{PlanID: "plan-1", RequirementID: "req-2"},
+			{PlanID: "plan-2", RequirementID: "req-2"},
 		},
 	}
 	_, err := mock.Generate(context.Background(), genReq)
@@ -57,7 +67,7 @@ func TestMockClient_Scan(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, resp.Assessments, 2)
 
-	expectedIDs := []string{"req-1", "req-2"}
+	expectedIDs := []string{"plan-1", "plan-2"}
 	for i, a := range resp.Assessments {
 		assert.Equal(t, expectedIDs[i], a.RequirementID)
 		assert.Equal(t, "mock passed", a.Message)
@@ -134,6 +144,6 @@ func TestMockClient_Scan_ResponseMapping(t *testing.T) {
 	resp, err := mock.Scan(context.Background(), scanReq)
 	require.NoError(t, err)
 	require.Len(t, resp.Assessments, 1)
-	assert.Equal(t, "single-req", resp.Assessments[0].RequirementID)
+	assert.Equal(t, "plan-1", resp.Assessments[0].RequirementID)
 	assert.Equal(t, "mock-check", resp.Assessments[0].Steps[0].Name)
 }

--- a/pkg/provider/mock_client_test.go
+++ b/pkg/provider/mock_client_test.go
@@ -12,10 +12,10 @@ import (
 var _ provider.Provider = (*mockClient)(nil)
 
 // mockClient provides an in-memory mock provider.Provider for testing only.
-// Like real providers, it stores requirement IDs during Generate and uses
+// Like real providers, it stores match IDs during Generate and uses
 // them during Scan (R47).
 type mockClient struct {
-	requirementIDs        []string
+	matchIDs              []string
 	complypackContentPath string
 }
 
@@ -32,19 +32,19 @@ func (m *mockClient) Describe(_ context.Context, _ *provider.DescribeRequest) (*
 }
 
 func (m *mockClient) Generate(_ context.Context, req *provider.GenerateRequest) (*provider.GenerateResponse, error) {
-	m.requirementIDs = make([]string, 0, len(req.Configuration))
+	m.matchIDs = make([]string, 0, len(req.Configuration))
 	for _, cfg := range req.Configuration {
-		m.requirementIDs = append(m.requirementIDs, cfg.RequirementID)
+		m.matchIDs = append(m.matchIDs, cfg.MatchID())
 	}
 	m.complypackContentPath = req.ComplypackContentPath
 	return &provider.GenerateResponse{Success: true}, nil
 }
 
 func (m *mockClient) Scan(_ context.Context, _ *provider.ScanRequest) (*provider.ScanResponse, error) {
-	assessments := make([]provider.AssessmentLog, 0, len(m.requirementIDs))
-	for _, reqID := range m.requirementIDs {
+	assessments := make([]provider.AssessmentLog, 0, len(m.matchIDs))
+	for _, matchID := range m.matchIDs {
 		assessments = append(assessments, provider.AssessmentLog{
-			RequirementID: reqID,
+			RequirementID: matchID,
 			Steps: []provider.Step{
 				{Name: "mock-check", Result: provider.ResultPassed, Message: "mock check passed"},
 			},


### PR DESCRIPTION
## Summary
- Populates `AssessmentConfiguration.PlanID` from the Gemara assessment plan `id`.
- Keeps `AssessmentConfiguration.RequirementID` as the Gemara `requirement-id`.
- Adds `AssessmentConfiguration.MatchID()` so provider matching prefers `PlanID` and falls back to `RequirementID` when no plan is defined.
- Updates provider test helpers and complypack reference mapping to use the shared match ID behavior.

## Related Issues
- Closes #622
- Follow-up to #624

## Review Hints
- `go test ./internal/policy ./pkg/provider ./cmd/complyctl/cli ./internal/cache ./internal/doctor`
- `make build`
- `make lint`
- `make test-unit`
- `git diff --check`
