### PR TITLE
fix: separate assessment log plan IDs

### DIFF
--- a/cmd/complyctl/cli/cli_test.go
+++ b/cmd/complyctl/cli/cli_test.go
@@ -767,17 +767,18 @@ func TestExtractPlanToReqMap_EmptyAssessments(t *testing.T) {
 
 func TestResolveAssessmentIDs_ReplacesMatchingIDs(t *testing.T) {
 	assessments := []provider.AssessmentLog{
-		{RequirementID: "ap-1"},
+		{PlanID: "ap-1"},
 		{RequirementID: "req-already-correct"},
 	}
 	planToReq := map[string]string{"ap-1": "req-1"}
 	resolveAssessmentIDs(assessments, planToReq)
+	assert.Equal(t, "ap-1", assessments[0].PlanID)
 	assert.Equal(t, "req-1", assessments[0].RequirementID)
 	assert.Equal(t, "req-already-correct", assessments[1].RequirementID)
 }
 
 func TestResolveAssessmentIDs_EmptyMap(t *testing.T) {
-	assessments := []provider.AssessmentLog{{RequirementID: "ap-1"}}
+	assessments := []provider.AssessmentLog{{PlanID: "ap-1"}}
 	resolveAssessmentIDs(assessments, map[string]string{})
 	assert.Equal(t, "ap-1", assessments[0].RequirementID)
 }
@@ -789,8 +790,8 @@ func TestResolveAssessmentIDs_NilAssessments(t *testing.T) {
 
 func TestResolveAssessmentIDs_AllReplaced(t *testing.T) {
 	assessments := []provider.AssessmentLog{
-		{RequirementID: "ap-1"},
-		{RequirementID: "ap-2"},
+		{PlanID: "ap-1"},
+		{PlanID: "ap-2"},
 	}
 	planToReq := map[string]string{
 		"ap-1": "req-1",

--- a/cmd/complyctl/cli/scan.go
+++ b/cmd/complyctl/cli/scan.go
@@ -740,12 +740,20 @@ func extractPlanToReqMap(graph *policy.DependencyGraph) map[string]string {
 	return m
 }
 
-// resolveAssessmentIDs replaces plan IDs in assessment results with actual
-// requirement IDs using the plan-to-requirement mapping from the policy graph.
+// resolveAssessmentIDs replaces provider match IDs in assessment results with
+// actual requirement IDs using the plan-to-requirement mapping from the policy
+// graph. Providers return plan IDs for plan-scoped assessments, while global
+// evaluators can return requirement IDs directly.
 func resolveAssessmentIDs(assessments []provider.AssessmentLog, planToReq map[string]string) {
 	for i := range assessments {
-		if reqID, ok := planToReq[assessments[i].RequirementID]; ok {
+		matchID := assessments[i].PlanID
+		if matchID == "" {
+			matchID = assessments[i].RequirementID
+		}
+		if reqID, ok := planToReq[matchID]; ok {
 			assessments[i].RequirementID = reqID
+		} else if assessments[i].RequirementID == "" {
+			assessments[i].RequirementID = matchID
 		}
 	}
 }

--- a/cmd/test-provider/main.go
+++ b/cmd/test-provider/main.go
@@ -31,7 +31,7 @@ var (
 
 // testEvaluator returns predefined responses for all RPCs.
 type testEvaluator struct {
-	requirementIDs []string
+	matchIDs []string
 }
 
 func (t *testEvaluator) Describe(_ context.Context, _ *provider.DescribeRequest) (*provider.DescribeResponse, error) {
@@ -43,9 +43,9 @@ func (t *testEvaluator) Describe(_ context.Context, _ *provider.DescribeRequest)
 }
 
 func (t *testEvaluator) Generate(_ context.Context, req *provider.GenerateRequest) (*provider.GenerateResponse, error) {
-	t.requirementIDs = make([]string, 0, len(req.Configuration))
+	t.matchIDs = make([]string, 0, len(req.Configuration))
 	for _, cfg := range req.Configuration {
-		t.requirementIDs = append(t.requirementIDs, cfg.MatchID())
+		t.matchIDs = append(t.matchIDs, cfg.MatchID())
 	}
 
 	// Log complypack content path receipt for E2E test observability.
@@ -64,10 +64,10 @@ func logComplypackPath(path string) {
 }
 
 func (t *testEvaluator) Scan(_ context.Context, req *provider.ScanRequest) (*provider.ScanResponse, error) {
-	assessments := make([]provider.AssessmentLog, 0, len(t.requirementIDs))
-	for _, reqID := range t.requirementIDs {
+	assessments := make([]provider.AssessmentLog, 0, len(t.matchIDs))
+	for _, matchID := range t.matchIDs {
 		assessments = append(assessments, provider.AssessmentLog{
-			RequirementID: reqID,
+			PlanID: matchID,
 			Steps: []provider.Step{
 				{
 					Name:    "test-check",
@@ -79,9 +79,9 @@ func (t *testEvaluator) Scan(_ context.Context, req *provider.ScanRequest) (*pro
 			Confidence: provider.ConfidenceLevelHigh,
 			Evidence: []provider.Evidence{
 				{
-					ID:          "ev-" + reqID,
+					ID:          "ev-" + matchID,
 					Type:        "log",
-					Description: "test evidence for " + reqID,
+					Description: "test evidence for " + matchID,
 					Payload:     []byte("sample payload"),
 					CollectedAt: time.Now().Format(time.RFC3339),
 				},

--- a/internal/cache/complypack_pipeline_test.go
+++ b/internal/cache/complypack_pipeline_test.go
@@ -228,7 +228,7 @@ func TestComplypackPipeline_MultipleEvaluators(t *testing.T) {
 // It mirrors the test-provider's behavior but runs in-process.
 type capturingProvider struct {
 	receivedComplypackPath string
-	requirementIDs         []string
+	matchIDs               []string
 }
 
 // Compile-time check: capturingProvider must implement provider.Provider.
@@ -243,18 +243,18 @@ func (p *capturingProvider) Describe(_ context.Context, _ *provider.DescribeRequ
 
 func (p *capturingProvider) Generate(_ context.Context, req *provider.GenerateRequest) (*provider.GenerateResponse, error) {
 	p.receivedComplypackPath = req.ComplypackContentPath
-	p.requirementIDs = make([]string, 0, len(req.Configuration))
+	p.matchIDs = make([]string, 0, len(req.Configuration))
 	for _, cfg := range req.Configuration {
-		p.requirementIDs = append(p.requirementIDs, cfg.MatchID())
+		p.matchIDs = append(p.matchIDs, cfg.MatchID())
 	}
 	return &provider.GenerateResponse{Success: true}, nil
 }
 
 func (p *capturingProvider) Scan(_ context.Context, _ *provider.ScanRequest) (*provider.ScanResponse, error) {
-	assessments := make([]provider.AssessmentLog, 0, len(p.requirementIDs))
-	for _, reqID := range p.requirementIDs {
+	assessments := make([]provider.AssessmentLog, 0, len(p.matchIDs))
+	for _, matchID := range p.matchIDs {
 		assessments = append(assessments, provider.AssessmentLog{
-			RequirementID: reqID,
+			PlanID: matchID,
 			Steps: []provider.Step{
 				{Name: "capture-check", Result: provider.ResultPassed, Message: "captured"},
 			},

--- a/pkg/provider/client.go
+++ b/pkg/provider/client.go
@@ -73,8 +73,13 @@ type ScanResponse struct {
 	Errors      []string
 }
 
-// AssessmentLog holds the evaluation result for a single requirement.
+// AssessmentLog holds the evaluation result for one provider assessment.
 type AssessmentLog struct {
+	// PlanID carries the provider-returned match ID before scan output resolves
+	// it to the Gemara requirement-id.
+	PlanID string
+	// RequirementID carries the final Gemara requirement-id after scan output
+	// resolution. Output/reporting code should use this field.
 	RequirementID  string
 	Steps          []Step
 	Message        string
@@ -219,7 +224,7 @@ func (c *Client) Scan(ctx context.Context, req *ScanRequest) (*ScanResponse, err
 			})
 		}
 		assessments = append(assessments, AssessmentLog{
-			RequirementID:  pa.GetRequirementId(),
+			PlanID:         pa.GetRequirementId(),
 			Steps:          steps,
 			Message:        pa.GetMessage(),
 			Confidence:     protoConfidenceToInternal(pa.GetConfidence()),

--- a/pkg/provider/client.go
+++ b/pkg/provider/client.go
@@ -256,7 +256,6 @@ func protoEvidenceToInternal(pe []*pluginv2.Evidence) []Evidence {
 	return evidence
 }
 
-
 func protoResultToInternal(r pluginv2.Result) Result {
 	switch r {
 	case pluginv2.Result_RESULT_PASSED:

--- a/pkg/provider/client_test.go
+++ b/pkg/provider/client_test.go
@@ -69,7 +69,8 @@ func TestMockClient_Scan(t *testing.T) {
 
 	expectedIDs := []string{"plan-1", "plan-2"}
 	for i, a := range resp.Assessments {
-		assert.Equal(t, expectedIDs[i], a.RequirementID)
+		assert.Equal(t, expectedIDs[i], a.PlanID)
+		assert.Empty(t, a.RequirementID)
 		assert.Equal(t, "mock passed", a.Message)
 		assert.Equal(t, provider.ConfidenceLevelHigh, a.Confidence)
 		require.Len(t, a.Steps, 1)
@@ -144,6 +145,7 @@ func TestMockClient_Scan_ResponseMapping(t *testing.T) {
 	resp, err := mock.Scan(context.Background(), scanReq)
 	require.NoError(t, err)
 	require.Len(t, resp.Assessments, 1)
-	assert.Equal(t, "plan-1", resp.Assessments[0].RequirementID)
+	assert.Equal(t, "plan-1", resp.Assessments[0].PlanID)
+	assert.Empty(t, resp.Assessments[0].RequirementID)
 	assert.Equal(t, "mock-check", resp.Assessments[0].Steps[0].Name)
 }

--- a/pkg/provider/manager_test.go
+++ b/pkg/provider/manager_test.go
@@ -329,7 +329,7 @@ func TestManager_RouteScanResult_Broadcast_RPCFailure(t *testing.T) {
 	// Assessments come only from the clean provider — RPC failures do not
 	// inject synthetic assessments (D3).
 	require.Len(t, result.Assessments, 1)
-	assert.Equal(t, "req-1", result.Assessments[0].RequirementID)
+	assert.Equal(t, "req-1", result.Assessments[0].PlanID)
 }
 
 func TestManager_RouteScan_DropsProviderErrors(t *testing.T) {

--- a/pkg/provider/manager_test.go
+++ b/pkg/provider/manager_test.go
@@ -92,7 +92,7 @@ func (f *failingMockClient) Scan(_ context.Context, _ *provider.ScanRequest) (*p
 	if f.failScan {
 		return nil, fmt.Errorf("scan RPC failed")
 	}
-	return &provider.ScanResponse{Assessments: []provider.AssessmentLog{{RequirementID: "test-req"}}}, nil
+	return &provider.ScanResponse{Assessments: []provider.AssessmentLog{{PlanID: "test-req"}}}, nil
 }
 
 func TestManager_RouteGenerate_SpecificProvider(t *testing.T) {
@@ -234,9 +234,9 @@ type errorEmbeddingMockClient struct {
 func (e *errorEmbeddingMockClient) Scan(_ context.Context, _ *provider.ScanRequest) (*provider.ScanResponse, error) {
 	return &provider.ScanResponse{
 		Assessments: []provider.AssessmentLog{{
-			RequirementID: "req-1",
-			Steps:         []provider.Step{{Name: "check", Result: provider.ResultPassed}},
-			Message:       "evaluated",
+			PlanID:  "req-1",
+			Steps:   []provider.Step{{Name: "check", Result: provider.ResultPassed}},
+			Message: "evaluated",
 		}},
 		Errors: []string{"target 'staging': clone failed: auth denied"},
 	}, nil
@@ -257,7 +257,7 @@ func TestManager_RouteScanResult_PartialResults(t *testing.T) {
 	assert.True(t, result.HasErrors())
 	assert.Contains(t, result.Errors[0], "clone failed")
 	require.Len(t, result.Assessments, 1)
-	assert.Equal(t, "req-1", result.Assessments[0].RequirementID)
+	assert.Equal(t, "req-1", result.Assessments[0].PlanID)
 }
 
 func TestManager_RouteScanResult_NoErrors(t *testing.T) {
@@ -315,7 +315,10 @@ func TestManager_RouteScanResult_Broadcast_RPCFailure(t *testing.T) {
 	lpClean := provider.NewMockLoadedProvider("clean-provider", "clean-eval", clean)
 	mgr.RegisterProviderForTest("clean-eval", lpClean)
 	_, _ = clean.Generate(context.Background(), &provider.GenerateRequest{
-		Configuration: []provider.AssessmentConfiguration{{RequirementID: "req-1"}},
+		Configuration: []provider.AssessmentConfiguration{
+			{PlanID: "plan-1", RequirementID: "req-1"},
+			{RequirementID: "fallback-req"},
+		},
 	})
 
 	// Broadcast: both providers scanned, one fails
@@ -328,8 +331,9 @@ func TestManager_RouteScanResult_Broadcast_RPCFailure(t *testing.T) {
 	assert.Contains(t, result.Errors[0], "scan RPC failed")
 	// Assessments come only from the clean provider — RPC failures do not
 	// inject synthetic assessments (D3).
-	require.Len(t, result.Assessments, 1)
-	assert.Equal(t, "req-1", result.Assessments[0].PlanID)
+	require.Len(t, result.Assessments, 2)
+	assert.Equal(t, "plan-1", result.Assessments[0].PlanID)
+	assert.Equal(t, "fallback-req", result.Assessments[1].PlanID)
 }
 
 func TestManager_RouteScan_DropsProviderErrors(t *testing.T) {
@@ -348,7 +352,7 @@ func TestManager_RouteScan_DropsProviderErrors(t *testing.T) {
 
 	// Assessments are returned
 	require.Len(t, results, 1)
-	assert.Equal(t, "req-1", results[0].RequirementID)
+	assert.Equal(t, "req-1", results[0].PlanID)
 	// The error is silently dropped (backwards-compatible behavior)
 }
 

--- a/pkg/provider/mock_client_test.go
+++ b/pkg/provider/mock_client_test.go
@@ -44,7 +44,7 @@ func (m *mockClient) Scan(_ context.Context, _ *provider.ScanRequest) (*provider
 	assessments := make([]provider.AssessmentLog, 0, len(m.matchIDs))
 	for _, matchID := range m.matchIDs {
 		assessments = append(assessments, provider.AssessmentLog{
-			RequirementID: matchID,
+			PlanID: matchID,
 			Steps: []provider.Step{
 				{Name: "mock-check", Result: provider.ResultPassed, Message: "mock check passed"},
 			},

--- a/pkg/provider/server.go
+++ b/pkg/provider/server.go
@@ -120,7 +120,6 @@ func internalEvidenceToProto(evidence []Evidence) []*proto.Evidence {
 	return pe
 }
 
-
 func internalResultToProto(r Result) proto.Result {
 	switch r {
 	case ResultPassed:

--- a/pkg/provider/server.go
+++ b/pkg/provider/server.go
@@ -83,8 +83,12 @@ func (s *grpcServer) Scan(ctx context.Context, req *proto.ScanRequest) (*proto.S
 				Message: step.Message,
 			})
 		}
+		matchID := a.PlanID
+		if matchID == "" {
+			matchID = a.RequirementID
+		}
 		protoAssessments = append(protoAssessments, &proto.AssessmentLog{
-			RequirementId:  a.RequirementID,
+			RequirementId:  matchID,
 			Steps:          protoSteps,
 			Message:        a.Message,
 			Confidence:     internalConfidenceToProto(a.Confidence),


### PR DESCRIPTION
## Summary
- Adds `PlanID` to `AssessmentLog` for provider-returned match IDs before scan output resolution.
- Keeps `RequirementID` as the final Gemara requirement-id used by output/reporting code.
- Updates scan ID resolution, provider server/client mapping, test providers, and regression tests for the response path.

## Related Issues
- Closes #635
- Follow-up to #632

## Review Hints
- `go test ./internal/policy ./pkg/provider ./cmd/complyctl/cli ./internal/cache ./internal/doctor -count=1`
- `make build`
- `make lint`
- `TMPDIR=/tmp make test-unit`
- `git diff --check`
