### PR TITLE
test(output): add NeedsReview, execution plan, OSCAL, and content tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,8 @@ require (
 	github.com/google/go-containerregistry v0.21.7
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.8.0
+	github.com/mattn/go-isatty v0.0.20
+	github.com/muesli/termenv v0.16.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/sigstore/protobuf-specs v0.5.1
@@ -85,12 +87,10 @@ require (
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/oklog/ulid/v2 v2.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/internal/output/evaluator_test.go
+++ b/internal/output/evaluator_test.go
@@ -195,6 +195,18 @@ func TestEvaluator_Write(t *testing.T) {
 	require.NoError(t, err)
 	assert.FileExists(t, path)
 	assert.Contains(t, path, "evaluation-log-test-policy-target-1-")
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	content := string(data)
+
+	assert.Contains(t, content, "result: Passed", "evaluation log should contain the result field")
+	assert.Contains(t, content, "id: test-policy", "evaluation log should contain the policy ID in metadata")
+	assert.Contains(t, content, "id: target-1", "evaluation log should contain the target ID")
+	assert.Contains(t, content, "name: target-1", "evaluation log should contain the target name")
+	assert.Contains(t, content, "entry-id: R1", "evaluation log should contain the requirement entry ID")
+	assert.Contains(t, content, "type: EvaluationLog", "evaluation log should contain the artifact type")
+	assert.Contains(t, content, "steps-executed: 1", "evaluation log should record steps executed")
 }
 
 func TestEvaluator_Write_StepIdentityWithComplypackRef(t *testing.T) {
@@ -367,4 +379,6 @@ func TestEvaluator_Write_StepIdentityEmptyName(t *testing.T) {
 	require.NoError(t, err)
 	content := string(data)
 	assert.NotContains(t, content, "providerStepToGemara")
+	assert.Contains(t, content, "steps:\n    - \"\"",
+		"empty step name should produce an empty-string step identity")
 }

--- a/internal/output/execution_plan_test.go
+++ b/internal/output/execution_plan_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package output
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/complytime/complyctl/internal/complytime"
+)
+
+func TestFormatExecutionPlan_SingleRow(t *testing.T) {
+	rows := []ExecutionPlanRow{
+		{
+			TargetID:         "my-app",
+			ProviderID:       "ampel",
+			RequirementCount: 5,
+			Status:           "healthy",
+		},
+	}
+
+	result := FormatExecutionPlan("test-policy", rows)
+
+	assert.Contains(t, result, "Execution Plan: test-policy")
+	assert.Contains(t, result, "Target: my-app")
+	assert.Contains(t, result, "Provider: ampel")
+	assert.Contains(t, result, complytime.StatusPassed)
+	assert.Contains(t, result, "healthy")
+	assert.Contains(t, result, "Requirements: 5")
+	assert.Contains(t, result, "Generation completed.")
+}
+
+func TestFormatExecutionPlan_MultipleRows(t *testing.T) {
+	rows := []ExecutionPlanRow{
+		{
+			TargetID:         "app-1",
+			ProviderID:       "ampel",
+			RequirementCount: 3,
+			Status:           "healthy",
+		},
+		{
+			TargetID:         "app-2",
+			ProviderID:       "opa",
+			RequirementCount: 7,
+			Status:           "unavailable",
+		},
+	}
+
+	result := FormatExecutionPlan("multi-policy", rows)
+
+	assert.Contains(t, result, "Execution Plan: multi-policy")
+	assert.Contains(t, result, "Target: app-1")
+	assert.Contains(t, result, "Provider: ampel")
+	assert.Contains(t, result, "Requirements: 3")
+	assert.Contains(t, result, "Target: app-2")
+	assert.Contains(t, result, "Provider: opa")
+	assert.Contains(t, result, "Requirements: 7")
+	assert.Contains(t, result, complytime.StatusPassed, "healthy provider should get passed emoji")
+	assert.Contains(t, result, complytime.StatusFailed, "unavailable provider should get failed emoji")
+}
+
+func TestFormatExecutionPlan_EmptyRows(t *testing.T) {
+	result := FormatExecutionPlan("empty-policy", nil)
+
+	assert.Contains(t, result, "Execution Plan: empty-policy")
+	assert.Contains(t, result, "Generation completed.")
+	assert.NotContains(t, result, "Target:")
+	assert.NotContains(t, result, "Provider:")
+}
+
+func TestFormatExecutionPlan_UnhealthyStatus(t *testing.T) {
+	rows := []ExecutionPlanRow{
+		{
+			TargetID:         "target-1",
+			ProviderID:       "broken-provider",
+			RequirementCount: 2,
+			Status:           "error",
+		},
+	}
+
+	result := FormatExecutionPlan("pol", rows)
+
+	assert.Contains(t, result, complytime.StatusFailed, "non-healthy status should get failed emoji")
+	assert.Contains(t, result, "error")
+}
+
+func TestFormatPreScanSummary_WithProvidersAndTargets(t *testing.T) {
+	result := FormatPreScanSummary(12, []string{"ampel", "opa"}, []string{"app-1", "app-2"})
+
+	assert.Contains(t, result, "Scanning 12 requirements")
+	assert.Contains(t, result, "ampel, opa")
+	assert.Contains(t, result, "app-1, app-2")
+	assert.Contains(t, result, "...")
+}
+
+func TestFormatPreScanSummary_SingleProviderAndTarget(t *testing.T) {
+	result := FormatPreScanSummary(5, []string{"ampel"}, []string{"my-target"})
+
+	assert.Equal(t, "Scanning 5 requirements via ampel for target(s): my-target...", result)
+}
+
+func TestFormatPreScanSummary_EmptyInputs(t *testing.T) {
+	result := FormatPreScanSummary(0, nil, nil)
+
+	assert.Equal(t, "Scanning 0 requirements via  for target(s): ...", result)
+}

--- a/internal/output/markdown_test.go
+++ b/internal/output/markdown_test.go
@@ -472,3 +472,75 @@ func TestMarkdown_ControlsTableShowsAllControls(t *testing.T) {
 	assert.Contains(t, content, "&nbsp;&nbsp;req-2")
 	assert.Contains(t, content, "&nbsp;&nbsp;req-3")
 }
+
+func TestMarkdown_NeedsReviewInFindings(t *testing.T) {
+	outDir := t.TempDir()
+	evalLog := &gemara.EvaluationLog{
+		Metadata: gemara.Metadata{
+			Id:            "nr-policy",
+			GemaraVersion: gemara.SchemaVersion,
+			Author: gemara.Actor{
+				Name: "complytime",
+			},
+		},
+		Result: gemara.NeedsReview,
+		Target: gemara.Resource{Id: "target-nr", Name: "target-nr", Type: gemara.Software},
+		Evaluations: []*gemara.ControlEvaluation{
+			{
+				Name:    "ctrl-review",
+				Result:  gemara.NeedsReview,
+				Message: "human review required",
+				Control: gemara.EntryMapping{ReferenceId: "nr-policy", EntryId: "ctrl-review"},
+				AssessmentLogs: []*gemara.AssessmentLog{
+					{
+						Requirement:     gemara.EntryMapping{ReferenceId: "nr-policy", EntryId: "req-review"},
+						Result:          gemara.NeedsReview,
+						Message:         "automated check inconclusive",
+						ConfidenceLevel: gemara.Medium,
+						Recommendation:  "Manual verification needed",
+					},
+				},
+			},
+			{
+				Name:    "ctrl-pass",
+				Result:  gemara.Passed,
+				Message: "ok",
+				Control: gemara.EntryMapping{ReferenceId: "nr-policy", EntryId: "ctrl-pass"},
+				AssessmentLogs: []*gemara.AssessmentLog{
+					{
+						Requirement: gemara.EntryMapping{ReferenceId: "nr-policy", EntryId: "req-pass"},
+						Result:      gemara.Passed,
+						Message:     "check passed",
+					},
+				},
+			},
+		},
+	}
+
+	md := output.NewMarkdown("nr-policy", evalLog)
+	path, err := md.Write(outDir)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	content := string(data)
+
+	// Summary counts table should include Needs Review column with value 1
+	assert.Contains(t, content, "Needs Review")
+	assert.Contains(t, content, "| 1 | 0 | 1 |", "should show 1 passed, 0 failed, 1 needs review")
+
+	// Controls table should show NeedsReview result
+	assert.Contains(t, content, "**ctrl-review**")
+	assert.Contains(t, content, "Needs Review")
+
+	// Findings section should include the NeedsReview finding
+	assert.Contains(t, content, "### Needs Review")
+	assert.Contains(t, content, "#### req-review -- Needs Review")
+	assert.Contains(t, content, "**Control**: ctrl-review")
+	assert.Contains(t, content, "automated check inconclusive")
+	assert.Contains(t, content, "**Confidence**: Medium")
+	assert.Contains(t, content, "**Recommendation**: Manual verification needed")
+
+	// Passed controls should NOT appear in findings
+	assert.NotContains(t, content, "#### req-pass")
+}

--- a/internal/output/oscal_test.go
+++ b/internal/output/oscal_test.go
@@ -142,6 +142,62 @@ func TestToOSCAL_ProperUUIDs(t *testing.T) {
 	}
 }
 
+func TestToOSCAL_AllResultMappings(t *testing.T) {
+	tests := []struct {
+		name           string
+		result         gemara.Result
+		expectedState  string
+		expectedReason string
+	}{
+		{"passed", gemara.Passed, "satisfied", ""},
+		{"failed", gemara.Failed, "not-satisfied", ""},
+		{"not applicable", gemara.NotApplicable, "satisfied", "not-applicable"},
+		{"unknown", gemara.Unknown, "not-satisfied", "unknown"},
+		{"not run (default)", gemara.NotRun, "not-satisfied", "unknown"},
+		{"needs review (default)", gemara.NeedsReview, "not-satisfied", "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outDir := t.TempDir()
+			log := &gemara.EvaluationLog{
+				Metadata: gemara.Metadata{
+					Id:            "test-policy",
+					GemaraVersion: gemara.SchemaVersion,
+					Author:        gemara.Actor{Id: "test", Name: "test", Type: gemara.Software},
+				},
+				Evaluations: []*gemara.ControlEvaluation{{
+					Name:    "ctrl-1",
+					Result:  tt.result,
+					Message: "test",
+					Control: gemara.EntryMapping{ReferenceId: "test-policy", EntryId: "ctrl-1"},
+					AssessmentLogs: []*gemara.AssessmentLog{{
+						Requirement: gemara.EntryMapping{ReferenceId: "test-policy", EntryId: "req-1"},
+						Result:      tt.result,
+						Message:     "test message",
+					}},
+				}},
+			}
+
+			path, err := output.ToOSCAL(log, outDir)
+			require.NoError(t, err)
+
+			data, err := os.ReadFile(path)
+			require.NoError(t, err)
+
+			var doc oscalTypes.OscalModels
+			require.NoError(t, json.Unmarshal(data, &doc))
+
+			require.NotNil(t, doc.AssessmentResults)
+			require.NotNil(t, doc.AssessmentResults.Results[0].Findings)
+			findings := *doc.AssessmentResults.Results[0].Findings
+			require.Len(t, findings, 1)
+
+			assert.Equal(t, tt.expectedState, findings[0].Target.Status.State, "state mismatch")
+			assert.Equal(t, tt.expectedReason, findings[0].Target.Status.Reason, "reason mismatch")
+		})
+	}
+}
+
 func TestToOSCAL_OutputFileNaming(t *testing.T) {
 	outDir := t.TempDir()
 	log := mockGemaraEvalLog()

--- a/internal/output/scan_summary_test.go
+++ b/internal/output/scan_summary_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gemaraproj/go-gemara"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -126,7 +127,21 @@ func TestFormatScanSummary_MissingTargetID(t *testing.T) {
 	output := FormatScanSummary(assessments, assessmentTargets, reqToControl, policyID, targetIDs, true)
 
 	require.Contains(t, output, "1 requirements")
-	assert.Contains(t, output, "-")
+
+	// Verify that the row containing REQ-1 has "-" as its target ID (first field).
+	// A bare Contains(output, "-") is trivially true due to hyphens in other text.
+	lines := strings.Split(output, "\n")
+	var foundFallbackTarget bool
+	for _, line := range lines {
+		if strings.Contains(line, "REQ-1") {
+			fields := strings.Fields(line)
+			if len(fields) > 0 && fields[0] == "-" {
+				foundFallbackTarget = true
+			}
+		}
+	}
+	assert.True(t, foundFallbackTarget,
+		"Row with REQ-1 should have '-' as target ID when assessmentTargets is empty")
 }
 
 func TestFormatOperationalWarnings_Empty(t *testing.T) {
@@ -234,20 +249,21 @@ func TestFormatScanSummary_ControlIDMissing(t *testing.T) {
 
 	output := FormatScanSummary(assessments, assessmentTargets, reqToControl, policyID, targetIDs, true)
 
+	// Verify that the row containing REQ-UNKNOWN has "-" as the control ID
+	// fallback. The table columns are: TARGET ID, REQUIREMENT ID, CONTROL ID, STATUS, MESSAGE.
+	// With strings.Fields the dash appears as a standalone field on that row.
 	lines := strings.Split(output, "\n")
-	var foundDash bool
+	var foundDashControl bool
 	for _, line := range lines {
 		if strings.Contains(line, "REQ-UNKNOWN") && strings.Contains(line, "target1") {
-			parts := strings.Fields(line)
-			for i, part := range parts {
-				if part == "REQ-UNKNOWN" && i+1 < len(parts) && parts[i+1] == "-" {
-					foundDash = true
-					break
-				}
+			fields := strings.Fields(line)
+			// fields[0]=target1, fields[1]=REQ-UNKNOWN, fields[2]=control ID
+			if len(fields) > 2 && fields[2] == "-" {
+				foundDashControl = true
 			}
 		}
 	}
-	assert.True(t, foundDash, "Should show '-' for missing control ID")
+	assert.True(t, foundDashControl, "Should show '-' for missing control ID in the CONTROL ID column")
 }
 
 func TestFormatScanSummary_ShowPassingFalse(t *testing.T) {
@@ -381,6 +397,54 @@ func TestFormatScanSummary_ShowPassingFalse_AllPassed_NoTable(t *testing.T) {
 
 	assert.NotContains(t, output, "TARGET ID")
 	assert.Contains(t, output, "2 requirements: 2 passed, 0 failed, 0 not applicable, 0 skipped, 0 errors")
+}
+
+func TestFormatScanSummary_ErrorResultDefaultBranch(t *testing.T) {
+	// provider.ResultError maps to gemara.Unknown, which hits the default
+	// branch in FormatScanSummary (errCount, StatusError). NeedsReview is
+	// not reachable through provider results alone — it requires gemara
+	// aggregation internals. Sort priority for NeedsReview is covered
+	// directly by TestSortPriority_NeedsReview below.
+	assessments := []provider.AssessmentLog{
+		{
+			RequirementID: "REQ-NR",
+			Steps: []provider.Step{
+				{Result: provider.ResultError, Message: "needs human review"},
+			},
+		},
+		{
+			RequirementID: "REQ-PASS",
+			Steps: []provider.Step{
+				{Result: provider.ResultPassed, Message: "OK"},
+			},
+		},
+	}
+	assessmentTargets := []string{"target1", "target1"}
+	reqToControl := map[string]string{
+		"REQ-NR":   "CTRL-NR",
+		"REQ-PASS": "CTRL-PASS",
+	}
+	policyID := "needs-review-policy"
+	targetIDs := []string{"target1"}
+
+	result := FormatScanSummary(assessments, assessmentTargets, reqToControl, policyID, targetIDs, true)
+
+	assert.Contains(t, result, "REQ-NR")
+	assert.Contains(t, result, "CTRL-NR")
+	assert.Contains(t, result, complytime.StatusError, "Unknown/NeedsReview results should show error emoji")
+	assert.Contains(t, result, "1 errors")
+	assert.Contains(t, result, "1 passed")
+}
+
+func TestSortPriority_NeedsReview(t *testing.T) {
+	// NeedsReview gets priority 3, between Unknown(2) and NotApplicable/NotRun(4).
+	assert.Equal(t, 3, sortPriority(gemara.NeedsReview))
+	assert.Less(t, sortPriority(gemara.Unknown), sortPriority(gemara.NeedsReview),
+		"Unknown should sort before NeedsReview")
+	assert.Less(t, sortPriority(gemara.NeedsReview), sortPriority(gemara.NotApplicable),
+		"NeedsReview should sort before NotApplicable")
+	assert.Less(t, sortPriority(gemara.Failed), sortPriority(gemara.NeedsReview),
+		"Failed should sort before NeedsReview")
 }
 
 func TestFormatScanSummary_AllFailed_ShowPassingTrue(t *testing.T) {


### PR DESCRIPTION
Add execution_plan_test.go with 7 tests for FormatExecutionPlan and
FormatPreScanSummary. Add NeedsReview result tests to scan_summary_test.go
and markdown_test.go. Enhance TestEvaluator_Write to verify file content
fields instead of just checking file existence.

Fix trivially true assertions in scan summary tests: replace Contains
checks that matched any output (like checking for "-") with targeted
assertions verifying the correct fallback values in table positions.

Add positive assertion for empty step identity instead of relying only
on NotContains.

Add OSCAL result mapping tests for Failed, Unknown, and default (NotRun,
NeedsReview) branches -- previously only 2 of 5 branches in
gemaraResultToOSCAL had coverage.

Refs: #653

Assisted-by: Claude Opus 4.6
Signed-off-by: Trevor Vaughan <tvaughan@redhat.com>
