### PR TITLE
fix: invalidate generation cache when complypack is re-fetched

### DIFF
--- a/cmd/complyctl/cli/cli_test.go
+++ b/cmd/complyctl/cli/cli_test.go
@@ -1488,3 +1488,151 @@ func TestBuildReqToComplypackRef_SkipsMissingDigest(t *testing.T) {
 	m := buildReqToComplypackRef(cacheDir, groups)
 	assert.Empty(t, m)
 }
+
+// --- invalidateGenerationForComplypack tests ---
+
+func TestInvalidateGenerationForComplypack_InvalidatesOnFetch(t *testing.T) {
+	baseDir := t.TempDir()
+	cacheDir := t.TempDir()
+
+	// 1. Seed generation state referencing the "opa" evaluator.
+	genState := &policy.GenerationState{
+		PolicyID:     "test-policy",
+		PolicyDigest: "sha256:abc",
+		EvaluatorIDs: []string{"opa"},
+	}
+	require.NoError(t, policy.SaveGenerationState(baseDir, "test-policy", genState))
+
+	// 2. Seed evaluator artifact directory.
+	evalDir := filepath.Join(baseDir, complytime.WorkspaceDir, "opa")
+	require.NoError(t, os.MkdirAll(evalDir, 0750))
+	require.NoError(t, os.WriteFile(filepath.Join(evalDir, "scan-config.json"), []byte("{}"), 0600))
+
+	// 3. Seed cache state with a complypack entry mapping repository to evaluator.
+	cacheState := &cache.State{
+		Complypacks: map[string]cache.PolicyState{
+			"registry.example.com/packs/opa": {
+				Version:     "1.0.0",
+				Digest:      "sha256:cp-digest",
+				EvaluatorID: "opa",
+			},
+		},
+	}
+	require.NoError(t, cache.SaveState(cacheState, cacheDir))
+
+	// Reload state from disk (simulates the real flow).
+	loadedState, err := cache.LoadState(cacheDir)
+	require.NoError(t, err)
+
+	// 4. Call invalidateGenerationForComplypack.
+	invalidateGenerationForComplypack(loadedState, "registry.example.com/packs/opa", baseDir)
+
+	// 5. Verify generation state file is removed.
+	loaded, err := policy.LoadGenerationState(baseDir, "test-policy")
+	assert.NoError(t, err)
+	assert.Nil(t, loaded, "generation state should be deleted after invalidation")
+
+	// 6. Verify evaluator artifact directory is removed.
+	_, statErr := os.Stat(evalDir)
+	assert.True(t, os.IsNotExist(statErr), "evaluator artifact dir should be removed")
+}
+
+func TestInvalidateGenerationForComplypack_NoOpWhenRepositoryUnknown(t *testing.T) {
+	baseDir := t.TempDir()
+	cacheDir := t.TempDir()
+
+	// Seed generation state that should NOT be touched.
+	genState := &policy.GenerationState{
+		PolicyID:     "test-policy",
+		PolicyDigest: "sha256:abc",
+		EvaluatorIDs: []string{"opa"},
+	}
+	require.NoError(t, policy.SaveGenerationState(baseDir, "test-policy", genState))
+
+	// Empty cache state — no complypack entry for the repository.
+	cacheState := &cache.State{
+		Complypacks: make(map[string]cache.PolicyState),
+	}
+	require.NoError(t, cache.SaveState(cacheState, cacheDir))
+	loadedState, err := cache.LoadState(cacheDir)
+	require.NoError(t, err)
+
+	invalidateGenerationForComplypack(loadedState, "registry.example.com/packs/unknown", baseDir)
+
+	// Generation state should be preserved.
+	loaded, err := policy.LoadGenerationState(baseDir, "test-policy")
+	assert.NoError(t, err)
+	assert.NotNil(t, loaded, "generation state should be preserved when repository is unknown")
+}
+
+func TestInvalidateGenerationForComplypack_NestedPolicyID(t *testing.T) {
+	baseDir := t.TempDir()
+	cacheDir := t.TempDir()
+
+	genState := &policy.GenerationState{
+		PolicyID:     "policies/nested-policy",
+		PolicyDigest: "sha256:abc",
+		EvaluatorIDs: []string{"opa"},
+	}
+	require.NoError(t, policy.SaveGenerationState(baseDir, "policies/nested-policy", genState))
+
+	evalDir := filepath.Join(baseDir, complytime.WorkspaceDir, "opa")
+	require.NoError(t, os.MkdirAll(evalDir, 0750))
+	require.NoError(t, os.WriteFile(filepath.Join(evalDir, "scan-config.json"), []byte("{}"), 0600))
+
+	cacheState := &cache.State{
+		Complypacks: map[string]cache.PolicyState{
+			"registry.example.com/packs/opa": {
+				Version:     "1.0.0",
+				Digest:      "sha256:cp-digest",
+				EvaluatorID: "opa",
+			},
+		},
+	}
+	require.NoError(t, cache.SaveState(cacheState, cacheDir))
+	loadedState, err := cache.LoadState(cacheDir)
+	require.NoError(t, err)
+
+	invalidateGenerationForComplypack(loadedState, "registry.example.com/packs/opa", baseDir)
+
+	loaded, err := policy.LoadGenerationState(baseDir, "policies/nested-policy")
+	assert.NoError(t, err)
+	assert.Nil(t, loaded, "nested generation state should be deleted after invalidation")
+
+	_, statErr := os.Stat(evalDir)
+	assert.True(t, os.IsNotExist(statErr), "evaluator artifact dir should be removed")
+}
+
+func TestInvalidateGenerationForComplypack_NoOpWhenEvaluatorIDEmpty(t *testing.T) {
+	baseDir := t.TempDir()
+	cacheDir := t.TempDir()
+
+	// Seed generation state that should NOT be touched.
+	genState := &policy.GenerationState{
+		PolicyID:     "test-policy",
+		PolicyDigest: "sha256:abc",
+		EvaluatorIDs: []string{"opa"},
+	}
+	require.NoError(t, policy.SaveGenerationState(baseDir, "test-policy", genState))
+
+	// Complypack entry exists but has empty evaluator ID.
+	cacheState := &cache.State{
+		Complypacks: map[string]cache.PolicyState{
+			"registry.example.com/packs/opa": {
+				Version:     "1.0.0",
+				Digest:      "sha256:cp-digest",
+				EvaluatorID: "",
+			},
+		},
+	}
+	require.NoError(t, cache.SaveState(cacheState, cacheDir))
+	loadedState, err := cache.LoadState(cacheDir)
+	require.NoError(t, err)
+
+	invalidateGenerationForComplypack(loadedState, "registry.example.com/packs/opa", baseDir)
+
+	// Generation state should be preserved.
+	loaded, err := policy.LoadGenerationState(baseDir, "test-policy")
+	assert.NoError(t, err)
+	assert.NotNil(t, loaded, "generation state should be preserved when evaluator ID is empty")
+}

