### PR TITLE
docs: add provider installation guidance

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -44,3 +44,7 @@ make build-test-provider
 ```
 
 Produces `bin/complyctl-provider-test` for use in E2E testing. See [E2E_INTEGRATION.md](E2E_INTEGRATION.md).
+
+## Next steps
+
+complyctl requires scanning providers to run compliance scans. After installing complyctl, see the [Quick Start](QUICK_START.md) to set up a provider and run your first scan.

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -6,14 +6,9 @@ See [INSTALLATION.md](INSTALLATION.md).
 
 ## Step 2: Install a provider
 
-Scanning providers are standalone executables placed in `~/.complytime/providers/`. The filename determines the evaluator ID.
-
-```bash
-mkdir -p ~/.complytime/providers
-cp bin/complyctl-provider-<name> ~/.complytime/providers/
-```
-
-Naming convention: `complyctl-provider-<evaluator-id>`. The CLI strips the prefix to derive the evaluator ID used for routing.
+Scanning providers are standalone executables that integrate
+complyctl with policy engines. At least one provider must be
+installed before `complyctl scan` can run.
 
 ### Available providers
 
@@ -21,8 +16,53 @@ Naming convention: `complyctl-provider-<evaluator-id>`. The CLI strips the prefi
 |----------|--------|-------------------|---------------|
 | [openscap](https://github.com/complytime/complytime-providers/blob/main/cmd/openscap-provider/docs/configuration.md) | `complyctl-provider-openscap` | SCAP policies (CIS, STIG, HIPAA, OSPP, etc.) | `openscap-scanner`, `scap-security-guide` |
 | [ampel](https://github.com/complytime/complytime-providers/tree/main/cmd/ampel-provider) | `complyctl-provider-ampel` | GitHub / GitLab branch protection | `snappy`, `ampel`, `GITHUB_TOKEN` or `GITLAB_TOKEN` |
+| [opa](https://github.com/complytime/complytime-providers/tree/main/cmd/opa-provider) | `complyctl-provider-opa` | OPA/Rego policies via conftest | `conftest`, `git` |
 
-See the [Provider Guide](https://github.com/complytime/complytime-providers/blob/main/docs/provider-guide.md) for authoring details.
+Pre-built Linux binaries (ampel, opa) are available from the
+[complytime-providers releases](https://github.com/complytime/complytime-providers/releases/latest)
+page. To build from source, see the
+[complytime-providers README](https://github.com/complytime/complytime-providers#install).
+Provider binaries go in `~/.complytime/providers/`.
+
+### Install provider prerequisites
+
+Each provider requires external tools on `PATH`. Install the
+prerequisites for the provider(s) you plan to use.
+
+**Ampel:**
+
+```bash
+go install github.com/carabiner-dev/snappy@v0.2.4
+go install github.com/carabiner-dev/ampel/cmd/ampel@v1.2.1
+```
+
+**OPA:**
+
+```bash
+go install github.com/open-policy-agent/conftest@v0.68.2
+```
+
+`git` is also required and is typically already installed.
+
+**OpenSCAP** (Fedora / RHEL / CentOS):
+
+```bash
+sudo dnf install openscap-scanner scap-security-guide
+```
+
+### Verify the installation
+
+```bash
+complyctl doctor
+```
+
+`doctor` checks whether provider binaries are discovered and
+whether each provider's prerequisites are met. You can also
+list discovered providers directly:
+
+```bash
+complyctl providers
+```
 
 ## Step 3: Create workspace config
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -18,11 +18,13 @@ installed before `complyctl scan` can run.
 | [ampel](https://github.com/complytime/complytime-providers/tree/main/cmd/ampel-provider) | `complyctl-provider-ampel` | GitHub / GitLab branch protection | `snappy`, `ampel`, `GITHUB_TOKEN` or `GITLAB_TOKEN` |
 | [opa](https://github.com/complytime/complytime-providers/tree/main/cmd/opa-provider) | `complyctl-provider-opa` | OPA/Rego policies via conftest | `conftest`, `git` |
 
-Pre-built Linux binaries (ampel, opa) are available from the
+Pre-built Linux binaries are available from the
 [complytime-providers releases](https://github.com/complytime/complytime-providers/releases/latest)
 page. To build from source, see the
 [complytime-providers README](https://github.com/complytime/complytime-providers#install).
 Provider binaries go in `~/.complytime/providers/`.
+
+See the [Provider Guide](https://github.com/complytime/complytime-providers/blob/main/docs/provider-guide.md) for authoring new providers.
 
 ### Install provider prerequisites
 


### PR DESCRIPTION
## Summary

Expand Quick Start Step 2 with provider setup guidance, addressing all four points from #623:

1. **Available providers and where to download them** — Added OPA provider row to the table. Added links to [complytime-providers releases](https://github.com/complytime/complytime-providers/releases/latest) for pre-built binaries and [complytime-providers README](https://github.com/complytime/complytime-providers#install) for build-from-source.
2. **Installation paths** — Documented `~/.complytime/providers/`.
3. **Per-provider dependencies** — Added install commands for each provider's prerequisites (`conftest`, `snappy`, `ampel`, `openscap-scanner`, `scap-security-guide`) with pinned versions.
4. **Verification command** — Documented `complyctl doctor` and `complyctl providers`.

Also added a "Next steps" section to `INSTALLATION.md` pointing to the Quick Start.

## Files Changed

- `docs/QUICK_START.md` — Expanded Step 2 with provider setup section
- `docs/INSTALLATION.md` — Added "Next steps" section

Closes #623