### PR TITLE
fix: migrate @version policy URLs to :tag syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Lists discovered scanning providers with their evaluator ID, path, health status
 ```yaml
 # .complytime/complytime.yaml
 policies:
-  - url: registry.example.com/policies/nist-800-53-r5@v1.0.0
+  - url: registry.example.com/policies/nist-800-53-r5:v1.0.0
     id: nist
   - url: registry.example.com/policies/cis-benchmark
 variables:
@@ -245,7 +245,7 @@ targets:
 
 | Field | Description |
 |:---|:---|
-| `policies[].url` | Full OCI reference (registry + repository + optional `@version`) |
+| `policies[].url` | Full OCI reference (registry + repository + optional `:tag`) |
 | `policies[].id` | Optional shortname; if omitted, derived from last path segment of URL |
 | `variables` | Workspace-scoped constants passed to providers via Generate RPC |
 | `targets[].id` | Scan target identifier |

--- a/cmd/complyctl/cli/cli_test.go
+++ b/cmd/complyctl/cli/cli_test.go
@@ -41,7 +41,7 @@ func writeWorkspaceConfig(t *testing.T, content string) {
 }
 
 const minimalConfig = `policies:
-  - url: registry.example.com/policies/test-policy@v1.0
+  - url: registry.example.com/policies/test-policy:v1.0
     id: test-policy
 targets:
   - id: local
