### PR TITLE
ci: use Makefile test targets in unit and e2e workflows

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -26,8 +26,5 @@ jobs:
               with:
                   go-version-file: './go.mod'
 
-            - name: Build binaries
-              run: make build build-test-provider
-
             - name: Run e2e tests
-              run: go test -tags=e2e -mod=vendor ./tests/e2e/... -v -count=1 -timeout 120s
+              run: make test-e2e

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -38,8 +38,5 @@ jobs:
               with:
                   go-version-file: './go.mod'
 
-            - name: Install dependencies
-              run: go mod tidy
-
             - name: Run unit tests
-              run: go list ./... | grep -v /tests | xargs go test -v
+              run: make test-unit


### PR DESCRIPTION
unit_test.yml bypassed the Makefile and ran a custom go test
invocation that was missing -race and -coverprofile flags, and
filtered packages by path instead of relying on build tags.

e2e_test.yml duplicated the Makefile go test command and its
build prerequisites inline instead of delegating to make test-e2e.

Both workflows now delegate to their respective Makefile targets
so CI inherits the same flags and prerequisites as local runs.

Refs: #653

Assisted-by: Claude Opus 4.6
Signed-off-by: Trevor Vaughan <tvaughan@redhat.com>
