### PR TITLE
test(policy): add happy-path loader tests and content assertions

### DIFF
--- a/internal/policy/loader_test.go
+++ b/internal/policy/loader_test.go
@@ -66,6 +66,58 @@ func TestGetCachedVersions_NonexistentPolicy(t *testing.T) {
 	assert.Empty(t, versions)
 }
 
+// --- ResolveVersion happy-path tests ---
+
+func TestResolveVersion_DirectTagMatch(t *testing.T) {
+	loader := seedTestPolicy(t, "resolve-direct", "v1.0.0")
+
+	version, err := loader.ResolveVersion("resolve-direct", "v1.0.0")
+	require.NoError(t, err)
+	assert.Equal(t, "v1.0.0", version)
+}
+
+func TestResolveVersion_LatestFallbackToCachedVersion(t *testing.T) {
+	loader := seedTestPolicy(t, "resolve-latest", "v1.0.0")
+
+	version, err := loader.ResolveVersion("resolve-latest", "")
+	require.NoError(t, err)
+	assert.Equal(t, "v1.0.0", version, "should fall back to the last cached version when 'latest' tag doesn't exist")
+}
+
+// --- ListCachedPolicies tests ---
+
+func TestListCachedPolicies_EmptyCache(t *testing.T) {
+	cacheDir := t.TempDir()
+	cacheMgr := cache.NewCache(cacheDir)
+	loader := NewLoader(cacheMgr)
+
+	result, err := loader.ListCachedPolicies()
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestListCachedPolicies_SeededCache(t *testing.T) {
+	cacheDir := filepath.Join(t.TempDir(), "cache")
+	require.NoError(t, os.MkdirAll(cacheDir, 0755))
+
+	mock := cachetest.NewMockPolicySource()
+	mock.SeedPolicy("policy-a", "v1.0.0", "sha256:digest-a")
+
+	cacheMgr := cache.NewCache(cacheDir)
+	state, err := cache.LoadState(cacheDir)
+	require.NoError(t, err)
+
+	sync := cache.NewSync(cacheMgr, state, mock)
+	_, err = sync.SyncPolicy(context.Background(), "policy-a", "latest")
+	require.NoError(t, err)
+
+	loader := NewLoader(cacheMgr)
+	result, err := loader.ListCachedPolicies()
+	require.NoError(t, err)
+	require.Contains(t, result, "policy-a")
+	assert.Equal(t, []string{"v1.0.0"}, result["policy-a"])
+}
+
 // --- T156: LoadLayerByMediaType ---
 
 func TestLoadLayerByMediaType_EmptyPolicyID(t *testing.T) {

--- a/internal/policy/resolver_test.go
+++ b/internal/policy/resolver_test.go
@@ -148,6 +148,12 @@ adherence:
 	assert.Len(t, graph.Assessments, 1)
 	assert.Equal(t, "openscap", graph.EvaluatorID)
 	assert.Equal(t, "ap-1", graph.Assessments[0].ID)
+
+	// Verify parsed content (matches bundle-path test pattern)
+	require.NotNil(t, graph.Controls[0].Parsed)
+	assert.Equal(t, "cat-1", graph.Controls[0].Parsed.Metadata.Id)
+	require.NotNil(t, graph.Guidelines[0].Parsed)
+	assert.Equal(t, "guide-1", graph.Guidelines[0].Parsed.Metadata.Id)
 }
 
 func TestResolvePolicyGraph_MissingOptionalLayers(t *testing.T) {


### PR DESCRIPTION
ResolveVersion's success paths (direct tag match and fallback to last
cached version) previously had zero happy-path coverage. Add tests for
both paths. Add tests for ListCachedPolicies which had zero coverage.

Verify parsed content (Controls and Guidelines fields) in the split-layer
resolver test to match the symmetric coverage already present in the
bundle-path equivalent test.

Refs: #653

Assisted-by: Claude Opus 4.6
Signed-off-by: Trevor Vaughan <tvaughan@redhat.com>