@@ -67,7 +67,7 @@ func TestScanOptions_Run_NoWorkspace(t *testing.T) {
 func TestScanOptions_Run_NoTargets(t *testing.T) {
 	chdirTemp(t)
 	writeWorkspaceConfig(t, `policies:
-  - url: registry.example.com/policies/test@v1.0
+  - url: registry.example.com/policies/test:v1.0
 targets: []
 `)
 	o := &scanOptions{
@@ -193,9 +193,9 @@ func TestMaybeExport_EnvVarParsing(t *testing.T) {
 
 // multiPolicyConfig has a target referencing two policies for disambiguation tests.
 const multiPolicyConfig = `policies:
-  - url: registry.example.com/policies/nist@v1.0
+  - url: registry.example.com/policies/nist:v1.0
     id: nist
-  - url: registry.example.com/policies/cis@v1.0
+  - url: registry.example.com/policies/cis:v1.0
     id: cis
 targets:
   - id: prod
@@ -670,10 +670,10 @@ func TestGetOptions_Run_NoWorkspace(t *testing.T) {
 func TestGetOptions_Run_WithComplypacks(t *testing.T) {
 	chdirTemp(t)
 	writeWorkspaceConfig(t, `policies:
-  - url: registry.example.com/policies/test-policy@v1.0
+  - url: registry.example.com/policies/test-policy:v1.0
     id: test-policy
 complypacks:
-  - url: registry.example.com/packs/test-pack@v1.0
+  - url: registry.example.com/packs/test-pack:v1.0
     id: test-pack
 targets:
   - id: local
@@ -1472,7 +1472,7 @@ func TestDoctorCmd_RunE_ValidWorkspace(t *testing.T) {
 	require.NoError(t, os.MkdirAll(configDir, 0o750))
 	require.NoError(t, os.WriteFile(
 		filepath.Join(configDir, "complytime.yaml"),
-		[]byte("policies:\n  - url: registry.example.com/p@v1\ntargets: []"), 0o600))
+		[]byte("policies:\n  - url: registry.example.com/p:v1\ntargets: []"), 0o600))
 
 	common := &Common{Workspace: dir}
 	cmd := doctorCmd(common)

--- a/cmd/complyctl/cli/init.go
+++ b/cmd/complyctl/cli/init.go
@@ -89,7 +89,7 @@ const emptyConfigTemplate = `# complytime.yaml - workspace configuration
 #
 # Add policies using the format below:
 #   policies:
-#     - url: registry.example.com/policies/my-policy@v1.0
+#     - url: registry.example.com/policies/my-policy:v1.0
 #       id: my-policy    # optional; auto-derived from URL path if omitted
 #
 # Add targets that reference policies by effective ID:
@@ -115,7 +115,7 @@ func promptPolicies() []complytime.PolicyEntry {
 	seenURLs := make(map[string]bool)
 
 	for i := 1; ; i++ {
-		fmt.Printf("  Policy %d URL (e.g. registry.com/policies/nist-800-53-r5@v1.0): ", i)
+		fmt.Printf("  Policy %d URL (e.g. registry.com/policies/nist-800-53-r5:v1.0): ", i)
 		var url string
 		if _, err := fmt.Scanln(&url); err != nil || strings.TrimSpace(url) == "" {
 			break

--- a/internal/complytime/config_test.go
+++ b/internal/complytime/config_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestParsePolicyRef_FullReference(t *testing.T) {
-	ref, err := complytime.ParsePolicyRef("registry.com/policies/nist-800-53-r5@v1.2.3")
+	ref, err := complytime.ParsePolicyRef("registry.com/policies/nist-800-53-r5:v1.2.3")
 	require.NoError(t, err)
 	assert.Equal(t, "registry.com", ref.Registry)
 	assert.Equal(t, "policies/nist-800-53-r5", ref.Repository)
@@ -33,7 +33,7 @@ func TestParsePolicyRef_NoVersion(t *testing.T) {
 }
 
 func TestParsePolicyRef_WithHTTPScheme(t *testing.T) {
-	ref, err := complytime.ParsePolicyRef("http://localhost:5000/policies/test@v1.0")
+	ref, err := complytime.ParsePolicyRef("http://localhost:5000/policies/test:v1.0")
 	require.NoError(t, err)
 	assert.Equal(t, "http://localhost:5000", ref.Registry)
 	assert.Equal(t, "policies/test", ref.Repository)
@@ -42,7 +42,7 @@ func TestParsePolicyRef_WithHTTPScheme(t *testing.T) {
 }
 
 func TestParsePolicyRef_WithHTTPSScheme(t *testing.T) {
-	ref, err := complytime.ParsePolicyRef("https://ghcr.io/org/policy@latest")
+	ref, err := complytime.ParsePolicyRef("https://ghcr.io/org/policy:latest")
 	require.NoError(t, err)
 	assert.Equal(t, "https://ghcr.io", ref.Registry)
 	assert.Equal(t, "org/policy", ref.Repository)
@@ -79,7 +79,7 @@ func TestParsePolicyRef_BareIDWithDigest(t *testing.T) {
 }
 
 func TestParsePolicyRef_PortInRegistry(t *testing.T) {
-	ref, err := complytime.ParsePolicyRef("localhost:5000/policy@v2")
+	ref, err := complytime.ParsePolicyRef("localhost:5000/policy:v2")
 	require.NoError(t, err)
 	assert.Equal(t, "localhost:5000", ref.Registry)
 	assert.Equal(t, "policy", ref.Repository)
@@ -219,42 +219,42 @@ func TestParsePolicyRef_NoDeprecationWarning_BareID(t *testing.T) {
 }
 
 func TestPolicyEntry_EffectiveID_ExplicitID(t *testing.T) {
-	p := complytime.PolicyEntry{URL: "registry.com/policies/nist-800-53-r5@v1.0", ID: "nist"}
+	p := complytime.PolicyEntry{URL: "registry.com/policies/nist-800-53-r5:v1.0", ID: "nist"}
 	assert.Equal(t, "nist", p.EffectiveID())
 }
 
 func TestPolicyEntry_EffectiveID_DerivedFromURL(t *testing.T) {
-	p := complytime.PolicyEntry{URL: "registry.com/policies/nist-800-53-r5@v1.0"}
+	p := complytime.PolicyEntry{URL: "registry.com/policies/nist-800-53-r5:v1.0"}
 	assert.Equal(t, "nist-800-53-r5", p.EffectiveID())
 }
 
 func TestPolicyEntry_EffectiveID_NestedPath(t *testing.T) {
-	p := complytime.PolicyEntry{URL: "registry.com/org/team/cis-fedora@v2.0"}
+	p := complytime.PolicyEntry{URL: "registry.com/org/team/cis-fedora:v2.0"}
 	assert.Equal(t, "cis-fedora", p.EffectiveID())
 }
 
 func TestFindPolicy_ByEffectiveID(t *testing.T) {
 	policies := []complytime.PolicyEntry{
-		{URL: "registry.com/policies/nist@v1.0", ID: "nist"},
-		{URL: "ghcr.io/cis@v2.0"},
+		{URL: "registry.com/policies/nist:v1.0", ID: "nist"},
+		{URL: "ghcr.io/cis:v2.0"},
 	}
 	entry, ok := complytime.FindPolicy(policies, "nist")
 	assert.True(t, ok)
-	assert.Equal(t, "registry.com/policies/nist@v1.0", entry.URL)
+	assert.Equal(t, "registry.com/policies/nist:v1.0", entry.URL)
 }
 
 func TestFindPolicy_ByDerivedID(t *testing.T) {
 	policies := []complytime.PolicyEntry{
-		{URL: "registry.com/policies/nist-800-53-r5@v1.0"},
+		{URL: "registry.com/policies/nist-800-53-r5:v1.0"},
 	}
 	entry, ok := complytime.FindPolicy(policies, "nist-800-53-r5")
 	assert.True(t, ok)
-	assert.Equal(t, "registry.com/policies/nist-800-53-r5@v1.0", entry.URL)
+	assert.Equal(t, "registry.com/policies/nist-800-53-r5:v1.0", entry.URL)
 }
 
 func TestFindPolicy_NotFound(t *testing.T) {
 	policies := []complytime.PolicyEntry{
-		{URL: "registry.com/policies/nist@v1.0"},
+		{URL: "registry.com/policies/nist:v1.0"},
 	}
 	_, ok := complytime.FindPolicy(policies, "nonexistent")
 	assert.False(t, ok)
@@ -263,7 +263,7 @@ func TestFindPolicy_NotFound(t *testing.T) {
 func TestValidate_Valid(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
 		Policies: []complytime.PolicyEntry{
-			{URL: "registry.com/policies/nist@v1.0", ID: "nist"},
+			{URL: "registry.com/policies/nist:v1.0", ID: "nist"},
 		},
 		Targets: []complytime.TargetConfig{{
 			ID:       "local",
@@ -276,7 +276,7 @@ func TestValidate_Valid(t *testing.T) {
 func TestValidate_ValidWithDerivedID(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
 		Policies: []complytime.PolicyEntry{
-			{URL: "registry.com/policies/nist-800-53-r5@v1.0"},
+			{URL: "registry.com/policies/nist-800-53-r5:v1.0"},
 		},
 		Targets: []complytime.TargetConfig{{
 			ID:       "local",
@@ -305,8 +305,8 @@ func TestValidate_EmptyURL(t *testing.T) {
 func TestValidate_DuplicateURL(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
 		Policies: []complytime.PolicyEntry{
-			{URL: "registry.com/a@v1"},
-			{URL: "registry.com/a@v1"},
+			{URL: "registry.com/a:v1"},
+			{URL: "registry.com/a:v1"},
 		},
 	}
 	err := complytime.Validate(cfg)
@@ -317,8 +317,8 @@ func TestValidate_DuplicateURL(t *testing.T) {
 func TestValidate_DuplicateEffectiveID(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
 		Policies: []complytime.PolicyEntry{
-			{URL: "registry.com/a/nist@v1"},
-			{URL: "ghcr.io/b/nist@v2"},
+			{URL: "registry.com/a/nist:v1"},
+			{URL: "ghcr.io/b/nist:v2"},
 		},
 	}
 	err := complytime.Validate(cfg)
@@ -329,8 +329,8 @@ func TestValidate_DuplicateEffectiveID(t *testing.T) {
 func TestValidate_DuplicateExplicitID(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
 		Policies: []complytime.PolicyEntry{
-			{URL: "registry.com/a@v1", ID: "same"},
-			{URL: "ghcr.io/b@v2", ID: "same"},
+			{URL: "registry.com/a:v1", ID: "same"},
+			{URL: "ghcr.io/b:v2", ID: "same"},
 		},
 	}
 	err := complytime.Validate(cfg)
@@ -341,7 +341,7 @@ func TestValidate_DuplicateExplicitID(t *testing.T) {
 func TestValidate_TargetPolicyNotInList(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
 		Policies: []complytime.PolicyEntry{
-			{URL: "registry.com/a@v1", ID: "nist"},
+			{URL: "registry.com/a:v1", ID: "nist"},
 		},
 		Targets: []complytime.TargetConfig{{
 			ID:       "local",
@@ -356,7 +356,7 @@ func TestValidate_TargetPolicyNotInList(t *testing.T) {
 func TestValidate_DuplicateTarget(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
 		Policies: []complytime.PolicyEntry{
-			{URL: "registry.com/a@v1", ID: "nist"},
+			{URL: "registry.com/a:v1", ID: "nist"},
 		},
 		Targets: []complytime.TargetConfig{
 			{ID: "local", Policies: []string{"nist"}},
@@ -371,7 +371,7 @@ func TestValidate_DuplicateTarget(t *testing.T) {
 func TestValidate_TargetNoPolicies(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
 		Policies: []complytime.PolicyEntry{
-			{URL: "registry.com/a@v1"},
+			{URL: "registry.com/a:v1"},
 		},
 		Targets: []complytime.TargetConfig{{ID: "local"}},
 	}
@@ -382,8 +382,8 @@ func TestValidate_TargetNoPolicies(t *testing.T) {
 
 func TestPolicyIDs(t *testing.T) {
 	policies := []complytime.PolicyEntry{
-		{URL: "registry.com/policies/nist@v1.0", ID: "nist"},
-		{URL: "ghcr.io/cis-fedora@v2.0"},
+		{URL: "registry.com/policies/nist:v1.0", ID: "nist"},
+		{URL: "ghcr.io/cis-fedora:v2.0"},
 	}
 	m := complytime.PolicyIDs(policies)
 	assert.Len(t, m, 2)
@@ -397,7 +397,7 @@ func TestResolveEnvVars_Substitution(t *testing.T) {
 	t.Setenv("CT_TEST_HOST", "db.example.com")
 
 	cfg := &complytime.WorkspaceConfig{
-		Policies: []complytime.PolicyEntry{{URL: "registry.com/p1@v1"}},
+		Policies: []complytime.PolicyEntry{{URL: "registry.com/p1:v1"}},
 		Targets: []complytime.TargetConfig{{
 			ID:       "target1",
 			Policies: []string{"p1"},
@@ -418,7 +418,7 @@ func TestResolveEnvVars_Substitution(t *testing.T) {
 //nolint:gosec // G101: test data, not real credentials
 func TestResolveEnvVars_UnsetVariableErrors(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
-		Policies: []complytime.PolicyEntry{{URL: "registry.com/p1@v1"}},
+		Policies: []complytime.PolicyEntry{{URL: "registry.com/p1:v1"}},
 		Targets: []complytime.TargetConfig{{
 			ID:       "target1",
 			Policies: []string{"p1"},
@@ -439,7 +439,7 @@ func TestResolveEnvVars_MultipleRefsInOneValue(t *testing.T) {
 	t.Setenv("CT_HOST", "example.com")
 
 	cfg := &complytime.WorkspaceConfig{
-		Policies: []complytime.PolicyEntry{{URL: "registry.com/p1@v1"}},
+		Policies: []complytime.PolicyEntry{{URL: "registry.com/p1:v1"}},
 		Targets: []complytime.TargetConfig{{
 			ID:       "target1",
 			Policies: []string{"p1"},
@@ -455,7 +455,7 @@ func TestResolveEnvVars_MultipleRefsInOneValue(t *testing.T) {
 
 func TestResolveEnvVars_NoVariables(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
-		Policies: []complytime.PolicyEntry{{URL: "registry.com/p1@v1"}},
+		Policies: []complytime.PolicyEntry{{URL: "registry.com/p1:v1"}},
 		Targets: []complytime.TargetConfig{{
 			ID:       "target1",
 			Policies: []string{"p1"},
@@ -469,7 +469,7 @@ func TestResolveEnvVars_EmptyValue(t *testing.T) {
 	t.Setenv("CT_EMPTY", "")
 
 	cfg := &complytime.WorkspaceConfig{
-		Policies: []complytime.PolicyEntry{{URL: "registry.com/p1@v1"}},
+		Policies: []complytime.PolicyEntry{{URL: "registry.com/p1:v1"}},
 		Targets: []complytime.TargetConfig{{
 			ID:       "target1",
 			Policies: []string{"p1"},
@@ -490,7 +490,7 @@ func TestResolveEnvVars_CollectorAuth(t *testing.T) {
 	t.Setenv("CT_TOKEN_EP", "https://idp.example.com/token")
 
 	cfg := &complytime.WorkspaceConfig{
-		Policies: []complytime.PolicyEntry{{URL: "registry.com/p1@v1"}},
+		Policies: []complytime.PolicyEntry{{URL: "registry.com/p1:v1"}},
 		Collector: &complytime.CollectorConfig{
 			Endpoint: "localhost:4317",
 			Auth: &complytime.AuthConfig{
@@ -510,7 +510,7 @@ func TestResolveEnvVars_CollectorAuth(t *testing.T) {
 //nolint:gosec // G101: test data, not real credentials
 func TestResolveEnvVars_CollectorAuthUnset(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
-		Policies: []complytime.PolicyEntry{{URL: "registry.com/p1@v1"}},
+		Policies: []complytime.PolicyEntry{{URL: "registry.com/p1:v1"}},
 		Collector: &complytime.CollectorConfig{
 			Endpoint: "localhost:4317",
 			Auth: &complytime.AuthConfig{
@@ -528,7 +528,7 @@ func TestResolveEnvVars_CollectorAuthUnset(t *testing.T) {
 
 func TestResolveEnvVars_CollectorNoAuth(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
-		Policies: []complytime.PolicyEntry{{URL: "registry.com/p1@v1"}},
+		Policies: []complytime.PolicyEntry{{URL: "registry.com/p1:v1"}},
 		Collector: &complytime.CollectorConfig{
 			Endpoint: "localhost:4317",
 		},
@@ -539,7 +539,7 @@ func TestResolveEnvVars_CollectorNoAuth(t *testing.T) {
 
 func TestResolveEnvVars_NoCollector(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
-		Policies: []complytime.PolicyEntry{{URL: "registry.com/p1@v1"}},
+		Policies: []complytime.PolicyEntry{{URL: "registry.com/p1:v1"}},
 	}
 
 	require.NoError(t, complytime.ResolveEnvVars(cfg))
@@ -549,7 +549,7 @@ func TestValidate_UnsupportedVersion(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
 		Version: 99,
 		Policies: []complytime.PolicyEntry{
-			{URL: "registry.com/a@v1", ID: "a"},
+			{URL: "registry.com/a:v1", ID: "a"},
 		},
 	}
 	err := complytime.Validate(cfg)
@@ -561,7 +561,7 @@ func TestValidate_CurrentVersion(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
 		Version: complytime.CurrentWorkspaceVersion,
 		Policies: []complytime.PolicyEntry{
-			{URL: "registry.com/a@v1", ID: "a"},
+			{URL: "registry.com/a:v1", ID: "a"},
 		},
 		Targets: []complytime.TargetConfig{{
 			ID:       "local",
@@ -575,7 +575,7 @@ func TestValidate_ZeroVersionAllowed(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
 		Version: 0,
 		Policies: []complytime.PolicyEntry{
-			{URL: "registry.com/a@v1", ID: "a"},
+			{URL: "registry.com/a:v1", ID: "a"},
 		},
 		Targets: []complytime.TargetConfig{{
 			ID:       "local",
@@ -588,7 +588,7 @@ func TestValidate_ZeroVersionAllowed(t *testing.T) {
 // T254: ValidateOCIRef tests
 
 func TestValidateOCIRef_ValidFullRef(t *testing.T) {
-	assert.NoError(t, complytime.ValidateOCIRef("registry.com/policies/nist-800-53-r5@v1.0"))
+	assert.NoError(t, complytime.ValidateOCIRef("registry.com/policies/nist-800-53-r5:v1.0"))
 }
 
 func TestValidateOCIRef_ValidWithTag(t *testing.T) {
@@ -600,19 +600,19 @@ func TestValidateOCIRef_ValidWithDigest(t *testing.T) {
 }
 
 func TestValidateOCIRef_ValidWithPort(t *testing.T) {
-	assert.NoError(t, complytime.ValidateOCIRef("localhost:5000/policies/test@v1.0"))
+	assert.NoError(t, complytime.ValidateOCIRef("localhost:5000/policies/test:v1.0"))
 }
 
 func TestValidateOCIRef_ValidHTTPS(t *testing.T) {
-	assert.NoError(t, complytime.ValidateOCIRef("https://ghcr.io/org/policy@latest"))
+	assert.NoError(t, complytime.ValidateOCIRef("https://ghcr.io/org/policy:latest"))
 }
 
 func TestValidateOCIRef_ValidHTTP(t *testing.T) {
-	assert.NoError(t, complytime.ValidateOCIRef("http://localhost:5000/policies/test@v1.0"))
+	assert.NoError(t, complytime.ValidateOCIRef("http://localhost:5000/policies/test:v1.0"))
 }
 
 func TestValidateOCIRef_ValidNestedPath(t *testing.T) {
-	assert.NoError(t, complytime.ValidateOCIRef("registry.com/org/team/policy@v2.0"))
+	assert.NoError(t, complytime.ValidateOCIRef("registry.com/org/team/policy:v2.0"))
 }
 
 func TestValidateOCIRef_RejectEmpty(t *testing.T) {
@@ -658,7 +658,7 @@ func TestValidateOCIRef_RejectBareWord(t *testing.T) {
 }
 
 func TestValidateOCIRef_RejectNoRegistryHost(t *testing.T) {
-	err := complytime.ValidateOCIRef("plaindir/repo@v1")
+	err := complytime.ValidateOCIRef("plaindir/repo:v1")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must include a registry host")
 }
@@ -693,11 +693,11 @@ func TestValidate_ShellInjectionInURL(t *testing.T) {
 func TestValidate_ComplypackDuplicateURL(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
 		Policies: []complytime.PolicyEntry{
-			{URL: "registry.com/policies/nist@v1.0", ID: "nist"},
+			{URL: "registry.com/policies/nist:v1.0", ID: "nist"},
 		},
 		Complypacks: []complytime.PolicyEntry{
-			{URL: "ghcr.io/org/pack-a@v1"},
-			{URL: "ghcr.io/org/pack-a@v1"},
+			{URL: "ghcr.io/org/pack-a:v1"},
+			{URL: "ghcr.io/org/pack-a:v1"},
 		},
 	}
 	err := complytime.Validate(cfg)
@@ -708,11 +708,11 @@ func TestValidate_ComplypackDuplicateURL(t *testing.T) {
 func TestValidate_ComplypackDuplicateEffectiveID(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
 		Policies: []complytime.PolicyEntry{
-			{URL: "registry.com/policies/nist@v1.0", ID: "nist"},
+			{URL: "registry.com/policies/nist:v1.0", ID: "nist"},
 		},
 		Complypacks: []complytime.PolicyEntry{
-			{URL: "registry.com/org/mypack@v1"},
-			{URL: "ghcr.io/other/mypack@v2"},
+			{URL: "registry.com/org/mypack:v1"},
+			{URL: "ghcr.io/other/mypack:v2"},
 		},
 	}
 	err := complytime.Validate(cfg)
@@ -723,7 +723,7 @@ func TestValidate_ComplypackDuplicateEffectiveID(t *testing.T) {
 func TestValidate_ComplypackAndPolicySameURL_Allowed(t *testing.T) {
 	// Cross-list independence: the same URL can appear in both
 	// policies and complypacks without conflict.
-	sharedURL := "ghcr.io/org/shared-artifact@v1.0"
+	sharedURL := "ghcr.io/org/shared-artifact:v1.0"
 	cfg := &complytime.WorkspaceConfig{
 		Policies: []complytime.PolicyEntry{
 			{URL: sharedURL, ID: "shared-policy"},
@@ -760,7 +760,7 @@ func TestValidate_ComplypackInvalidOCIRef(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &complytime.WorkspaceConfig{
 				Policies: []complytime.PolicyEntry{
-					{URL: "registry.com/policies/nist@v1.0", ID: "nist"},
+					{URL: "registry.com/policies/nist:v1.0", ID: "nist"},
 				},
 				Complypacks: []complytime.PolicyEntry{
 					{URL: tt.url},
@@ -776,7 +776,7 @@ func TestValidate_ComplypackInvalidOCIRef(t *testing.T) {
 func TestValidate_ComplypackEmptyURL(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
 		Policies: []complytime.PolicyEntry{
-			{URL: "registry.com/policies/nist@v1.0", ID: "nist"},
+			{URL: "registry.com/policies/nist:v1.0", ID: "nist"},
 		},
 		Complypacks: []complytime.PolicyEntry{
 			{URL: ""},
@@ -800,7 +800,7 @@ func TestValidate_ComplypackEmpty_Allowed(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &complytime.WorkspaceConfig{
 				Policies: []complytime.PolicyEntry{
-					{URL: "registry.com/policies/nist@v1.0", ID: "nist"},
+					{URL: "registry.com/policies/nist:v1.0", ID: "nist"},
 				},
 				Complypacks: tt.complypacks,
 				Targets: []complytime.TargetConfig{{
@@ -818,12 +818,12 @@ func TestLoadFrom_WithComplypacks(t *testing.T) {
 	configPath := filepath.Join(dir, "complytime.yml")
 
 	yamlContent := `policies:
-  - url: registry.com/policies/nist@v1.0
+  - url: registry.com/policies/nist:v1.0
     id: nist
 complypacks:
-  - url: ghcr.io/org/complypack-rhel9@v1.0
+  - url: ghcr.io/org/complypack-rhel9:v1.0
     id: rhel9
-  - url: ghcr.io/org/complypack-ubuntu@v2.0
+  - url: ghcr.io/org/complypack-ubuntu:v2.0
 targets:
   - id: local
     policies:
@@ -837,13 +837,13 @@ targets:
 
 	// Verify policies parsed correctly
 	require.Len(t, cfg.Policies, 1)
-	assert.Equal(t, "registry.com/policies/nist@v1.0", cfg.Policies[0].URL)
+	assert.Equal(t, "registry.com/policies/nist:v1.0", cfg.Policies[0].URL)
 
 	// Verify complypacks parsed correctly
 	require.Len(t, cfg.Complypacks, 2)
-	assert.Equal(t, "ghcr.io/org/complypack-rhel9@v1.0", cfg.Complypacks[0].URL)
+	assert.Equal(t, "ghcr.io/org/complypack-rhel9:v1.0", cfg.Complypacks[0].URL)
 	assert.Equal(t, "rhel9", cfg.Complypacks[0].ID)
-	assert.Equal(t, "ghcr.io/org/complypack-ubuntu@v2.0", cfg.Complypacks[1].URL)
+	assert.Equal(t, "ghcr.io/org/complypack-ubuntu:v2.0", cfg.Complypacks[1].URL)
 	assert.Empty(t, cfg.Complypacks[1].ID)
 
 	// Verify EffectiveID derivation works for the entry without explicit ID
@@ -873,7 +873,7 @@ func TestLoadFrom_InvalidComplypackURL(t *testing.T) {
 	configPath := filepath.Join(dir, "complytime.yml")
 
 	yamlContent := `policies:
-  - url: registry.com/policies/nist@v1.0
+  - url: registry.com/policies/nist:v1.0
     id: nist
 complypacks:
   - url: "   "
@@ -921,7 +921,7 @@ func TestLoadFrom_WithoutComplypacks(t *testing.T) {
 
 	// Existing config format without complypacks — must still work unchanged.
 	yamlContent := `policies:
-  - url: registry.com/policies/nist@v1.0
+  - url: registry.com/policies/nist:v1.0
     id: nist
 targets:
   - id: local
@@ -936,7 +936,7 @@ targets:
 
 	// Policies load as before
 	require.Len(t, cfg.Policies, 1)
-	assert.Equal(t, "registry.com/policies/nist@v1.0", cfg.Policies[0].URL)
+	assert.Equal(t, "registry.com/policies/nist:v1.0", cfg.Policies[0].URL)
 
 	// Complypacks is nil/empty when not present in YAML
 	assert.Empty(t, cfg.Complypacks)

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -113,7 +113,7 @@ func TestCheckPolicyVersions_NoPolicies(t *testing.T) {
 
 func TestCheckPolicyVersions_NilResolver(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
-		Policies: []complytime.PolicyEntry{{URL: "reg.io/policies/nist@v1.0.0"}},
+		Policies: []complytime.PolicyEntry{{URL: "reg.io/policies/nist:v1.0.0"}},
 	}
 	results := CheckPolicyVersions(cfg, "/tmp", nil)
 	if results != nil {
@@ -133,7 +133,7 @@ func TestCheckPolicyVersions_PolicyAtLatest(t *testing.T) {
 
 	cfg := &complytime.WorkspaceConfig{
 		Policies: []complytime.PolicyEntry{
-			{URL: "reg.io/policies/nist@v1.0.0"},
+			{URL: "reg.io/policies/nist:v1.0.0"},
 		},
 	}
 
@@ -195,7 +195,7 @@ func TestCheckPolicyVersions_PinnedMatchesCached_LatestDiffers(t *testing.T) {
 
 	cfg := &complytime.WorkspaceConfig{
 		Policies: []complytime.PolicyEntry{
-			{URL: "reg.io/policies/nist@v1.0.0"},
+			{URL: "reg.io/policies/nist:v1.0.0"},
 		},
 	}
 
@@ -263,7 +263,7 @@ func TestCheckPolicyVersions_PinnedMismatchCached(t *testing.T) {
 
 	cfg := &complytime.WorkspaceConfig{
 		Policies: []complytime.PolicyEntry{
-			{URL: "reg.io/policies/nist@v2.0.0"},
+			{URL: "reg.io/policies/nist:v2.0.0"},
 		},
 	}
 
@@ -295,7 +295,7 @@ func TestCheckPolicyVersions_NotCached(t *testing.T) {
 
 	cfg := &complytime.WorkspaceConfig{
 		Policies: []complytime.PolicyEntry{
-			{URL: "reg.io/policies/nist@v1.0.0"},
+			{URL: "reg.io/policies/nist:v1.0.0"},
 		},
 	}
 
@@ -326,8 +326,8 @@ func TestCheckPolicyVersions_RegistryUnreachable(t *testing.T) {
 
 	cfg := &complytime.WorkspaceConfig{
 		Policies: []complytime.PolicyEntry{
-			{URL: "unreachable.io/policies/nist@v1.0.0"},
-			{URL: "unreachable.io/policies/cis@v2.0.0", ID: "cis"},
+			{URL: "unreachable.io/policies/nist:v1.0.0"},
+			{URL: "unreachable.io/policies/cis:v2.0.0", ID: "cis"},
 		},
 	}
 
@@ -367,7 +367,7 @@ func TestCheckPolicyVersions_LatestMissing_PinnedResolves(t *testing.T) {
 
 	cfg := &complytime.WorkspaceConfig{
 		Policies: []complytime.PolicyEntry{
-			{URL: "reg.io/policies/nist@v1.0.0"},
+			{URL: "reg.io/policies/nist:v1.0.0"},
 		},
 	}
 
@@ -472,7 +472,7 @@ func TestCheckPolicyVersions_PinnedBoth404(t *testing.T) {
 
 	cfg := &complytime.WorkspaceConfig{
 		Policies: []complytime.PolicyEntry{
-			{URL: "reg.io/policies/nist@v2.0.0"},
+			{URL: "reg.io/policies/nist:v2.0.0"},
 		},
 	}
 
@@ -542,8 +542,8 @@ func TestCheckPolicyVersions_PinnedNetworkFailure_BothFail(t *testing.T) {
 
 	cfg := &complytime.WorkspaceConfig{
 		Policies: []complytime.PolicyEntry{
-			{URL: "flaky.io/policies/nist@v1.0.0"},
-			{URL: "flaky.io/policies/cis@v1.0.0", ID: "cis"},
+			{URL: "flaky.io/policies/nist:v1.0.0"},
+			{URL: "flaky.io/policies/cis:v1.0.0", ID: "cis"},
 		},
 	}
 
@@ -569,7 +569,7 @@ func TestCheckPolicyVersions_BadCacheState(t *testing.T) {
 	}
 
 	cfg := &complytime.WorkspaceConfig{
-		Policies: []complytime.PolicyEntry{{URL: "reg.io/policies/nist@v1.0.0"}},
+		Policies: []complytime.PolicyEntry{{URL: "reg.io/policies/nist:v1.0.0"}},
 	}
 
 	results := CheckPolicyVersions(cfg, tmpDir, newMockVersionResolver())
@@ -712,7 +712,7 @@ func TestCheckVariables_NoVerbose_NoDetail(t *testing.T) {
 func TestCheckVariables_UnmappedTargetVars_NilResolver(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
 		Variables: map[string]string{"output_dir": "/tmp"},
-		Policies:  []complytime.PolicyEntry{{URL: "reg.io/policies/nist@v1.0.0"}},
+		Policies:  []complytime.PolicyEntry{{URL: "reg.io/policies/nist:v1.0.0"}},
 		Targets:   []complytime.TargetConfig{{ID: "host1", Policies: []string{"nist"}}},
 	}
 	health := []ProviderHealth{{
@@ -739,7 +739,7 @@ func TestCheckVariables_UnmappedTargetVars_NilResolver(t *testing.T) {
 func TestCheckVariables_UnmappedTargetVars_ResolverFails(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
 		Variables: map[string]string{},
-		Policies:  []complytime.PolicyEntry{{URL: "reg.io/policies/nist@v1.0.0"}},
+		Policies:  []complytime.PolicyEntry{{URL: "reg.io/policies/nist:v1.0.0"}},
 		Targets: []complytime.TargetConfig{{
 			ID:       "host1",
 			Policies: []string{"nist"},
@@ -785,7 +785,7 @@ func TestCheckVariables_UnmappedTargetVars_ResolverFails(t *testing.T) {
 func TestCheckVariables_UnmappedTargetVars_EvaluatorNotInGraph(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
 		Variables: map[string]string{},
-		Policies:  []complytime.PolicyEntry{{URL: "reg.io/policies/nist@v1.0.0"}},
+		Policies:  []complytime.PolicyEntry{{URL: "reg.io/policies/nist:v1.0.0"}},
 		Targets: []complytime.TargetConfig{{
 			ID:       "host1",
 			Policies: []string{"nist"},
@@ -818,7 +818,7 @@ func TestCheckVariables_UnmappedTargetVars_EvaluatorNotInGraph(t *testing.T) {
 func TestCheckVariables_MappedTargetVars_MissingProfile(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
 		Variables: map[string]string{},
-		Policies:  []complytime.PolicyEntry{{URL: "reg.io/policies/nist@v1.0.0"}},
+		Policies:  []complytime.PolicyEntry{{URL: "reg.io/policies/nist:v1.0.0"}},
 		Targets: []complytime.TargetConfig{{
 			ID:        "host1",
 			Policies:  []string{"nist"},
@@ -852,7 +852,7 @@ func TestCheckVariables_MappedTargetVars_MissingProfile(t *testing.T) {
 func TestCheckVariables_Verbose_UnmappedTargetVars(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
 		Variables: map[string]string{},
-		Policies:  []complytime.PolicyEntry{{URL: "reg.io/policies/nist@v1.0.0"}},
+		Policies:  []complytime.PolicyEntry{{URL: "reg.io/policies/nist:v1.0.0"}},
 		Targets: []complytime.TargetConfig{{
 			ID:       "host1",
 			Policies: []string{"nist"},
@@ -932,7 +932,7 @@ func TestCheckVariables_WorkspaceAutoInjected_Verbose(t *testing.T) {
 func TestCheckVariables_ResolveFailure_PolicyNotFound(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
 		Variables: map[string]string{},
-		Policies:  []complytime.PolicyEntry{{URL: "reg.io/policies/nist@v1.0.0"}},
+		Policies:  []complytime.PolicyEntry{{URL: "reg.io/policies/nist:v1.0.0"}},
 		Targets: []complytime.TargetConfig{{
 			ID:       "host1",
 			Policies: []string{"nonexistent-policy"},
@@ -989,7 +989,7 @@ func TestCheckVariables_ResolveFailure_InvalidRef(t *testing.T) {
 func TestCheckVariables_ResolveFailure_VersionNotFound(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
 		Variables: map[string]string{},
-		Policies:  []complytime.PolicyEntry{{URL: "reg.io/policies/nist@v1.0.0"}},
+		Policies:  []complytime.PolicyEntry{{URL: "reg.io/policies/nist:v1.0.0"}},
 		Targets: []complytime.TargetConfig{{
 			ID:       "host1",
 			Policies: []string{"nist"},
@@ -1018,7 +1018,7 @@ func TestCheckVariables_ResolveFailure_VersionNotFound(t *testing.T) {
 func TestCheckVariables_ResolveFailure_GraphNotFound(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
 		Variables: map[string]string{},
-		Policies:  []complytime.PolicyEntry{{URL: "reg.io/policies/nist@v1.0.0"}},
+		Policies:  []complytime.PolicyEntry{{URL: "reg.io/policies/nist:v1.0.0"}},
 		Targets: []complytime.TargetConfig{{
 			ID:       "host1",
 			Policies: []string{"nist"},
@@ -1057,7 +1057,7 @@ func TestCheckPolicyActivePeriod_NilConfig(t *testing.T) {
 
 func TestCheckPolicyActivePeriod_NilResolver(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
-		Policies: []complytime.PolicyEntry{{URL: "reg.io/policies/nist@v1.0.0"}},
+		Policies: []complytime.PolicyEntry{{URL: "reg.io/policies/nist:v1.0.0"}},
 	}
 	results := CheckPolicyActivePeriod(cfg, nil, false)
 	if results != nil {
@@ -1067,7 +1067,7 @@ func TestCheckPolicyActivePeriod_NilResolver(t *testing.T) {
 
 func TestCheckPolicyActivePeriod_NoTimeline(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
-		Policies: []complytime.PolicyEntry{{URL: "reg.io/policies/nist@v1.0.0"}},
+		Policies: []complytime.PolicyEntry{{URL: "reg.io/policies/nist:v1.0.0"}},
 	}
 	resolver := newMockPolicyGraphResolver()
 	resolver.versions["policies/nist@v1.0.0"] = "v1.0.0"
@@ -1090,7 +1090,7 @@ func TestCheckPolicyActivePeriod_NoTimeline(t *testing.T) {
 
 func TestCheckPolicyActivePeriod_Active(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
-		Policies: []complytime.PolicyEntry{{URL: "reg.io/policies/nist@v1.0.0"}},
+		Policies: []complytime.PolicyEntry{{URL: "reg.io/policies/nist:v1.0.0"}},
 	}
 	resolver := newMockPolicyGraphResolver()
 	resolver.versions["policies/nist@v1.0.0"] = "v1.0.0"
@@ -1116,7 +1116,7 @@ func TestCheckPolicyActivePeriod_Active(t *testing.T) {
 
 func TestCheckPolicyActivePeriod_NotYetActive(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
-		Policies: []complytime.PolicyEntry{{URL: "reg.io/policies/nist@v1.0.0"}},
+		Policies: []complytime.PolicyEntry{{URL: "reg.io/policies/nist:v1.0.0"}},
 	}
 	resolver := newMockPolicyGraphResolver()
 	resolver.versions["policies/nist@v1.0.0"] = "v1.0.0"
@@ -1142,7 +1142,7 @@ func TestCheckPolicyActivePeriod_NotYetActive(t *testing.T) {
 
 func TestCheckPolicyActivePeriod_Expired(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
-		Policies: []complytime.PolicyEntry{{URL: "reg.io/policies/nist@v1.0.0"}},
+		Policies: []complytime.PolicyEntry{{URL: "reg.io/policies/nist:v1.0.0"}},
 	}
 	resolver := newMockPolicyGraphResolver()
 	resolver.versions["policies/nist@v1.0.0"] = "v1.0.0"
@@ -1168,7 +1168,7 @@ func TestCheckPolicyActivePeriod_Expired(t *testing.T) {
 
 func TestCheckPolicyActivePeriod_OpenEnded(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
-		Policies: []complytime.PolicyEntry{{URL: "reg.io/policies/nist@v1.0.0"}},
+		Policies: []complytime.PolicyEntry{{URL: "reg.io/policies/nist:v1.0.0"}},
 	}
 	resolver := newMockPolicyGraphResolver()
 	resolver.versions["policies/nist@v1.0.0"] = "v1.0.0"
@@ -1193,7 +1193,7 @@ func TestCheckPolicyActivePeriod_OpenEnded(t *testing.T) {
 
 func TestCheckPolicyActivePeriod_Verbose_ShowsEnforcement(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
-		Policies: []complytime.PolicyEntry{{URL: "reg.io/policies/nist@v1.0.0"}},
+		Policies: []complytime.PolicyEntry{{URL: "reg.io/policies/nist:v1.0.0"}},
 	}
 	resolver := newMockPolicyGraphResolver()
 	resolver.versions["policies/nist@v1.0.0"] = "v1.0.0"
@@ -1248,7 +1248,7 @@ func TestCheckPolicyActivePeriod_Verbose_ShowsEnforcement(t *testing.T) {
 
 func TestCheckPolicyActivePeriod_UnparseableDate(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
-		Policies: []complytime.PolicyEntry{{URL: "reg.io/policies/nist@v1.0.0"}},
+		Policies: []complytime.PolicyEntry{{URL: "reg.io/policies/nist:v1.0.0"}},
 	}
 	resolver := newMockPolicyGraphResolver()
 	resolver.versions["policies/nist@v1.0.0"] = "v1.0.0"
@@ -1573,10 +1573,10 @@ func TestCheckComplypacks_AllPresent(t *testing.T) {
 
 	cfg := &complytime.WorkspaceConfig{
 		Policies: []complytime.PolicyEntry{
-			{URL: "reg.io/policies/nist@v1.0.0"},
+			{URL: "reg.io/policies/nist:v1.0.0"},
 		},
 		Complypacks: []complytime.PolicyEntry{
-			{URL: "reg.io/complypacks/openscap@v1.0.0"},
+			{URL: "reg.io/complypacks/openscap:v1.0.0"},
 		},
 	}
 
@@ -1604,10 +1604,10 @@ func TestCheckComplypacks_Missing(t *testing.T) {
 
 	cfg := &complytime.WorkspaceConfig{
 		Policies: []complytime.PolicyEntry{
-			{URL: "reg.io/policies/nist@v1.0.0"},
+			{URL: "reg.io/policies/nist:v1.0.0"},
 		},
 		Complypacks: []complytime.PolicyEntry{
-			{URL: "reg.io/complypacks/openscap@v1.0.0"},
+			{URL: "reg.io/complypacks/openscap:v1.0.0"},
 		},
 	}
 
@@ -1644,7 +1644,7 @@ func TestCheckComplypacks_NilConfig(t *testing.T) {
 func TestCheckComplypacks_NoComplypacks(t *testing.T) {
 	cfg := &complytime.WorkspaceConfig{
 		Policies: []complytime.PolicyEntry{
-			{URL: "reg.io/policies/nist@v1.0.0"},
+			{URL: "reg.io/policies/nist:v1.0.0"},
 		},
 		// Complypacks is nil/empty — check should be skipped.
 	}
@@ -1662,7 +1662,7 @@ func TestCheckComplypacks_InvalidPolicyRef(t *testing.T) {
 			{URL: ""},
 		},
 		Complypacks: []complytime.PolicyEntry{
-			{URL: "reg.io/complypacks/openscap@v1.0.0"},
+			{URL: "reg.io/complypacks/openscap:v1.0.0"},
 		},
 	}
 

--- a/tests/cross-repo/testdata/complytime.yaml
+++ b/tests/cross-repo/testdata/complytime.yaml
@@ -5,9 +5,9 @@ policies:
     id: test-opa-k8s
 
 complypacks:
-  - url: http://localhost:8765/complypacks/ampel-bp@v1.0.0
+  - url: http://localhost:8765/complypacks/ampel-bp:v1.0.0
     id: ampel-bp-pack
-  - url: http://localhost:8765/complypacks/test-opa-complypack@v1.0.0
+  - url: http://localhost:8765/complypacks/test-opa-complypack:v1.0.0
     id: opa-complypack
 
 targets:


### PR DESCRIPTION
## Summary

Migrates all shipped examples, config files, CLI hints, and test fixtures from the deprecated `@version` policy URL notation to standard OCI `:tag` syntax. This eliminates the deprecation warning triggered by the project's own examples.

Closes #612

## User-facing changes

- `complyctl init` template comment and interactive prompt now use `:tag` examples
- `README.md` config example and field description updated
- `tests/cross-repo/testdata/complytime.yaml` complypack URLs updated

## Test fixture changes

- `internal/complytime/config_test.go` — ~63 URL literals migrated
- `internal/doctor/doctor_test.go` — ~34 PolicyEntry URL literals migrated
- `cmd/complyctl/cli/cli_test.go` — 7 URL literals migrated

### Intentionally preserved with `@version`

- `TestParsePolicyRef_DeprecationWarning_AtVersion` — verifies the deprecation warning fires
- `TestParsePolicyRef_NoDeprecationWarning_BareID` — verifies bare IDs don't trigger the warning
- `TestParsePolicyRef_NoRegistry` — bare policy ID (not a full OCI ref)
- All `@sha256:` digest references (valid OCI syntax)
- Mock resolver internal keys (`policyID + "@" + version`)

## Verification

- `make test-unit` — all tests pass
- `make lint` — 0 issues

---

Signed-off-by: Yvonne Devlin <ydevlin@redhat.com>
Assisted-by: OpenCode (claude-opus-4-6)