### PR TITLE
test(complytime): add tests for utility functions and duplicate policy validation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 # Use LF line endings
 * text eol=lf
 # Tells Git to treat the file as a binary file, which prevents any line ending conversions.
-vendor/github.com/go-logfmt/logfmt/README.md -text
-vendor/oras.land/oras-go/v2/MIGRATION_GUIDE.md -text
+vendor/** -text

--- a/internal/complytime/config_test.go
+++ b/internal/complytime/config_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1253,4 +1254,69 @@ func TestValidate_ValidMixedVerificationConfigs(t *testing.T) {
 		},
 	}
 	assert.NoError(t, complytime.Validate(cfg))
+}
+
+func TestFilenameSafe(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"no slashes", "test-policy", "test-policy"},
+		{"single slash", "org/policy", "org-policy"},
+		{"multiple slashes", "org/sub/policy", "org-sub-policy"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, complytime.FilenameSafe(tt.input))
+		})
+	}
+}
+
+func TestExpandPath(t *testing.T) {
+	t.Run("tilde prefix", func(t *testing.T) {
+		result := complytime.ExpandPath("~/test")
+		assert.NotEqual(t, "~/test", result)
+		assert.True(t, strings.HasSuffix(result, "/test"))
+	})
+	t.Run("no tilde", func(t *testing.T) {
+		assert.Equal(t, "/absolute/path", complytime.ExpandPath("/absolute/path"))
+	})
+	t.Run("relative path", func(t *testing.T) {
+		assert.Equal(t, "relative/path", complytime.ExpandPath("relative/path"))
+	})
+}
+
+func TestResolveCacheDir(t *testing.T) {
+	dir, err := complytime.ResolveCacheDir()
+	require.NoError(t, err)
+	assert.NotEmpty(t, dir)
+	assert.Contains(t, dir, ".complytime")
+}
+
+func TestResolveProviderDir(t *testing.T) {
+	dir, err := complytime.ResolveProviderDir()
+	require.NoError(t, err)
+	assert.NotEmpty(t, dir)
+	assert.Contains(t, dir, ".complytime")
+	assert.Contains(t, dir, "providers")
+}
+
+func TestValidate_DuplicatePolicyInTarget(t *testing.T) {
+	cfg := &complytime.WorkspaceConfig{
+		Version: 1,
+		Policies: []complytime.PolicyEntry{
+			{URL: "registry.com/policies/nist:v1.0", ID: "nist"},
+		},
+		Targets: []complytime.TargetConfig{
+			{
+				ID:       "prod",
+				Policies: []string{"nist", "nist"},
+			},
+		},
+	}
+	err := complytime.Validate(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate policy")
 }


### PR DESCRIPTION
Add tests for FilenameSafe, ExpandPath, ResolveCacheDir, and
ResolveProviderDir which had zero test coverage. Add test for
duplicate-policy-within-target validation path.

Refs: #653

Assisted-by: Claude Opus 4.6
Signed-off-by: Trevor Vaughan <tvaughan@redhat.com>