--- a/cmd/complyctl/cli/get.go
+++ b/cmd/complyctl/cli/get.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/complytime/complyctl/internal/cache"
 	"github.com/complytime/complyctl/internal/complytime"
+	"github.com/complytime/complyctl/internal/policy"
 	"github.com/complytime/complyctl/internal/registry"
 )
 
@@ -82,17 +83,17 @@ func (o *getOptions) run(ctx context.Context) error {
 
 	// Chain policy and complypack sync into a single error return.
 	// syncComplypacks is a no-op when no complypacks are configured.
-	return o.syncAll(ctx, cfg)
+	return o.syncAll(ctx, cfg, baseDir)
 }
 
 // syncAll runs policy sync followed by complypack sync. Keeping both
 // calls in a single method avoids an extra branch in run() and keeps
 // the CRAP score aligned with the baseline.
-func (o *getOptions) syncAll(ctx context.Context, cfg *complytime.WorkspaceConfig) error {
+func (o *getOptions) syncAll(ctx context.Context, cfg *complytime.WorkspaceConfig, baseDir string) error {
 	if err := o.syncPolicies(ctx, cfg); err != nil {
 		return err
 	}
-	return o.syncComplypacks(ctx, cfg)
+	return o.syncComplypacks(ctx, cfg, baseDir)
 }
 
 func (o *getOptions) syncPolicies(ctx context.Context, cfg *complytime.WorkspaceConfig) error {
@@ -115,7 +116,7 @@ func (o *getOptions) syncPolicies(ctx context.Context, cfg *complytime.Workspace
 
 // syncComplypacks fetches complypack artifacts listed in the workspace config.
 // Skips silently when no complypacks are configured.
-func (o *getOptions) syncComplypacks(ctx context.Context, cfg *complytime.WorkspaceConfig) error {
+func (o *getOptions) syncComplypacks(ctx context.Context, cfg *complytime.WorkspaceConfig, baseDir string) error {
 	if len(cfg.Complypacks) == 0 {
 		return nil
 	}
@@ -132,7 +133,7 @@ func (o *getOptions) syncComplypacks(ctx context.Context, cfg *complytime.Worksp
 		return fmt.Errorf("authentication setup failed: %w", err)
 	}
 
-	return syncAllComplypacks(ctx, state, credFunc, cfg.Complypacks, o.cacheDir)
+	return syncAllComplypacks(ctx, state, credFunc, cfg.Complypacks, o.cacheDir, baseDir)
 }
 
 func syncAllPolicies(ctx context.Context, cacheMgr *cache.Cache, state *cache.State, credFunc auth.CredentialFunc, policies []complytime.PolicyEntry) error {
@@ -189,12 +190,12 @@ func resolveLatestVersion(ctx context.Context, client *registry.Client, reposito
 	return resolvedVersion
 }
 
-func syncAllComplypacks(ctx context.Context, state *cache.State, credFunc auth.CredentialFunc, complypacks []complytime.PolicyEntry, cacheDir string) error {
+func syncAllComplypacks(ctx context.Context, state *cache.State, credFunc auth.CredentialFunc, complypacks []complytime.PolicyEntry, cacheDir, baseDir string) error {
 	logger.Info("Starting complypack synchronization", "complypack_count", len(complypacks))
 
 	total := len(complypacks)
 	for i, entry := range complypacks {
-		if err := syncSingleComplypack(ctx, state, credFunc, entry, i+1, total, cacheDir); err != nil {
+		if err := syncSingleComplypack(ctx, state, credFunc, entry, i+1, total, cacheDir, baseDir); err != nil {
 			return err
 		}
 	}
@@ -204,7 +205,7 @@ func syncAllComplypacks(ctx context.Context, state *cache.State, credFunc auth.C
 	return nil
 }
 
-func syncSingleComplypack(ctx context.Context, state *cache.State, credFunc auth.CredentialFunc, entry complytime.PolicyEntry, index, total int, cacheDir string) error {
+func syncSingleComplypack(ctx context.Context, state *cache.State, credFunc auth.CredentialFunc, entry complytime.PolicyEntry, index, total int, cacheDir, baseDir string) error {
 	ref, err := complytime.ParsePolicyRef(entry.URL)
 	if err != nil {
 		return fmt.Errorf("invalid complypack reference %q: %w", entry.URL, err)
@@ -234,7 +235,37 @@ func syncSingleComplypack(ctx context.Context, state *cache.State, credFunc auth
 	if fetched {
 		fmt.Fprintf(os.Stderr, "WARNING: complypack %s has not been cryptographically verified\n", entry.EffectiveID())
 		logger.Warn("Complypack not cryptographically verified", "complypack", entry.EffectiveID())
+		invalidateGenerationForComplypack(state, ref.Repository, baseDir)
 	}
 
 	return nil
+}
+
+// invalidateGenerationForComplypack removes workspace generation state and
+// evaluator artifacts when a complypack has been re-fetched. Errors are logged
+// as warnings — they do not fail the get command.
+func invalidateGenerationForComplypack(state *cache.State, repository, baseDir string) {
+	ps, exists := state.GetComplypackState(repository)
+	if !exists || ps.EvaluatorID == "" {
+		return
+	}
+	evalID := ps.EvaluatorID
+
+	skipWarnings, err := policy.InvalidateForEvaluator(baseDir, evalID)
+	for _, w := range skipWarnings {
+		logger.Debug("Generation state invalidation", "warning", w)
+	}
+	if err != nil {
+		logger.Warn("Failed to invalidate generation state", "evaluator", evalID, "error", err)
+		fmt.Fprintf(os.Stderr, "WARNING: failed to invalidate generation state for %s: %v\n", evalID, err)
+		return
+	}
+	if err := policy.RemoveEvaluatorArtifacts(baseDir, evalID); err != nil {
+		logger.Warn("Failed to remove evaluator artifacts", "evaluator", evalID, "error", err)
+		fmt.Fprintf(os.Stderr, "WARNING: failed to remove evaluator artifacts for %s: %v\n", evalID, err)
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, "Complypack %s updated — generation cache invalidated for %s\n", repository, evalID)
+	logger.Info("Generation cache invalidated after complypack update", "repository", repository, "evaluator", evalID)
 }

--- a/internal/policy/generation_state.go
+++ b/internal/policy/generation_state.go
@@ -8,8 +8,11 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"time"
 
+	"github.com/complytime/complyctl/internal/cache"
 	"github.com/complytime/complyctl/internal/complytime"
 )
 
@@ -91,4 +94,60 @@ func NewGenerationState(policyID, digest string, evaluatorIDs []string, complypa
 		GeneratedAt:       time.Now().UTC().Format(time.RFC3339),
 		EvaluatorIDs:      evaluatorIDs,
 	}
+}
+
+// InvalidateForEvaluator removes generation state files that reference the
+// given evaluator-id. This forces the next scan to trigger a fresh Generate
+// cycle for any policy that used that evaluator. Returns nil if the generation
+// directory does not exist. Walks subdirectories since policy IDs may contain
+// path separators (e.g. "policies/cis-fedora-l1-workstation").
+//
+// Files that cannot be read or contain malformed JSON are skipped and reported
+// in the returned warnings slice so the caller can log them for diagnostics.
+func InvalidateForEvaluator(baseDir, evaluatorID string) (warnings []string, _ error) {
+	genDir := filepath.Join(baseDir, complytime.WorkspaceDir, "generation")
+
+	err := filepath.WalkDir(genDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".json") {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			warnings = append(warnings, fmt.Sprintf("skipped unreadable file %s: %v", path, readErr))
+			return nil
+		}
+		var state GenerationState
+		if jsonErr := json.Unmarshal(data, &state); jsonErr != nil {
+			warnings = append(warnings, fmt.Sprintf("skipped malformed JSON %s: %v", path, jsonErr))
+			return nil
+		}
+		if slices.Contains(state.EvaluatorIDs, evaluatorID) {
+			if rmErr := os.Remove(path); rmErr != nil && !os.IsNotExist(rmErr) {
+				return fmt.Errorf("failed to remove generation state %s: %w", path, rmErr)
+			}
+		}
+		return nil
+	})
+	return warnings, err
+}
+
+// RemoveEvaluatorArtifacts removes the workspace evaluator artifact directory
+// ({baseDir}/.complytime/{evaluatorID}/). Returns nil if the directory does
+// not exist. Validates evaluatorID as a safe path component before constructing
+// the target path.
+func RemoveEvaluatorArtifacts(baseDir, evaluatorID string) error {
+	if err := cache.ValidatePathComponent(evaluatorID); err != nil {
+		return fmt.Errorf("invalid evaluator ID: %w", err)
+	}
+	dir := filepath.Join(baseDir, complytime.WorkspaceDir, evaluatorID)
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("failed to remove evaluator artifacts %s: %w", dir, err)
+	}
+	return nil
 }

--- a/internal/policy/generation_state_test.go
+++ b/internal/policy/generation_state_test.go
@@ -163,3 +163,200 @@ func TestNewGenerationState_NilEvaluatorIDs(t *testing.T) {
 	assert.Nil(t, state.EvaluatorIDs)
 	assert.Nil(t, state.ComplypackDigests)
 }
+
+// --- InvalidateForEvaluator tests ---
+
+func TestInvalidateForEvaluator_RemovesMatchingState(t *testing.T) {
+	baseDir := t.TempDir()
+	state := &GenerationState{
+		PolicyID:     "test-policy",
+		PolicyDigest: "sha256:abc",
+		EvaluatorIDs: []string{"opa", "ampel"},
+	}
+	require.NoError(t, SaveGenerationState(baseDir, "test-policy", state))
+
+	warnings, err := InvalidateForEvaluator(baseDir, "opa")
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+
+	loaded, err := LoadGenerationState(baseDir, "test-policy")
+	assert.NoError(t, err)
+	assert.Nil(t, loaded, "generation state referencing 'opa' should be deleted")
+}
+
+func TestInvalidateForEvaluator_PreservesUnrelatedState(t *testing.T) {
+	baseDir := t.TempDir()
+
+	opaState := &GenerationState{
+		PolicyID:     "policy-a",
+		PolicyDigest: "sha256:aaa",
+		EvaluatorIDs: []string{"opa"},
+	}
+	ampelState := &GenerationState{
+		PolicyID:     "policy-b",
+		PolicyDigest: "sha256:bbb",
+		EvaluatorIDs: []string{"ampel"},
+	}
+	require.NoError(t, SaveGenerationState(baseDir, "policy-a", opaState))
+	require.NoError(t, SaveGenerationState(baseDir, "policy-b", ampelState))
+
+	warnings, err := InvalidateForEvaluator(baseDir, "opa")
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+
+	loaded, err := LoadGenerationState(baseDir, "policy-a")
+	assert.NoError(t, err)
+	assert.Nil(t, loaded, "policy-a should be removed (references opa)")
+
+	loaded, err = LoadGenerationState(baseDir, "policy-b")
+	assert.NoError(t, err)
+	assert.NotNil(t, loaded, "policy-b should be preserved (only references ampel)")
+}
+
+func TestInvalidateForEvaluator_NoGenerationDir(t *testing.T) {
+	baseDir := t.TempDir()
+	warnings, err := InvalidateForEvaluator(baseDir, "opa")
+	assert.NoError(t, err, "should not error when generation/ does not exist")
+	assert.Empty(t, warnings)
+}
+
+func TestInvalidateForEvaluator_MalformedJSON(t *testing.T) {
+	baseDir := t.TempDir()
+	genDir := filepath.Join(baseDir, complytime.WorkspaceDir, "generation")
+	require.NoError(t, os.MkdirAll(genDir, 0750))
+	require.NoError(t, os.WriteFile(filepath.Join(genDir, "bad.json"), []byte("{invalid"), 0600))
+
+	warnings, err := InvalidateForEvaluator(baseDir, "opa")
+	assert.NoError(t, err, "malformed JSON files should be skipped, not cause an error")
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "skipped malformed JSON")
+	assert.Contains(t, warnings[0], "bad.json")
+
+	_, statErr := os.Stat(filepath.Join(genDir, "bad.json"))
+	assert.NoError(t, statErr, "malformed file should not be removed")
+}
+
+func TestInvalidateForEvaluator_UnreadableFile(t *testing.T) {
+	baseDir := t.TempDir()
+	genDir := filepath.Join(baseDir, complytime.WorkspaceDir, "generation")
+	require.NoError(t, os.MkdirAll(genDir, 0750))
+
+	unreadable := filepath.Join(genDir, "locked.json")
+	require.NoError(t, os.WriteFile(unreadable, []byte(`{"evaluator_ids":["opa"]}`), 0000))
+	t.Cleanup(func() { _ = os.Chmod(unreadable, 0600) })
+
+	warnings, err := InvalidateForEvaluator(baseDir, "opa")
+	assert.NoError(t, err)
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "skipped unreadable file")
+	assert.Contains(t, warnings[0], "locked.json")
+}
+
+func TestInvalidateForEvaluator_NestedPolicyID(t *testing.T) {
+	baseDir := t.TempDir()
+	state := &GenerationState{
+		PolicyID:     "policies/nested-policy",
+		PolicyDigest: "sha256:abc",
+		EvaluatorIDs: []string{"opa"},
+	}
+	require.NoError(t, SaveGenerationState(baseDir, "policies/nested-policy", state))
+
+	warnings, err := InvalidateForEvaluator(baseDir, "opa")
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+
+	loaded, err := LoadGenerationState(baseDir, "policies/nested-policy")
+	assert.NoError(t, err)
+	assert.Nil(t, loaded, "nested generation state referencing 'opa' should be deleted")
+}
+
+func TestInvalidateForEvaluator_NestedNonJSONPreserved(t *testing.T) {
+	baseDir := t.TempDir()
+	genDir := filepath.Join(baseDir, complytime.WorkspaceDir, "generation", "policies")
+	require.NoError(t, os.MkdirAll(genDir, 0750))
+
+	require.NoError(t, os.WriteFile(filepath.Join(genDir, "README.md"), []byte("# keep"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(genDir, "metadata.yaml"), []byte("keep: true"), 0600))
+
+	state := &GenerationState{
+		PolicyID:     "policies/target",
+		PolicyDigest: "sha256:abc",
+		EvaluatorIDs: []string{"opa"},
+	}
+	require.NoError(t, SaveGenerationState(baseDir, "policies/target", state))
+
+	warnings, err := InvalidateForEvaluator(baseDir, "opa")
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+
+	loaded, err := LoadGenerationState(baseDir, "policies/target")
+	assert.NoError(t, err)
+	assert.Nil(t, loaded, "matching state should be deleted")
+
+	_, statErr := os.Stat(filepath.Join(genDir, "README.md"))
+	assert.NoError(t, statErr, "nested non-JSON file should be preserved")
+
+	_, statErr = os.Stat(filepath.Join(genDir, "metadata.yaml"))
+	assert.NoError(t, statErr, "nested non-JSON file should be preserved")
+}
+
+// --- RemoveEvaluatorArtifacts tests ---
+
+func TestRemoveEvaluatorArtifacts_RemovesDir(t *testing.T) {
+	baseDir := t.TempDir()
+	evalDir := filepath.Join(baseDir, complytime.WorkspaceDir, "opa")
+	require.NoError(t, os.MkdirAll(evalDir, 0750))
+	require.NoError(t, os.WriteFile(filepath.Join(evalDir, "scan-config.json"), []byte("{}"), 0600))
+
+	err := RemoveEvaluatorArtifacts(baseDir, "opa")
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(evalDir)
+	assert.True(t, os.IsNotExist(statErr), "evaluator artifact dir should be removed")
+}
+
+func TestRemoveEvaluatorArtifacts_DirNotExist(t *testing.T) {
+	baseDir := t.TempDir()
+	err := RemoveEvaluatorArtifacts(baseDir, "nonexistent")
+	assert.NoError(t, err, "should not error when dir does not exist")
+}
+
+func TestInvalidateForEvaluator_IgnoresNonJSONFiles(t *testing.T) {
+	baseDir := t.TempDir()
+	genDir := filepath.Join(baseDir, complytime.WorkspaceDir, "generation")
+	require.NoError(t, os.MkdirAll(genDir, 0750))
+
+	// Place a non-JSON file alongside a valid JSON state file.
+	require.NoError(t, os.WriteFile(filepath.Join(genDir, "notes.txt"), []byte("keep me"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(genDir, "backup.bak"), []byte("keep me too"), 0600))
+
+	state := &GenerationState{
+		PolicyID:     "policy-x",
+		PolicyDigest: "sha256:xxx",
+		EvaluatorIDs: []string{"opa"},
+	}
+	require.NoError(t, SaveGenerationState(baseDir, "policy-x", state))
+
+	warnings, err := InvalidateForEvaluator(baseDir, "opa")
+	require.NoError(t, err)
+	assert.Empty(t, warnings)
+
+	// JSON state file referencing 'opa' should be deleted.
+	loaded, err := LoadGenerationState(baseDir, "policy-x")
+	assert.NoError(t, err)
+	assert.Nil(t, loaded, "JSON state file should be deleted")
+
+	// Non-JSON files should be preserved.
+	_, statErr := os.Stat(filepath.Join(genDir, "notes.txt"))
+	assert.NoError(t, statErr, "non-JSON .txt file should be preserved")
+
+	_, statErr = os.Stat(filepath.Join(genDir, "backup.bak"))
+	assert.NoError(t, statErr, "non-JSON .bak file should be preserved")
+}
+
+func TestRemoveEvaluatorArtifacts_RejectsPathTraversal(t *testing.T) {
+	baseDir := t.TempDir()
+	err := RemoveEvaluatorArtifacts(baseDir, "../../etc")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid evaluator ID")
+}

--- a/openspec/changes/fix-complypack-cache-invalidation/.openspec.yaml
+++ b/openspec/changes/fix-complypack-cache-invalidation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-06-30

--- a/openspec/changes/fix-complypack-cache-invalidation/design.md
+++ b/openspec/changes/fix-complypack-cache-invalidation/design.md
@@ -1,0 +1,64 @@
+## Context
+
+`complyctl get` calls `ComplypackCache.Store()` which does `os.RemoveAll(finalDir)` followed by `os.Rename(tmpDir, finalDir)`. This atomic replacement destroys any provider-extracted `content/` subdirectory that lived inside the version directory. The workspace generation cache (`.complytime/generation/*.json`) and evaluator artifact directories (`.complytime/{evaluator}/`) are not touched by `get`, causing the next `complyctl scan` to skip Generate and read stale paths.
+
+Issue #583 (closed) added complypack digest tracking to `GenerationState.IsFresh()` as a lazy detection mechanism. However, this fails when:
+1. The remote digest is unchanged (same manifest, re-pushed content)
+2. Provider artifacts reference absolute paths into the replaced cache directory
+
+Eager invalidation at fetch time eliminates both failure modes.
+
+## Goals / Non-Goals
+
+### Goals
+- When a complypack is re-fetched, eagerly invalidate workspace generation state for the affected evaluator-id
+- Remove stale evaluator artifact directories that may contain dead path references
+- Provide clear stderr feedback when invalidation occurs
+- Maintain backward compatibility (workspaces without complypacks are unaffected)
+
+### Non-Goals
+- Evicting old complypack versions from cache (follow-up: #646)
+- Fixing `LookupByEvaluatorID` non-determinism (follow-up: #645)
+- Validating duplicate evaluator-ids across repos (follow-up: #647)
+- Adding `--force` flag to `get` (follow-up: #649)
+- Invalidating on policy re-sync (lower severity, policies don't do destructive replace)
+
+## Decisions
+
+### D1: Eager invalidation in `get`, not lazy detection in `scan`
+
+**Decision**: When `SyncComplypack` returns `fetched == true`, immediately delete generation state files and evaluator artifacts in the workspace.
+
+**Rationale**: Lazy detection via `IsFresh()` already exists but has failure modes (unchanged digest, stale paths in provider artifacts). Eager invalidation is a belt-and-suspenders approach that guarantees correctness. The cost is minimal — deleting a few JSON files and a directory.
+
+**Alternatives considered**: Strengthen `evaluatorArtifactsExist()` to check content validity (e.g., verify referenced paths in scan-config.json). Rejected — too coupled to provider internals; complyctl should not parse provider-specific config formats.
+
+### D2: Thread `baseDir` through sync functions
+
+**Decision**: Add a `baseDir string` parameter to `syncComplypacks()`, `syncAllComplypacks()`, and `syncSingleComplypack()`. The value comes from `o.ResolveWorkspace()` which is already called in `run()`.
+
+**Rationale**: The workspace path is needed to locate `.complytime/generation/` and `.complytime/{evaluator}/`. Passing it explicitly keeps the dependency visible. Using a struct field on `getOptions` was considered but rejected to avoid widening the struct's surface for a single use case.
+
+### D3: Resolve evaluator-id from state after sync
+
+**Decision**: After `SyncComplypack` returns `fetched == true`, read `state.Complypacks[repository].EvaluatorID` to get the evaluator-id for invalidation.
+
+**Rationale**: The evaluator-id is only known after unpacking the complypack artifact. `SyncComplypack` already calls `state.UpdateComplypackState(repository, version, digest, evaluatorID)` before returning, so the state is guaranteed to have the correct evaluator-id at this point.
+
+### D4: Invalidation helper scans generation/*.json files
+
+**Decision**: `InvalidateForEvaluator(baseDir, evaluatorID)` reads all `.json` files in `{baseDir}/.complytime/generation/`, unmarshals each to check the `evaluator_ids` field, and removes files where the slice contains the target evaluator-id.
+
+**Rationale**: Generation state files are keyed by policy repository (not evaluator-id), so a scan is necessary to find affected files. The generation directory is small (one file per configured policy), so the scan is cheap.
+
+### D5: Non-fatal invalidation errors are logged, not returned
+
+**Decision**: If invalidation fails (e.g., permission error on removal), log a warning to stderr and continue. Do not fail the `get` command.
+
+**Rationale**: The complypack was successfully fetched and cached. Failing `get` due to a workspace cleanup issue would be confusing. The next `scan` will trigger regeneration anyway via the digest mismatch path (secondary defense).
+
+## Risks / Trade-offs
+
+- **[`get` now touches workspace]** Previously `get` only wrote to the global cache (`~/.complytime/`). Now it also modifies workspace-local files. This is acceptable — the alternative is silent corruption.
+- **[Scan after interrupted invalidation]** If `get` crashes between writing the new complypack and completing invalidation, stale state may persist. Mitigation: the digest-based `IsFresh()` check in `scan` acts as a secondary defense.
+- **[Multi-workspace scenarios]** If multiple workspaces reference the same complypack, only the resolved workspace is invalidated. Other workspaces will rely on lazy digest detection. This is acceptable for the initial fix; a follow-up could invalidate all known workspaces.

--- a/openspec/changes/fix-complypack-cache-invalidation/proposal.md
+++ b/openspec/changes/fix-complypack-cache-invalidation/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+`complyctl get` re-syncs complypack artifacts via atomic directory replacement (`RemoveAll` + `Rename`), destroying any provider-extracted content inside `~/.complytime/complypacks/<evaluator>/<version>/`. The workspace generation cache (`.complytime/generation/`) and provider artifact directories (`.complytime/<evaluator>/`) are not invalidated. The next `complyctl scan` sees matching digests and existing artifact directories, prints "Reusing generated artifacts...", and the provider reads a dead path from stale configuration files.
+
+This is tracked in [issue #551](https://github.com/complytime/complyctl/issues/551). The workaround requires manual deletion of generation state and evaluator artifacts before each scan after a re-fetch.
+
+## What Changes
+
+- When `complyctl get` fetches a complypack (`fetched == true`), it eagerly invalidates the workspace generation state for the affected evaluator-id and removes stale workspace artifacts for that evaluator.
+- A new `InvalidateForEvaluator` helper scans generation state files and removes those referencing the updated evaluator-id.
+- A new `RemoveEvaluatorArtifacts` helper removes the workspace evaluator artifact directory.
+- The `syncComplypacks` call chain gains access to the workspace `baseDir` to perform invalidation.
+
+## Capabilities
+
+### New Capabilities
+- `generation-invalidation`: Eager invalidation of workspace generation state and evaluator artifacts when a complypack is re-fetched, ensuring the next scan triggers a fresh Generate cycle.
+
+### Modified Capabilities
+- `get`: When a complypack fetch occurs, the command now invalidates workspace generation cache for the affected evaluator-id and emits a message to stderr.
+
+### Removed Capabilities
+- None. This is purely additive behavior on an existing code path.
+
+## Impact
+
+- `cmd/complyctl/cli/get.go` — `syncComplypacks`, `syncAllComplypacks`, `syncSingleComplypack` gain `baseDir` parameter; invalidation logic added when `fetched == true`
+- `internal/policy/generation_state.go` — new `InvalidateForEvaluator()` and `RemoveEvaluatorArtifacts()` functions
+- `internal/policy/generation_state_test.go` — new unit tests for invalidation helpers
+- `cmd/complyctl/cli/cli_test.go` — integration test for the full invalidation flow
+
+## Constitution Alignment
+
+### I. Autonomous Collaboration
+
+**Assessment**: PASS
+
+The fix produces self-describing behavior: stderr messages inform the user when invalidation occurs. No manual intervention is needed after `get` to achieve correct scan behavior.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+Invalidation is scoped per-evaluator-id. Unrelated evaluators and their generation state are untouched. The helpers are standalone functions usable by other callers if needed.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+Invalidation emits a stderr message indicating which evaluator's cache was cleared. Generation state files are machine-parseable JSON. The behavior is deterministic and testable.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+Each helper (`InvalidateForEvaluator`, `RemoveEvaluatorArtifacts`) is independently testable with filesystem isolation via `t.TempDir()`. The integration flow is testable by mocking the sync return value.

--- a/openspec/changes/fix-complypack-cache-invalidation/specs/cache-invalidation/spec.md
+++ b/openspec/changes/fix-complypack-cache-invalidation/specs/cache-invalidation/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Get command invalidates generation cache on complypack re-fetch
+
+When `complyctl get` fetches a complypack that replaces an existing cached version, the command SHALL invalidate the workspace generation state for all policies that reference the affected evaluator-id. The command SHALL also remove the workspace evaluator artifact directory for the affected evaluator-id.
+
+#### Scenario: Complypack re-sync triggers generation invalidation
+
+- **GIVEN** a workspace with generation state referencing evaluator "opa" and evaluator artifacts at `.complytime/opa/`
+- **WHEN** `complyctl get` fetches a new complypack for evaluator "opa" (`fetched == true`)
+- **THEN** the generation state file(s) whose `evaluator_ids` include "opa" SHALL be deleted
+- **AND** the workspace evaluator artifact directory `.complytime/opa/` SHALL be removed
+- **AND** a message SHALL be emitted to stderr indicating the invalidation occurred
+
+#### Scenario: Complypack incremental skip does not invalidate
+
+- **GIVEN** a workspace with generation state referencing evaluator "opa"
+- **WHEN** `complyctl get` determines the remote complypack digest matches the local cache (`fetched == false`)
+- **THEN** the generation state SHALL NOT be modified
+- **AND** the workspace evaluator artifact directory SHALL NOT be removed
+
+#### Scenario: Invalidation preserves unrelated evaluator state
+
+- **GIVEN** a workspace with generation state for evaluators "opa" and "ampel"
+- **WHEN** `complyctl get` fetches a new complypack for evaluator "opa" only
+- **THEN** only generation state files referencing "opa" SHALL be deleted
+- **AND** generation state files referencing only "ampel" SHALL be preserved
+- **AND** the `.complytime/ampel/` artifact directory SHALL NOT be removed
+
+#### Scenario: No generation state directory exists
+
+- **GIVEN** a workspace with no `.complytime/generation/` directory
+- **WHEN** `complyctl get` fetches a complypack
+- **THEN** the invalidation SHALL complete without error (no-op)
+
+#### Scenario: No evaluator artifact directory exists
+
+- **GIVEN** a workspace with generation state but no `.complytime/{evaluator}/` directory
+- **WHEN** `complyctl get` fetches a complypack for that evaluator
+- **THEN** the generation state SHALL be deleted
+- **AND** the artifact removal SHALL complete without error (no-op for missing dir)
+
+## MODIFIED Requirements
+
+None — existing generation freshness checking via `IsFresh()` remains as the secondary defense layer. This change adds eager invalidation as a primary defense.
+
+## REMOVED Requirements
+
+None.

--- a/openspec/changes/fix-complypack-cache-invalidation/tasks.md
+++ b/openspec/changes/fix-complypack-cache-invalidation/tasks.md
@@ -1,0 +1,44 @@
+## 1. Add generation state invalidation helpers
+
+- [x] 1.1 Add `InvalidateForEvaluator(baseDir, evaluatorID string) (warnings []string, _ error)` to `internal/policy/generation_state.go` — walks `.complytime/generation/` tree (supports nested policy IDs), loads each `.json`, removes files whose `EvaluatorIDs` slice contains the target evaluator-id. Returns nil if the generation directory does not exist. Reports skipped files as warnings.
+- [x] 1.2 Add `RemoveEvaluatorArtifacts(baseDir, evaluatorID string) error` to `internal/policy/generation_state.go` — calls `os.RemoveAll` on `{baseDir}/.complytime/{evaluatorID}/`. Returns nil if the directory does not exist. Validates evaluatorID against path traversal.
+- [x] 1.3 [P] Add unit tests in `internal/policy/generation_state_test.go`:
+  - `TestInvalidateForEvaluator_RemovesMatchingState`
+  - `TestInvalidateForEvaluator_PreservesUnrelatedState`
+  - `TestInvalidateForEvaluator_NoGenerationDir`
+  - `TestInvalidateForEvaluator_MalformedJSON` (verifies warning returned)
+  - `TestInvalidateForEvaluator_UnreadableFile` (verifies warning returned)
+  - `TestInvalidateForEvaluator_NestedPolicyID`
+  - `TestInvalidateForEvaluator_NestedNonJSONPreserved`
+  - `TestInvalidateForEvaluator_IgnoresNonJSONFiles`
+  - `TestRemoveEvaluatorArtifacts_RemovesDir`
+  - `TestRemoveEvaluatorArtifacts_DirNotExist`
+  - `TestRemoveEvaluatorArtifacts_RejectsPathTraversal`
+
+## 2. Thread baseDir through complypack sync in get.go
+
+- [x] 2.1 Add `baseDir string` parameter to `syncComplypacks` method on `getOptions`
+- [x] 2.2 Add `baseDir string` parameter to `syncAllComplypacks` function
+- [x] 2.3 Add `baseDir string` parameter to `syncSingleComplypack` function
+- [x] 2.4 Update `syncAll` to pass `baseDir` (already available from `run()` via closure or parameter threading)
+
+## 3. Wire invalidation on complypack fetch
+
+- [x] 3.1 In `syncSingleComplypack`, when `fetched == true`: read `state.Complypacks[ref.Repository].EvaluatorID`
+- [x] 3.2 Call `policy.InvalidateForEvaluator(baseDir, evaluatorID)` — log skip-warnings at Debug level, log error at Warn level, do not fail
+- [x] 3.3 Call `policy.RemoveEvaluatorArtifacts(baseDir, evaluatorID)` — log warning on error, do not fail
+- [x] 3.4 Emit stderr message: `"Complypack %s updated — generation cache invalidated for %s\n"`
+
+## 4. Integration test
+
+- [x] 4.1 [P] Add tests in `cmd/complyctl/cli/cli_test.go`:
+  - `TestInvalidateGenerationForComplypack_InvalidatesOnFetch`
+  - `TestInvalidateGenerationForComplypack_NestedPolicyID`
+  - `TestInvalidateGenerationForComplypack_NoOpWhenRepositoryUnknown`
+  - `TestInvalidateGenerationForComplypack_NoOpWhenEvaluatorIDEmpty`
+
+## 5. Verification
+
+- [x] 5.1 Run `go test -race ./...` and confirm all tests pass
+- [x] 5.2 Run `go vet ./...` and confirm no vet errors
+- [x] 5.3 Verify #551 reproduction steps no longer produce the stale-path error (local repro with mock-oci-registry)


### PR DESCRIPTION
## Summary

- Fixes #551 — `complyctl scan` no longer uses stale generation state after
  `complyctl get` re-fetches a complypack. When a complypack is re-fetched,
  the workspace generation state and evaluator artifact directory are eagerly
  invalidated so the next scan triggers a fresh Generate cycle.
- Adds `InvalidateForEvaluator()` and `RemoveEvaluatorArtifacts()` helpers to
  `internal/policy/generation_state.go` with full test coverage.
- Threads `baseDir` through the complypack sync call chain in `get.go` so
  invalidation can locate the workspace generation directory.

## Changes

| File | What |
|------|------|
| `internal/policy/generation_state.go` | New `InvalidateForEvaluator()` (walks nested dirs, returns skip-warnings) and `RemoveEvaluatorArtifacts()` (path-traversal safe) |
| `cmd/complyctl/cli/get.go` | `invalidateGenerationForComplypack()` orchestrator; `baseDir` threaded through sync functions |
| `internal/policy/generation_state_test.go` | 11 unit tests covering matching, nesting, malformed JSON, unreadable files, path traversal |
| `cmd/complyctl/cli/cli_test.go` | 4 integration tests for the orchestrator function |
| `openspec/changes/fix-complypack-cache-invalidation/` | Proposal, spec, design, and tasks artifacts |

## Test plan

- [x] `go test -race ./internal/policy/ ./cmd/complyctl/cli/` passes
- [x] `go vet ./...` clean
- [x] Local e2e reproduction: get → scan → get (forced re-fetch) → scan regenerates
- [ ] CI unit tests pass
- [ ] CI e2e tests pass

Closes #551