### PR TITLE
fix: write format reports to .complytime/scan/ alongside evaluation log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,10 @@
 
 ### Fixed
 
+- `complyctl scan --format` reports (SARIF, OSCAL, Markdown) now written
+  to `.complytime/scan/` alongside the evaluation log, matching
+  documented behavior. Previously, format reports were written to the
+  workspace root. (#615)
 - Generation freshness detection now tracks complypack digests alongside
   policy digests. Previously, updating a complypack without changing the
   policy would skip regeneration, causing providers to use stale

--- a/cmd/complyctl/cli/scan.go
+++ b/cmd/complyctl/cli/scan.go
@@ -414,7 +414,7 @@ func processScanOutput(format string, scanOut *scanOutput, repository string, ma
 
 	outDir := filepath.Join(baseDir, complytime.WorkspaceDir, complytime.ScanOutputDir)
 	for _, eval := range evaluators {
-		if err := writeScanReports(format, eval, outDir, baseDir, repository); err != nil {
+		if err := writeScanReports(format, eval, outDir, repository); err != nil {
 			return err
 		}
 	}
@@ -645,36 +645,36 @@ func scanSingleTarget(ctx context.Context, mgr *provider.Manager, groups map[str
 	return results, operationalErrors, nil
 }
 
-func writeScanReports(format string, eval *output.Evaluator, outDir, reportDir, repository string) error {
+func writeScanReports(format string, eval *output.Evaluator, outDir, repository string) error {
 	logPath, err := eval.Write(outDir)
 	if err != nil {
 		return fmt.Errorf("failed to write evaluation log: %w", err)
 	}
 	fmt.Printf("Evaluation log written: %s [target: %s]\n", logPath, eval.TargetID())
 
-	if err := writeFormatReport(format, eval, logPath, reportDir, repository); err != nil {
+	if err := writeFormatReport(format, eval, logPath, outDir, repository); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func writeFormatReport(format string, eval *output.Evaluator, logPath, reportDir, repository string) error {
+func writeFormatReport(format string, eval *output.Evaluator, logPath, outDir, repository string) error {
 	switch format {
 	case complytime.OutputFormatPretty:
-		return writePrettyReport(eval, logPath, reportDir, repository)
+		return writePrettyReport(eval, logPath, outDir, repository)
 	case complytime.OutputFormatSARIF:
-		return writeSARIFReport(eval, reportDir)
+		return writeSARIFReport(eval, outDir)
 	case complytime.OutputFormatOSCAL:
-		return writeOSCALReport(eval, reportDir)
+		return writeOSCALReport(eval, outDir)
 	}
 	return nil
 }
 
-func writePrettyReport(eval *output.Evaluator, logPath, reportDir, repository string) error {
+func writePrettyReport(eval *output.Evaluator, logPath, outDir, repository string) error {
 	md := output.NewMarkdown(repository, eval.GemaraLog())
 	md.SetEmbedEvaluationLog(logPath)
-	mdPath, err := md.Write(reportDir)
+	mdPath, err := md.Write(outDir)
 	if err != nil {
 		return fmt.Errorf("failed to write markdown report: %w", err)
 	}
@@ -682,8 +682,8 @@ func writePrettyReport(eval *output.Evaluator, logPath, reportDir, repository st
 	return nil
 }
 
-func writeSARIFReport(eval *output.Evaluator, reportDir string) error {
-	sarifPath, err := output.ToSARIF(eval.GemaraLog(), "file:///scan", reportDir)
+func writeSARIFReport(eval *output.Evaluator, outDir string) error {
+	sarifPath, err := output.ToSARIF(eval.GemaraLog(), "file:///scan", outDir)
 	if err != nil {
 		return fmt.Errorf("failed to export SARIF: %w", err)
 	}
@@ -691,8 +691,8 @@ func writeSARIFReport(eval *output.Evaluator, reportDir string) error {
 	return nil
 }
 
-func writeOSCALReport(eval *output.Evaluator, reportDir string) error {
-	oscalPath, err := output.ToOSCAL(eval.GemaraLog(), reportDir)
+func writeOSCALReport(eval *output.Evaluator, outDir string) error {
+	oscalPath, err := output.ToOSCAL(eval.GemaraLog(), outDir)
 	if err != nil {
 		return fmt.Errorf("failed to export OSCAL: %w", err)
 	}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -96,7 +96,7 @@ func TestE2E_FullWorkflow(t *testing.T) {
 
 		evalDir := filepath.Join(scanDir, complytime.WorkspaceDir, complytime.ScanOutputDir)
 		assertOutputFile(t, evalDir, "evaluation-log-", ".yaml")
-		oscalFile := assertOutputFile(t, scanDir, "assessment-results-", ".json")
+		oscalFile := assertOutputFile(t, evalDir, "assessment-results-", ".json")
 
 		data, err := os.ReadFile(oscalFile)
 		require.NoError(t, err)
@@ -125,7 +125,7 @@ func TestE2E_FullWorkflow(t *testing.T) {
 
 		evalDir := filepath.Join(scanDir, complytime.WorkspaceDir, complytime.ScanOutputDir)
 		assertOutputFile(t, evalDir, "evaluation-log-", ".yaml")
-		mdFile := assertOutputFile(t, scanDir, "report-", ".md")
+		mdFile := assertOutputFile(t, evalDir, "report-", ".md")
 
 		data, err := os.ReadFile(mdFile)
 		require.NoError(t, err)
@@ -146,7 +146,7 @@ func TestE2E_FullWorkflow(t *testing.T) {
 
 		evalDir := filepath.Join(scanDir, complytime.WorkspaceDir, complytime.ScanOutputDir)
 		assertOutputFile(t, evalDir, "evaluation-log-", ".yaml")
-		sarifFile := assertOutputFile(t, scanDir, "scan-", ".json")
+		sarifFile := assertOutputFile(t, evalDir, "scan-", ".json")
 
 		data, err := os.ReadFile(sarifFile)
 		require.NoError(t, err)
@@ -581,13 +581,13 @@ func TestE2E_NestedPolicyID(t *testing.T) {
 
 		evalDir := filepath.Join(scanDir, complytime.WorkspaceDir, complytime.ScanOutputDir)
 		evalLog := assertOutputFile(t, evalDir, "evaluation-log-", ".yaml")
-		oscalFile := assertOutputFile(t, scanDir, "assessment-results-", ".json")
+		oscalFile := assertOutputFile(t, evalDir, "assessment-results-", ".json")
 
 		// Filenames must be flat (no intermediate directories from slashed IDs)
 		assert.Equal(t, evalDir, filepath.Dir(evalLog),
 			"evaluation log must be directly in output dir, not nested")
-		assert.Equal(t, scanDir, filepath.Dir(oscalFile),
-			"OSCAL file must be directly in CWD, not nested")
+		assert.Equal(t, evalDir, filepath.Dir(oscalFile),
+			"OSCAL file must be directly in scan output dir, not nested")
 	})
 }
 
@@ -687,7 +687,8 @@ func TestE2E_ScanExportEnabledWithFormatSarif(t *testing.T) {
 
 	// Verify SARIF report was produced
 	assert.Contains(t, out, "SARIF report written")
-	assertOutputFile(t, scanDir, "scan-", ".sarif.json")
+	evalDir := filepath.Join(scanDir, complytime.WorkspaceDir, complytime.ScanOutputDir)
+	assertOutputFile(t, evalDir, "scan-", ".sarif.json")
 
 	// Verify export summary was also printed
 	assert.Contains(t, out, "Export Summary")

--- a/tests/integration_test.sh
+++ b/tests/integration_test.sh
@@ -196,7 +196,7 @@ assert_file_exists "scan oscal: evaluation-log exists" \
     "${WORK_DIR}/.complytime/scan/evaluation-log-*.yaml" >/dev/null
 
 OSCAL_FILE="$(assert_file_exists "scan oscal: assessment-results exists" \
-    "${WORK_DIR}/assessment-results-*.json")"
+    "${WORK_DIR}/.complytime/scan/assessment-results-*.json")"
 
 if [[ -n "${OSCAL_FILE}" ]]; then
     assert_json_eq "scan oscal: oscal-version is 1.1.3" \
@@ -213,7 +213,7 @@ echo "${OUT}"
 assert_contains "scan pretty: completed" "${OUT}" "requirements:"
 
 MD_FILE="$(assert_file_exists "scan pretty: markdown report exists" \
-    "${WORK_DIR}/report-*.md")"
+    "${WORK_DIR}/.complytime/scan/report-*.md")"
 
 if [[ -n "${MD_FILE}" ]]; then
     MD_CONTENT="$(cat "${MD_FILE}")"
@@ -228,7 +228,7 @@ echo "${OUT}"
 assert_contains "scan sarif: completed" "${OUT}" "requirements:"
 
 SARIF_FILE="$(assert_file_exists "scan sarif: sarif file exists" \
-    "${WORK_DIR}/scan-*.sarif.json")"
+    "${WORK_DIR}/.complytime/scan/scan-*.sarif.json")"
 
 if [[ -n "${SARIF_FILE}" ]]; then
     assert_json_eq "scan sarif: version is 2.1.0" \
@@ -238,16 +238,15 @@ fi
 echo ""
 echo "=== scan (default, no --format) ==="
 rm -rf "${WORK_DIR}/.complytime/scan"
-rm -f "${WORK_DIR}"/assessment-results-* "${WORK_DIR}"/report-* "${WORK_DIR}"/scan-*
 OUT="$(run_complyctl scan --policy-id "${POLICY_ID}")"
 echo "${OUT}"
 assert_contains "scan default: completed" "${OUT}" "requirements:"
 assert_file_exists "scan default: evaluation-log exists" \
     "${WORK_DIR}/.complytime/scan/evaluation-log-*.yaml" >/dev/null
 
-NO_OSCAL=$(ls "${WORK_DIR}/assessment-results-"* 2>/dev/null || true)
-NO_MD=$(ls "${WORK_DIR}/report-"* 2>/dev/null || true)
-NO_SARIF=$(ls "${WORK_DIR}/scan-"* 2>/dev/null || true)
+NO_OSCAL=$(ls "${WORK_DIR}/.complytime/scan/assessment-results-"* 2>/dev/null || true)
+NO_MD=$(ls "${WORK_DIR}/.complytime/scan/report-"* 2>/dev/null || true)
+NO_SARIF=$(ls "${WORK_DIR}/.complytime/scan/scan-"* 2>/dev/null || true)
 if [[ -z "${NO_OSCAL}" && -z "${NO_MD}" && -z "${NO_SARIF}" ]]; then
     pass "scan default: no formatted output without --format"
 else


### PR DESCRIPTION
## Summary

All `--format` reports (SARIF, OSCAL, Markdown) were written to the workspace root while the EvaluationLog was written to `.complytime/scan/`. This diverged from the documented behavior and cluttered the working directory.

## Problem

The `writeScanReports` function in `cmd/complyctl/cli/scan.go` received two separate directory parameters: `outDir` (`.complytime/scan/`) for the EvaluationLog and `reportDir` (workspace root) for format reports. This caused the following file layout:

<workspace>/
├── .complytime/scan/evaluation-log-.yaml    # correct
├── assessment-results-.json                 # wrong — should be in .complytime/scan/
├── scan-.sarif.json                         # wrong — should be in .complytime/scan/
└── report-.md                               # wrong — should be in .complytime/scan/

## Fix

Removed the redundant `reportDir` parameter from `writeScanReports` and all downstream functions (`writeFormatReport`, `writePrettyReport`, `writeSARIFReport`, `writeOSCALReport`). All scan output now uses the single `outDir` path (`.complytime/scan/`), producing:

<workspace>/
└── .complytime/scan/
    ├── evaluation-log-.yaml
    ├── assessment-results-.json
    ├── scan-.sarif.json
    └── report-.md

## Changes

| File | Change |
|------|--------|
| `cmd/complyctl/cli/scan.go` | Removed `reportDir` parameter; all format reports use `outDir` |
| `tests/e2e/e2e_test.go` | Updated 5 assertions to expect files in `.complytime/scan/` |
| `tests/integration_test.sh` | Updated 8 path references to `.complytime/scan/` |

## Testing

- `make test-unit` — passed
- `make test-e2e` — passed (14/14)
- `make test-integration` — passed (26/26)
- `make lint` — 0 issues

No documentation changes needed — the docs already describe the correct (now-implemented) behavior.

Closes #615

Signed-off-by: Yvonne Devlin <ydevlin@redhat.com>
Assisted-by: OpenCode (claude-opus-4-6)