### PR TITLE
fix: complypack cache reliability — version eviction and generation state accuracy

### DIFF
--- a/cmd/complyctl/cli/cli_test.go
+++ b/cmd/complyctl/cli/cli_test.go
@@ -448,8 +448,9 @@ func TestGenerateForAllTargets_EmptyGroups(t *testing.T) {
 	cacheDir := t.TempDir()
 	groups := map[string]policy.EvaluatorGroup{}
 	targets := []complytime.TargetConfig{{ID: "local"}}
-	err := generateForAllTargets(context.Background(), cacheDir, nil, groups, targets, nil)
+	available, err := generateForAllTargets(context.Background(), cacheDir, nil, groups, targets, nil)
 	assert.NoError(t, err)
+	assert.Empty(t, available)
 }
 
 // --- getOptions tests ---
@@ -1058,6 +1059,188 @@ func TestComplypackDigestsByEvaluator_ExtractsDigests(t *testing.T) {
 		"io.complytime.opa":   "sha256:aaa",
 		"io.complytime.ampel": "sha256:bbb",
 	}, result)
+}
+
+// --- filterComplypackDigests tests ---
+
+func TestFilterComplypackDigests_AllAvailable(t *testing.T) {
+	allDigests := map[string]string{
+		"io.complytime.opa":   "sha256:aaa",
+		"io.complytime.ampel": "sha256:bbb",
+	}
+	available := []string{"io.complytime.opa", "io.complytime.ampel"}
+	result := filterComplypackDigests(allDigests, available)
+	assert.Equal(t, map[string]string{
+		"io.complytime.opa":   "sha256:aaa",
+		"io.complytime.ampel": "sha256:bbb",
+	}, result)
+}
+
+func TestFilterComplypackDigests_Unavailable(t *testing.T) {
+	allDigests := map[string]string{
+		"io.complytime.opa":   "sha256:aaa",
+		"io.complytime.ampel": "sha256:bbb",
+	}
+	// Only opa was available; ampel had no content.
+	available := []string{"io.complytime.opa"}
+	result := filterComplypackDigests(allDigests, available)
+	assert.Equal(t, map[string]string{
+		"io.complytime.opa": "sha256:aaa",
+	}, result)
+	assert.NotContains(t, result, "io.complytime.ampel",
+		"unavailable evaluator must not have digest recorded")
+}
+
+func TestFilterComplypackDigests_MixedAvailability(t *testing.T) {
+	allDigests := map[string]string{
+		"io.complytime.opa":     "sha256:aaa",
+		"io.complytime.ampel":   "sha256:bbb",
+		"io.complytime.kyverno": "sha256:ccc",
+	}
+	available := []string{"io.complytime.opa", "io.complytime.kyverno"}
+	result := filterComplypackDigests(allDigests, available)
+	assert.Equal(t, map[string]string{
+		"io.complytime.opa":     "sha256:aaa",
+		"io.complytime.kyverno": "sha256:ccc",
+	}, result)
+	assert.NotContains(t, result, "io.complytime.ampel")
+}
+
+func TestFilterComplypackDigests_NoComplypacks(t *testing.T) {
+	allDigests := map[string]string{
+		"io.complytime.opa": "sha256:aaa",
+	}
+	// No evaluators had complypack content available.
+	result := filterComplypackDigests(allDigests, nil)
+	assert.Empty(t, result, "nil availableEvaluators should produce empty digests")
+
+	result = filterComplypackDigests(allDigests, []string{})
+	assert.Empty(t, result, "empty availableEvaluators should produce empty digests")
+}
+
+// --- saveGenerationAndPrint integration tests ---
+
+func TestSaveGenerationAndPrint_AllComplypacksAvailable(t *testing.T) {
+	cacheDir := t.TempDir()
+	baseDir := t.TempDir()
+
+	// Set up cache state with two complypack entries.
+	state := &cache.State{
+		Policies: map[string]cache.PolicyState{
+			"test-repo": {Version: "1.0.0", Digest: "sha256:policy-digest"},
+		},
+		Complypacks: map[string]cache.PolicyState{
+			"example.com/cp/opa":   {EvaluatorID: "io.complytime.opa", Digest: "sha256:opa-digest"},
+			"example.com/cp/ampel": {EvaluatorID: "io.complytime.ampel", Digest: "sha256:ampel-digest"},
+		},
+	}
+	require.NoError(t, cache.SaveState(state, cacheDir))
+
+	// Both evaluators had content available.
+	err := saveGenerationAndPrint(cacheDir, baseDir, "test-repo", "test-eid",
+		[]string{"io.complytime.opa", "io.complytime.ampel"},
+		[]string{"io.complytime.opa", "io.complytime.ampel"},
+		nil,
+	)
+	require.NoError(t, err)
+
+	genState, err := policy.LoadGenerationState(baseDir, "test-repo")
+	require.NoError(t, err)
+	require.NotNil(t, genState)
+	assert.Equal(t, "sha256:policy-digest", genState.PolicyDigest)
+	assert.Equal(t, map[string]string{
+		"io.complytime.opa":   "sha256:opa-digest",
+		"io.complytime.ampel": "sha256:ampel-digest",
+	}, genState.ComplypackDigests)
+}
+
+func TestSaveGenerationAndPrint_ComplypackUnavailable(t *testing.T) {
+	cacheDir := t.TempDir()
+	baseDir := t.TempDir()
+
+	// State has a complypack entry, but content was not available.
+	state := &cache.State{
+		Policies: map[string]cache.PolicyState{
+			"test-repo": {Version: "1.0.0", Digest: "sha256:policy-digest"},
+		},
+		Complypacks: map[string]cache.PolicyState{
+			"example.com/cp/opa": {EvaluatorID: "io.complytime.opa", Digest: "sha256:opa-digest"},
+		},
+	}
+	require.NoError(t, cache.SaveState(state, cacheDir))
+
+	// No evaluators had content available (cache deleted, etc).
+	err := saveGenerationAndPrint(cacheDir, baseDir, "test-repo", "test-eid",
+		[]string{"io.complytime.opa"},
+		nil, // no available evaluators
+		nil,
+	)
+	require.NoError(t, err)
+
+	genState, err := policy.LoadGenerationState(baseDir, "test-repo")
+	require.NoError(t, err)
+	require.NotNil(t, genState)
+	assert.Empty(t, genState.ComplypackDigests,
+		"digest must be empty when complypack content was unavailable")
+}
+
+func TestSaveGenerationAndPrint_MixedAvailability(t *testing.T) {
+	cacheDir := t.TempDir()
+	baseDir := t.TempDir()
+
+	state := &cache.State{
+		Policies: map[string]cache.PolicyState{
+			"test-repo": {Version: "1.0.0", Digest: "sha256:policy-digest"},
+		},
+		Complypacks: map[string]cache.PolicyState{
+			"example.com/cp/opa":   {EvaluatorID: "io.complytime.opa", Digest: "sha256:opa-digest"},
+			"example.com/cp/ampel": {EvaluatorID: "io.complytime.ampel", Digest: "sha256:ampel-digest"},
+		},
+	}
+	require.NoError(t, cache.SaveState(state, cacheDir))
+
+	// Only opa had content available; ampel was missing.
+	err := saveGenerationAndPrint(cacheDir, baseDir, "test-repo", "test-eid",
+		[]string{"io.complytime.opa", "io.complytime.ampel"},
+		[]string{"io.complytime.opa"}, // only opa available
+		nil,
+	)
+	require.NoError(t, err)
+
+	genState, err := policy.LoadGenerationState(baseDir, "test-repo")
+	require.NoError(t, err)
+	require.NotNil(t, genState)
+	assert.Equal(t, map[string]string{
+		"io.complytime.opa": "sha256:opa-digest",
+	}, genState.ComplypackDigests,
+		"only available evaluator's digest should be recorded")
+}
+
+func TestSaveGenerationAndPrint_NoComplypacks(t *testing.T) {
+	cacheDir := t.TempDir()
+	baseDir := t.TempDir()
+
+	// No complypack entries in state at all.
+	state := &cache.State{
+		Policies: map[string]cache.PolicyState{
+			"test-repo": {Version: "1.0.0", Digest: "sha256:policy-digest"},
+		},
+		Complypacks: make(map[string]cache.PolicyState),
+	}
+	require.NoError(t, cache.SaveState(state, cacheDir))
+
+	err := saveGenerationAndPrint(cacheDir, baseDir, "test-repo", "test-eid",
+		[]string{"io.complytime.opa"},
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	genState, err := policy.LoadGenerationState(baseDir, "test-repo")
+	require.NoError(t, err)
+	require.NotNil(t, genState)
+	assert.Empty(t, genState.ComplypackDigests,
+		"no complypacks configured should produce empty digests")
 }
 
 // --- lazyLogWriter tests ---

--- a/cmd/complyctl/cli/generate.go
+++ b/cmd/complyctl/cli/generate.go
@@ -115,26 +115,27 @@ func (o *generateOptions) generatePolicy(ctx context.Context, cfg *complytime.Wo
 	groups := policy.GroupByEvaluator(configs, graph)
 	policyTargets := filterTargetsForPolicy(cfg.Targets, eid)
 
-	evaluatorIDs, planRows, err := invokeGenerate(ctx, o.cacheDir, baseDir, mgr, groups, policyTargets, cfg.Variables)
+	evaluatorIDs, availableEvaluators, planRows, err := invokeGenerate(ctx, o.cacheDir, baseDir, mgr, groups, policyTargets, cfg.Variables)
 	if err != nil {
 		return err
 	}
 
-	return saveGenerationAndPrint(o.cacheDir, baseDir, ref.Repository, eid, evaluatorIDs, planRows)
+	return saveGenerationAndPrint(o.cacheDir, baseDir, ref.Repository, eid, evaluatorIDs, availableEvaluators, planRows)
 }
 
-func invokeGenerate(ctx context.Context, cacheDir, baseDir string, mgr *provider.Manager, groups map[string]policy.EvaluatorGroup, policyTargets []complytime.TargetConfig, configVars map[string]string) ([]string, []output.ExecutionPlanRow, error) {
+func invokeGenerate(ctx context.Context, cacheDir, baseDir string, mgr *provider.Manager, groups map[string]policy.EvaluatorGroup, policyTargets []complytime.TargetConfig, configVars map[string]string) ([]string, []string, []output.ExecutionPlanRow, error) {
 	spin := terminal.NewSpinner("Generating policy artifacts...")
 	spin.Start()
 	defer spin.Stop()
 
 	globalVars := complytime.WithWorkspaceVar(configVars, baseDir)
-	if err := generateForAllTargets(ctx, cacheDir, mgr, groups, policyTargets, globalVars); err != nil {
-		return nil, nil, err
+	availableEvaluators, err := generateForAllTargets(ctx, cacheDir, mgr, groups, policyTargets, globalVars)
+	if err != nil {
+		return nil, nil, nil, err
 	}
 
 	evaluatorIDs, planRows := buildExecutionPlan(mgr, groups, policyTargets)
-	return evaluatorIDs, planRows, nil
+	return evaluatorIDs, availableEvaluators, planRows, nil
 }
 
 func buildExecutionPlan(mgr *provider.Manager, groups map[string]policy.EvaluatorGroup, policyTargets []complytime.TargetConfig) ([]string, []output.ExecutionPlanRow) {
@@ -162,13 +163,21 @@ func providerStatus(mgr *provider.Manager, evalID string) string {
 	return "healthy"
 }
 
-func saveGenerationAndPrint(cacheDir, baseDir, repository, eid string, evaluatorIDs []string, planRows []output.ExecutionPlanRow) error {
+// saveGenerationAndPrint saves the generation state file and prints the
+// execution plan. availableEvaluators is the set of evaluator-ids that had
+// complypack content actually resolved during generation. Only digests for
+// these evaluators are recorded — evaluators without content get no digest
+// entry, which forces regeneration when the complypack becomes available.
+func saveGenerationAndPrint(cacheDir, baseDir, repository, eid string, evaluatorIDs, availableEvaluators []string, planRows []output.ExecutionPlanRow) error {
 	cacheState, err := cache.LoadState(cacheDir)
 	if err != nil {
 		return fmt.Errorf("failed to load cache state: %w", err)
 	}
 	policyState, _ := cacheState.GetPolicyState(repository)
-	cpDigests := complypackDigestsByEvaluator(cacheState)
+	cpDigests := filterComplypackDigests(
+		complypackDigestsByEvaluator(cacheState),
+		availableEvaluators,
+	)
 	genState := policy.NewGenerationState(repository, policyState.Digest, evaluatorIDs, cpDigests)
 	if err := policy.SaveGenerationState(baseDir, repository, genState); err != nil {
 		return fmt.Errorf("failed to save generation state: %w", err)

--- a/cmd/complyctl/cli/scan.go
+++ b/cmd/complyctl/cli/scan.go
@@ -515,6 +515,19 @@ func complypackDigestsByEvaluator(cacheState *cache.State) map[string]string {
 	return m
 }
 
+// filterComplypackDigests returns a new map containing only the digests for
+// evaluator-ids that had complypack content actually available during
+// generation. If availableEvaluators is nil or empty, an empty map is returned.
+func filterComplypackDigests(allDigests map[string]string, availableEvaluators []string) map[string]string {
+	filtered := make(map[string]string)
+	for _, evalID := range availableEvaluators {
+		if digest, ok := allDigests[evalID]; ok {
+			filtered[evalID] = digest
+		}
+	}
+	return filtered
+}
+
 func needsRegeneration(baseDir string, genState *policy.GenerationState, digest string, complypackDigests map[string]string, eid string) bool {
 	if genState == nil {
 		fmt.Fprintf(os.Stderr, "No prior generation found — generating artifacts for %s\n", eid)
@@ -552,35 +565,44 @@ func runGeneration(ctx context.Context, cacheDir, baseDir string, mgr *provider.
 	genSpin.Start()
 	defer genSpin.Stop()
 
-	if err := generateForAllTargets(ctx, cacheDir, mgr, groups, policyTargets, globalVars); err != nil {
+	availableEvaluators, err := generateForAllTargets(ctx, cacheDir, mgr, groups, policyTargets, globalVars)
+	if err != nil {
 		return err
 	}
 
-	newGenState := policy.NewGenerationState(repository, policyDigest, evaluatorIDs, complypackDigests)
+	filteredDigests := filterComplypackDigests(complypackDigests, availableEvaluators)
+	newGenState := policy.NewGenerationState(repository, policyDigest, evaluatorIDs, filteredDigests)
 	if err := policy.SaveGenerationState(baseDir, repository, newGenState); err != nil {
 		return fmt.Errorf("failed to save generation state: %w", err)
 	}
 	return nil
 }
 
-func generateForAllTargets(ctx context.Context, cacheDir string, mgr *provider.Manager, groups map[string]policy.EvaluatorGroup, policyTargets []complytime.TargetConfig, globalVars map[string]string) error {
+// generateForAllTargets invokes providers for each evaluator/target combination.
+// It returns the list of evaluator-ids that had complypack content available
+// (non-empty content path from LookupByEvaluatorID).
+func generateForAllTargets(ctx context.Context, cacheDir string, mgr *provider.Manager, groups map[string]policy.EvaluatorGroup, policyTargets []complytime.TargetConfig, globalVars map[string]string) ([]string, error) {
 	complypackCache := cache.NewComplypackCache(cacheDir)
 	workspace := globalVars[complytime.WorkspaceVarKey]
+	var availableEvaluators []string
 	for evalID, group := range groups {
 		// Look up cached complypack content for this evaluator-id.
 		// If no complypack is cached, contentPath is "" (backward compatible).
 		contentPath, _, err := complypackCache.LookupByEvaluatorID(evalID)
 		if err != nil {
-			return fmt.Errorf("failed to look up complypack for evaluator %s: %w", evalID, err)
+			return nil, fmt.Errorf("failed to look up complypack for evaluator %s: %w", evalID, err)
+		}
+		if contentPath != "" {
+			availableEvaluators = append(availableEvaluators, evalID)
 		}
 		for _, target := range policyTargets {
 			targetVars := complytime.WithWorkspaceVar(target.Variables, workspace)
 			if err := mgr.RouteGenerate(ctx, evalID, globalVars, targetVars, group.Configs, contentPath); err != nil {
-				return err
+				return nil, err
 			}
 		}
 	}
-	return nil
+	return availableEvaluators, nil
 }
 
 func executeScan(ctx context.Context, mgr *provider.Manager, groups map[string]policy.EvaluatorGroup, policyTargets []complytime.TargetConfig) (*scanOutput, error) {

--- a/internal/cache/complypack.go
+++ b/internal/cache/complypack.go
@@ -11,6 +11,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/charmbracelet/log"
+
 	"github.com/complytime/complyctl/internal/complytime"
 	"github.com/complytime/complypack/pkg/complypack"
 )
@@ -128,6 +130,10 @@ func (c *ComplypackCache) Store(config complypack.Config, content io.Reader) (st
 		return "", fmt.Errorf("failed to write config file: %w", err)
 	}
 
+	// Evict old version directories for the same evaluator-id.
+	// This ensures at most one version exists per evaluator-id after Store().
+	evictOldVersions(parentDir, config.Version)
+
 	// Remove any existing final directory before the atomic rename.
 	if err := os.RemoveAll(finalDir); err != nil {
 		return "", fmt.Errorf("failed to remove existing cache directory %s: %w", finalDir, err)
@@ -140,6 +146,42 @@ func (c *ComplypackCache) Store(config complypack.Config, content io.Reader) (st
 	cleanup = false // Rename succeeded; don't remove the final directory.
 
 	return filepath.Join(finalDir, complypackContentFile), nil
+}
+
+// evictOldVersions removes all version directories under evaluatorDir that are
+// not the target version and not hidden (dot-prefixed). Eviction errors are
+// non-fatal: a warning is logged but the store operation continues.
+func evictOldVersions(evaluatorDir, targetVersion string) {
+	entries, err := os.ReadDir(evaluatorDir)
+	if err != nil {
+		// If the directory doesn't exist yet, nothing to evict.
+		if os.IsNotExist(err) {
+			return
+		}
+		log.Warn("failed to list complypack versions for eviction",
+			"dir", evaluatorDir, "error", err)
+		return
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		// Skip hidden/temporary directories (e.g. .complypack-tmp-*).
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
+		// Skip the version being stored.
+		if name == targetVersion {
+			continue
+		}
+		oldDir := filepath.Join(evaluatorDir, name)
+		if removeErr := os.RemoveAll(oldDir); removeErr != nil {
+			log.Warn("failed to evict old complypack version",
+				"dir", oldDir, "error", removeErr)
+		}
+	}
 }
 
 // Lookup finds the cached complypack content path and config for a specific

--- a/internal/cache/complypack.go
+++ b/internal/cache/complypack.go
@@ -151,6 +151,10 @@ func (c *ComplypackCache) Store(config complypack.Config, content io.Reader) (st
 // evictOldVersions removes all version directories under evaluatorDir that are
 // not the target version and not hidden (dot-prefixed). Eviction errors are
 // non-fatal: a warning is logged but the store operation continues.
+//
+// evaluatorDir must be a path within the complypack cache root
+// (e.g. {cacheDir}/complypacks/{evaluator-id}). Callers are responsible
+// for validating the path before calling this function.
 func evictOldVersions(evaluatorDir, targetVersion string) {
 	entries, err := os.ReadDir(evaluatorDir)
 	if err != nil {

--- a/internal/cache/complypack_test.go
+++ b/internal/cache/complypack_test.go
@@ -116,33 +116,114 @@ func TestComplypackCache_Store_AtomicWrite(t *testing.T) {
 	assert.NoDirExists(t, evilDir)
 }
 
-func TestComplypackCache_Store_MultipleVersions(t *testing.T) {
+func TestComplypackCache_Store_EvictsOldVersions(t *testing.T) {
 	cacheDir := t.TempDir()
 	cc := cache.NewComplypackCache(cacheDir)
 
+	// Store version 1.0.0.
 	cfg1 := newTestConfig("io.complytime.opa", "1.0.0")
-	path1, err := cc.Store(cfg1, strings.NewReader("v1 content"))
+	_, err := cc.Store(cfg1, strings.NewReader("v1 content"))
 	require.NoError(t, err)
+	assert.DirExists(t, filepath.Join(cacheDir, "complypacks", "io.complytime.opa", "1.0.0"))
 
+	// Store version 2.0.0 — should evict 1.0.0.
 	cfg2 := newTestConfig("io.complytime.opa", "2.0.0")
 	path2, err := cc.Store(cfg2, strings.NewReader("v2 content"))
 	require.NoError(t, err)
 
-	// Both versions must exist independently.
-	assert.FileExists(t, path1)
+	// Old version must be removed.
+	assert.NoDirExists(t, filepath.Join(cacheDir, "complypacks", "io.complytime.opa", "1.0.0"))
+	// New version must exist with correct content.
 	assert.FileExists(t, path2)
-
-	// Verify they are in separate directories.
-	assert.DirExists(t, filepath.Join(cacheDir, "complypacks", "io.complytime.opa", "1.0.0"))
-	assert.DirExists(t, filepath.Join(cacheDir, "complypacks", "io.complytime.opa", "2.0.0"))
-
-	// Verify content is distinct.
-	data1, err := os.ReadFile(path1)
-	require.NoError(t, err)
 	data2, err := os.ReadFile(path2)
 	require.NoError(t, err)
-	assert.Equal(t, "v1 content", string(data1))
 	assert.Equal(t, "v2 content", string(data2))
+}
+
+func TestComplypackCache_Store_EvictsMultipleOldVersions(t *testing.T) {
+	cacheDir := t.TempDir()
+	cc := cache.NewComplypackCache(cacheDir)
+
+	// Pre-seed three versions by creating directories with content directly.
+	evalDir := filepath.Join(cacheDir, "complypacks", "io.complytime.opa")
+	for _, v := range []string{"0.1.0", "0.2.0", "0.3.0"} {
+		dir := filepath.Join(evalDir, v)
+		require.NoError(t, os.MkdirAll(dir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "content.tar.gz"), []byte("old"), 0600))
+	}
+
+	// Store version 1.0.0 — should evict all three old versions.
+	cfg := newTestConfig("io.complytime.opa", "1.0.0")
+	_, err := cc.Store(cfg, strings.NewReader("new content"))
+	require.NoError(t, err)
+
+	// All old versions must be removed.
+	assert.NoDirExists(t, filepath.Join(evalDir, "0.1.0"))
+	assert.NoDirExists(t, filepath.Join(evalDir, "0.2.0"))
+	assert.NoDirExists(t, filepath.Join(evalDir, "0.3.0"))
+	// New version must exist.
+	assert.DirExists(t, filepath.Join(evalDir, "1.0.0"))
+}
+
+func TestComplypackCache_Store_DoesNotAffectOtherEvaluators(t *testing.T) {
+	cacheDir := t.TempDir()
+	cc := cache.NewComplypackCache(cacheDir)
+
+	// Store opa/1.0.0 and ampel/1.0.0.
+	cfgOpa := newTestConfig("opa", "1.0.0")
+	_, err := cc.Store(cfgOpa, strings.NewReader("opa v1"))
+	require.NoError(t, err)
+
+	cfgAmpel := newTestConfig("ampel", "1.0.0")
+	ampelPath, err := cc.Store(cfgAmpel, strings.NewReader("ampel v1"))
+	require.NoError(t, err)
+
+	// Store opa/2.0.0 — should evict opa/1.0.0 but not touch ampel.
+	cfgOpa2 := newTestConfig("opa", "2.0.0")
+	_, err = cc.Store(cfgOpa2, strings.NewReader("opa v2"))
+	require.NoError(t, err)
+
+	// ampel/1.0.0 must be untouched.
+	assert.FileExists(t, ampelPath)
+	assert.DirExists(t, filepath.Join(cacheDir, "complypacks", "ampel", "1.0.0"))
+
+	// opa/1.0.0 must be evicted.
+	assert.NoDirExists(t, filepath.Join(cacheDir, "complypacks", "opa", "1.0.0"))
+	assert.DirExists(t, filepath.Join(cacheDir, "complypacks", "opa", "2.0.0"))
+}
+
+func TestComplypackCache_Store_SameVersionIdempotent(t *testing.T) {
+	cacheDir := t.TempDir()
+	cc := cache.NewComplypackCache(cacheDir)
+
+	cfg := newTestConfig("io.complytime.opa", "1.0.0")
+
+	// Store the same version twice — should succeed without error.
+	_, err := cc.Store(cfg, strings.NewReader("first write"))
+	require.NoError(t, err)
+
+	path, err := cc.Store(cfg, strings.NewReader("second write"))
+	require.NoError(t, err)
+
+	// Content should reflect the second write (atomic replace).
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "second write", string(data))
+}
+
+func TestComplypackCache_Store_NoExistingDir(t *testing.T) {
+	cacheDir := t.TempDir()
+	cc := cache.NewComplypackCache(cacheDir)
+
+	// Store with no prior evaluator directory — should succeed.
+	cfg := newTestConfig("brand-new-evaluator", "1.0.0")
+	path, err := cc.Store(cfg, strings.NewReader("fresh content"))
+	require.NoError(t, err)
+
+	assert.FileExists(t, path)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "fresh content", string(data))
 }
 
 func TestComplypackCache_Lookup_Found(t *testing.T) {

--- a/openspec/changes/complypack-version-eviction/.openspec.yaml
+++ b/openspec/changes/complypack-version-eviction/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-06-30

--- a/openspec/changes/complypack-version-eviction/design.md
+++ b/openspec/changes/complypack-version-eviction/design.md
@@ -1,0 +1,45 @@
+## Context
+
+`ComplypackCache.Store()` currently:
+1. Creates a temp directory with `content.tar.gz` and `config.json`
+2. Calls `os.RemoveAll` on the target version path
+3. Calls `os.Rename` to atomically move temp → target
+
+This leaves old version directories when the version field changes.
+
+## Goals
+
+- Ensure at most one version directory per evaluator-id after any `Store()` call
+- Maintain atomic store semantics (no partial state on failure)
+- No change to `Store()` signature or return type
+
+## Non-Goals
+
+- Adding a `complyctl cache clean` command (future enhancement)
+- Tracking version history or rollback capability
+
+## Decisions
+
+### D1: Evict before atomic rename
+
+Eviction of old versions happens after the temp directory is prepared but before the final rename. If eviction of an old directory fails, the store still proceeds (log warning) — the new version takes priority.
+
+Sequence:
+1. Prepare temp dir with content
+2. List sibling version directories under `{cacheDir}/complypacks/{evaluator-id}/`
+3. Remove all directories that are not the target version or hidden (`.tmp-*`)
+4. `RemoveAll` target version path (existing logic)
+5. `Rename` temp → target (existing logic)
+
+### D2: Skip hidden/temp directories
+
+Directories starting with `.` are skipped during eviction (these are temp dirs from in-flight writes).
+
+### D3: Eviction errors are non-fatal
+
+If removing an old version directory fails (permissions, etc.), emit a warning but proceed with the store. The primary goal (write new version) takes priority over cleanup.
+
+## Risks / Trade-offs
+
+- **Race condition**: If two `Store()` calls run concurrently for the same evaluator-id with different versions, both may evict each other. Mitigation: complypack sync is sequential per-evaluator in practice.
+- **Disk space not freed on error**: If eviction fails, old directories persist. Acceptable — no worse than current behavior.

--- a/openspec/changes/complypack-version-eviction/proposal.md
+++ b/openspec/changes/complypack-version-eviction/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+`ComplypackCache.LookupByEvaluatorID()` iterates version directories via `os.ReadDir` and returns the first match. Go's `ReadDir` returns entries in directory order, which is filesystem-dependent and non-deterministic. When multiple version directories coexist (e.g. `0.1.0/` and `0.2.0/`), the provider may receive outdated complypack content silently.
+
+The root cause is that `ComplypackCache.Store()` only removes the exact version path being written. If the complypack's version field changes between releases, the old version directory remains on disk indefinitely with no eviction.
+
+This is tracked in [#645](https://github.com/complytime/complyctl/issues/645) and [#646](https://github.com/complytime/complyctl/issues/646).
+
+## What Changes
+
+- `ComplypackCache.Store()` evicts all sibling version directories for the same evaluator-id before writing the new version, ensuring only one version exists at any time.
+- `LookupByEvaluatorID()` remains unchanged but is now guaranteed to find at most one version directory.
+
+## Capabilities
+
+### New Capabilities
+- `complypack-version-eviction`: On store, all prior version directories for the same evaluator-id are removed before writing the new version.
+
+### Modified Capabilities
+- `complypack-store`: Now atomically evicts old versions as part of the store operation.
+
+### Removed Capabilities
+- None.
+
+## Impact
+
+- `internal/cache/complypack.go` — `Store()` gains eviction of sibling version directories
+- `internal/cache/complypack_test.go` — new tests for eviction behavior
+- No CLI interface changes, no config changes
+
+## Constitution Alignment
+
+### I. Autonomous Collaboration
+
+**Assessment**: PASS
+
+The eviction is automatic and transparent. Users don't need to manually clean old versions.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+Eviction is scoped per evaluator-id. Different evaluators' caches are untouched. The change is internal to `Store()` with no signature change.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+The cache directory structure becomes deterministic: one evaluator-id → one version directory. `complyctl providers` already shows the cached version.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+Testable via `t.TempDir()` with pre-seeded old version directories. Verify they're removed after `Store()`.

--- a/openspec/changes/complypack-version-eviction/specs/version-eviction/spec.md
+++ b/openspec/changes/complypack-version-eviction/specs/version-eviction/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### FR-001: Evict prior versions on complypack store
+
+**Given** a complypack with evaluator-id `E` version `2.0.0` is being stored
+**And** a prior version directory `~/.complytime/complypacks/E/1.0.0/` exists
+**When** `ComplypackCache.Store()` completes successfully
+**Then** the directory `~/.complytime/complypacks/E/1.0.0/` MUST NOT exist
+**And** the directory `~/.complytime/complypacks/E/2.0.0/` MUST exist with content
+
+### FR-002: Eviction handles multiple stale versions
+
+**Given** directories `~/.complytime/complypacks/E/0.1.0/`, `E/0.2.0/`, `E/0.3.0/` exist
+**When** `Store()` writes version `1.0.0` for evaluator-id `E`
+**Then** all three prior directories MUST be removed
+**And** only `E/1.0.0/` remains
+
+### FR-003: Eviction does not affect other evaluator-ids
+
+**Given** directories `~/.complytime/complypacks/opa/1.0.0/` and `ampel/1.0.0/` exist
+**When** `Store()` writes version `2.0.0` for evaluator-id `opa`
+**Then** `ampel/1.0.0/` MUST NOT be affected
+
+### FR-004: Eviction tolerates missing evaluator directory
+
+**Given** no prior cache directory exists for evaluator-id `E`
+**When** `Store()` writes version `1.0.0` for evaluator-id `E`
+**Then** the store MUST succeed without error
+
+### FR-005: Same version re-store is idempotent
+
+**Given** `~/.complytime/complypacks/E/1.0.0/` already exists
+**When** `Store()` writes version `1.0.0` for the same evaluator-id `E`
+**Then** the directory is atomically replaced (existing behavior)
+**And** no error occurs

--- a/openspec/changes/complypack-version-eviction/tasks.md
+++ b/openspec/changes/complypack-version-eviction/tasks.md
@@ -1,19 +1,19 @@
 ## 1. Implement version eviction in Store()
 
-- [ ] 1.1 In `internal/cache/complypack.go` `Store()`, after preparing the temp directory and before `os.RemoveAll` of the target path: list all entries in `{cacheDir}/complypacks/{evaluator-id}/`
-- [ ] 1.2 For each entry that is a directory, not hidden (no `.` prefix), and not the target version name: call `os.RemoveAll` on it
-- [ ] 1.3 Log a warning (to stderr) if removal fails but do not return an error
+- [x] 1.1 In `internal/cache/complypack.go` `Store()`, after preparing the temp directory and before `os.RemoveAll` of the target path: list all entries in `{cacheDir}/complypacks/{evaluator-id}/`
+- [x] 1.2 For each entry that is a directory, not hidden (no `.` prefix), and not the target version name: call `os.RemoveAll` on it
+- [x] 1.3 Log a warning (to stderr) if removal fails but do not return an error
 
 ## 2. Unit tests
 
-- [ ] 2.1 [P] `TestStore_EvictsOldVersions` — pre-seed `E/1.0.0/`, store `E/2.0.0`, verify `1.0.0/` removed
-- [ ] 2.2 [P] `TestStore_EvictsMultipleOldVersions` — pre-seed 3 versions, store new, verify all old removed
-- [ ] 2.3 [P] `TestStore_DoesNotAffectOtherEvaluators` — pre-seed `opa/1.0.0` and `ampel/1.0.0`, store `opa/2.0.0`, verify `ampel/` untouched
-- [ ] 2.4 [P] `TestStore_SameVersionIdempotent` — store same version twice, no error
-- [ ] 2.5 [P] `TestStore_NoExistingDir` — store with no prior evaluator dir, succeeds
+- [x] 2.1 [P] `TestStore_EvictsOldVersions` — pre-seed `E/1.0.0/`, store `E/2.0.0`, verify `1.0.0/` removed
+- [x] 2.2 [P] `TestStore_EvictsMultipleOldVersions` — pre-seed 3 versions, store new, verify all old removed
+- [x] 2.3 [P] `TestStore_DoesNotAffectOtherEvaluators` — pre-seed `opa/1.0.0` and `ampel/1.0.0`, store `opa/2.0.0`, verify `ampel/` untouched
+- [x] 2.4 [P] `TestStore_SameVersionIdempotent` — store same version twice, no error
+- [x] 2.5 [P] `TestStore_NoExistingDir` — store with no prior evaluator dir, succeeds
 
 ## 3. Verification
 
-- [ ] 3.1 Run `go test -race ./internal/cache/` and confirm all tests pass
-- [ ] 3.2 Run `go vet ./...`
-- [ ] 3.3 E2E: `complyctl get` with version change → verify only new version dir exists
+- [x] 3.1 Run `go test -race ./internal/cache/` and confirm all tests pass
+- [x] 3.2 Run `go vet ./...`
+- [x] 3.3 E2E: `complyctl get` with version change → verify only new version dir exists

--- a/openspec/changes/complypack-version-eviction/tasks.md
+++ b/openspec/changes/complypack-version-eviction/tasks.md
@@ -1,0 +1,19 @@
+## 1. Implement version eviction in Store()
+
+- [ ] 1.1 In `internal/cache/complypack.go` `Store()`, after preparing the temp directory and before `os.RemoveAll` of the target path: list all entries in `{cacheDir}/complypacks/{evaluator-id}/`
+- [ ] 1.2 For each entry that is a directory, not hidden (no `.` prefix), and not the target version name: call `os.RemoveAll` on it
+- [ ] 1.3 Log a warning (to stderr) if removal fails but do not return an error
+
+## 2. Unit tests
+
+- [ ] 2.1 [P] `TestStore_EvictsOldVersions` — pre-seed `E/1.0.0/`, store `E/2.0.0`, verify `1.0.0/` removed
+- [ ] 2.2 [P] `TestStore_EvictsMultipleOldVersions` — pre-seed 3 versions, store new, verify all old removed
+- [ ] 2.3 [P] `TestStore_DoesNotAffectOtherEvaluators` — pre-seed `opa/1.0.0` and `ampel/1.0.0`, store `opa/2.0.0`, verify `ampel/` untouched
+- [ ] 2.4 [P] `TestStore_SameVersionIdempotent` — store same version twice, no error
+- [ ] 2.5 [P] `TestStore_NoExistingDir` — store with no prior evaluator dir, succeeds
+
+## 3. Verification
+
+- [ ] 3.1 Run `go test -race ./internal/cache/` and confirm all tests pass
+- [ ] 3.2 Run `go vet ./...`
+- [ ] 3.3 E2E: `complyctl get` with version change → verify only new version dir exists

--- a/openspec/changes/generate-state-from-actual-usage/.openspec.yaml
+++ b/openspec/changes/generate-state-from-actual-usage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-06-30

--- a/openspec/changes/generate-state-from-actual-usage/design.md
+++ b/openspec/changes/generate-state-from-actual-usage/design.md
@@ -1,0 +1,45 @@
+## Context
+
+`saveGenerationAndPrint()` at line 165 of `generate.go`:
+1. Loads `state.json` from the cache directory
+2. Reads policy digest from `state.GetPolicyState(repository)`
+3. Builds `complypackDigestsByEvaluator(cacheState)` — reads ALL complypack digests from state
+4. Saves generation state with those digests
+
+The problem: step 3 reads digests from `state.json` regardless of whether the complypack content was actually used during generation.
+
+## Goals
+
+- Generation state complypack digests reflect what was actually passed to providers
+- If complypack content was unavailable (path empty), record no digest for that evaluator
+- Maintain backward compatibility for the happy path (content available)
+
+## Non-Goals
+
+- Adding complypack content verification (checksum validation)
+- Changing the Generate RPC to report what it consumed
+- Fixing `state.json` drift itself (that's a separate concern)
+
+## Decisions
+
+### D1: Filter digests by actual content availability
+
+Instead of blindly recording all complypack digests from `state.json`, only include digests for evaluators whose complypack content path was successfully resolved (non-empty) during the generate call.
+
+The generate flow already resolves complypack content paths via `LookupByEvaluatorID`. Pass the set of evaluator-ids that had actual content into `saveGenerationAndPrint`.
+
+### D2: Thread content availability through
+
+Add a parameter to `saveGenerationAndPrint`:
+- `availableEvaluators []string` — evaluator-ids for which complypack content was found
+
+Filter `complypackDigestsByEvaluator` output to only include entries in `availableEvaluators`.
+
+### D3: Scan path unchanged
+
+`scan.go` already calls `saveGenerationAndPrint` through a similar path. Apply the same filtering there for consistency.
+
+## Risks / Trade-offs
+
+- **Signature change**: `saveGenerationAndPrint` gains a parameter. Internal-only, no public API impact.
+- **Regeneration on first run**: If complypack becomes available after a generate-without-complypack, the next scan correctly detects the digest mismatch and regenerates. This is the desired behavior.

--- a/openspec/changes/generate-state-from-actual-usage/proposal.md
+++ b/openspec/changes/generate-state-from-actual-usage/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+`complyctl generate` invokes the provider Generate RPC without a freshness check, then calls `saveGenerationAndPrint()` which reads `state.json` for current policy/complypack digests and records them in the generation state file. If `state.json` has drifted from actual cache contents (e.g. cache directory manually deleted), the recorded digests won't match what was actually used during generation.
+
+On the next `complyctl scan`, `IsFresh()` compares recorded digests against current `state.json`. If they match (both stale), scan skips regeneration even though workspace artifacts may be based on different content.
+
+This is tracked in [#648](https://github.com/complytime/complyctl/issues/648).
+
+## What Changes
+
+- `saveGenerationAndPrint()` records the complypack content path that was actually passed to the provider. When the path was empty (no complypack available), the recorded complypack digest is empty/absent — forcing regeneration on next scan when the complypack becomes available.
+- Alternatively: verify complypack cache existence before reading `state.json` digests.
+
+## Capabilities
+
+### New Capabilities
+- `generation-state-accuracy`: Generation state reflects what was actually used during generation, not what `state.json` claims.
+
+### Modified Capabilities
+- `generate`: `saveGenerationAndPrint` validates complypack content was actually available before recording its digest.
+
+### Removed Capabilities
+- None.
+
+## Impact
+
+- `cmd/complyctl/cli/generate.go` — `saveGenerationAndPrint()` logic change
+- `cmd/complyctl/cli/scan.go` — potentially `saveGenerationAndPrint` reuse
+- Generation state test updates
+
+## Constitution Alignment
+
+### I. Autonomous Collaboration
+
+**Assessment**: PASS
+
+Generation state becomes self-consistent — what's recorded is what was used.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+Change is localized to `saveGenerationAndPrint`. Callers are unaffected.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+Generation state files accurately represent the inputs that produced the artifacts, enabling reliable freshness detection.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+Testable by mocking scenarios where complypack content path is empty vs populated.

--- a/openspec/changes/generate-state-from-actual-usage/specs/generation-accuracy/spec.md
+++ b/openspec/changes/generate-state-from-actual-usage/specs/generation-accuracy/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### FR-001: Record empty digest when complypack was unavailable
+
+**Given** a complypack for evaluator-id `E` is configured in `state.json`
+**But** the complypack cache directory is missing (no `content.tar.gz`)
+**When** `complyctl generate` completes and saves generation state
+**Then** the recorded complypack digest for `E` MUST be empty/absent
+**And** the next `complyctl scan` MUST trigger regeneration (digest mismatch)
+
+### FR-002: Record actual digest when complypack was available
+
+**Given** a complypack for evaluator-id `E` is cached with digest `D`
+**And** the content path was successfully resolved and passed to the provider
+**When** `complyctl generate` saves generation state
+**Then** the recorded complypack digest for `E` MUST be `D`
+
+### FR-003: Policy digest always from state.json
+
+**Given** a policy is cached with digest `P` in `state.json`
+**When** generation state is saved
+**Then** the policy digest MUST be `P` (no change to policy digest handling)
+
+### FR-004: Mixed complypack availability
+
+**Given** two evaluators: `opa` (complypack available, digest `D1`) and `ampel` (complypack missing)
+**When** generation state is saved
+**Then** `opa` digest MUST be `D1`
+**And** `ampel` digest MUST be empty/absent

--- a/openspec/changes/generate-state-from-actual-usage/tasks.md
+++ b/openspec/changes/generate-state-from-actual-usage/tasks.md
@@ -1,0 +1,23 @@
+## 1. Thread complypack content availability
+
+- [ ] 1.1 In `cmd/complyctl/cli/generate.go`, track which evaluator-ids had complypack content resolved (non-empty path from `LookupByEvaluatorID`)
+- [ ] 1.2 Pass `availableEvaluators []string` to `saveGenerationAndPrint`
+- [ ] 1.3 Update `saveGenerationAndPrint` signature to accept `availableEvaluators`
+
+## 2. Filter recorded digests
+
+- [ ] 2.1 In `saveGenerationAndPrint`, filter `complypackDigestsByEvaluator` output to only include evaluator-ids present in `availableEvaluators`
+- [ ] 2.2 Apply the same filtering in the `scan.go` code path that saves generation state
+
+## 3. Unit tests
+
+- [ ] 3.1 [P] `TestSaveGenerationAndPrint_AllComplypacksAvailable` — all digests recorded
+- [ ] 3.2 [P] `TestSaveGenerationAndPrint_ComplypackUnavailable` — missing evaluator digest is empty
+- [ ] 3.3 [P] `TestSaveGenerationAndPrint_MixedAvailability` — only available evaluators' digests recorded
+- [ ] 3.4 [P] `TestSaveGenerationAndPrint_NoComplypacks` — nil/empty availableEvaluators, no digests recorded
+
+## 4. Verification
+
+- [ ] 4.1 Run `go test -race ./cmd/complyctl/cli/`
+- [ ] 4.2 Run `go vet ./...`
+- [ ] 4.3 E2E: delete complypack cache dir, run `generate`, verify generation state has empty complypack digest; then `get` to restore, run `scan`, verify regeneration triggers

--- a/openspec/changes/generate-state-from-actual-usage/tasks.md
+++ b/openspec/changes/generate-state-from-actual-usage/tasks.md
@@ -1,23 +1,23 @@
 ## 1. Thread complypack content availability
 
-- [ ] 1.1 In `cmd/complyctl/cli/generate.go`, track which evaluator-ids had complypack content resolved (non-empty path from `LookupByEvaluatorID`)
-- [ ] 1.2 Pass `availableEvaluators []string` to `saveGenerationAndPrint`
-- [ ] 1.3 Update `saveGenerationAndPrint` signature to accept `availableEvaluators`
+- [x] 1.1 In `cmd/complyctl/cli/generate.go`, track which evaluator-ids had complypack content resolved (non-empty path from `LookupByEvaluatorID`)
+- [x] 1.2 Pass `availableEvaluators []string` to `saveGenerationAndPrint`
+- [x] 1.3 Update `saveGenerationAndPrint` signature to accept `availableEvaluators`
 
 ## 2. Filter recorded digests
 
-- [ ] 2.1 In `saveGenerationAndPrint`, filter `complypackDigestsByEvaluator` output to only include evaluator-ids present in `availableEvaluators`
-- [ ] 2.2 Apply the same filtering in the `scan.go` code path that saves generation state
+- [x] 2.1 In `saveGenerationAndPrint`, filter `complypackDigestsByEvaluator` output to only include evaluator-ids present in `availableEvaluators`
+- [x] 2.2 Apply the same filtering in the `scan.go` code path that saves generation state
 
 ## 3. Unit tests
 
-- [ ] 3.1 [P] `TestSaveGenerationAndPrint_AllComplypacksAvailable` — all digests recorded
-- [ ] 3.2 [P] `TestSaveGenerationAndPrint_ComplypackUnavailable` — missing evaluator digest is empty
-- [ ] 3.3 [P] `TestSaveGenerationAndPrint_MixedAvailability` — only available evaluators' digests recorded
-- [ ] 3.4 [P] `TestSaveGenerationAndPrint_NoComplypacks` — nil/empty availableEvaluators, no digests recorded
+- [x] 3.1 [P] `TestSaveGenerationAndPrint_AllComplypacksAvailable` — all digests recorded
+- [x] 3.2 [P] `TestSaveGenerationAndPrint_ComplypackUnavailable` — missing evaluator digest is empty
+- [x] 3.3 [P] `TestSaveGenerationAndPrint_MixedAvailability` — only available evaluators' digests recorded
+- [x] 3.4 [P] `TestSaveGenerationAndPrint_NoComplypacks` — nil/empty availableEvaluators, no digests recorded
 
 ## 4. Verification
 
-- [ ] 4.1 Run `go test -race ./cmd/complyctl/cli/`
-- [ ] 4.2 Run `go vet ./...`
-- [ ] 4.3 E2E: delete complypack cache dir, run `generate`, verify generation state has empty complypack digest; then `get` to restore, run `scan`, verify regeneration triggers
+- [x] 4.1 Run `go test -race ./cmd/complyctl/cli/`
+- [x] 4.2 Run `go vet ./...`
+- [x] 4.3 E2E: delete complypack cache dir, run `generate`, verify generation state has empty complypack digest; then `get` to restore, run `scan`, verify regeneration triggers


### PR DESCRIPTION
## Summary

Fixes three related complypack cache reliability issues:

- **#645**: `LookupByEvaluatorID` selects arbitrary complypack version when multiple exist
- **#646**: Old complypack versions not evicted from cache on re-sync
- **#648**: `complyctl generate` records generation state from potentially stale `state.json`

## Changes

### Complypack version eviction (#645, #646)

`ComplypackCache.Store()` now evicts all sibling version directories for the same evaluator-id before writing the new version. This ensures at most one version exists per evaluator-id, making `LookupByEvaluatorID()` deterministic.

- Added `evictOldVersions()` helper in `internal/cache/complypack.go`
- Eviction errors are non-fatal (warning logged, store continues)
- Hidden/temp directories (dot-prefixed) are skipped during eviction

### Generation state accuracy (#648)

`saveGenerationAndPrint()` and `runGeneration()` now filter complypack digests to only include evaluator-ids whose content was actually resolved during generation. When complypack content is unavailable (cache deleted, not yet synced), its digest is recorded as empty — forcing regeneration on the next scan when the complypack becomes available.

- `generateForAllTargets()` returns available evaluator-ids
- Added `filterComplypackDigests()` helper
- Both generate and scan code paths apply the same filtering

## Files Changed

| File | Change |
|------|--------|
| `internal/cache/complypack.go` | `evictOldVersions()`, import `charmbracelet/log` |
| `internal/cache/complypack_test.go` | 5 eviction tests, replaced `TestStore_MultipleVersions` |
| `cmd/complyctl/cli/generate.go` | `saveGenerationAndPrint` gains `availableEvaluators` param |
| `cmd/complyctl/cli/scan.go` | `generateForAllTargets` returns available evaluators, `filterComplypackDigests()` |
| `cmd/complyctl/cli/cli_test.go` | 8 new tests (4 filter + 4 integration) |

## Testing

- `go test -race ./internal/cache/` — all 49 tests pass
- `go test -race ./cmd/complyctl/cli/` — all tests pass
- `go vet ./...` — clean
- `make test-integration` — 26/26 pass
- E2E verification with mock registry: version eviction confirmed, generation state accuracy confirmed

## OpenSpec Artifacts

- `openspec/changes/complypack-version-eviction/` — proposal, design, spec, tasks (11/11 complete)
- `openspec/changes/generate-state-from-actual-usage/` — proposal, design, spec, tasks (12/12 complete)

Fixes #645
Fixes #646
Fixes #648