### PR TITLE
docs: bump ampel prerequisite and fix Go version

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -19,7 +19,7 @@ cosign verify-blob \
 
 ### Prerequisites
 
-- **Go** 1.24+
+- **Go** 1.25+
 - **Make**
 - **buf** CLI (optional, for protobuf regeneration)
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -35,7 +35,7 @@ prerequisites for the provider(s) you plan to use.
 
 ```bash
 go install github.com/carabiner-dev/snappy@v0.2.4
-go install github.com/carabiner-dev/ampel/cmd/ampel@v1.2.1
+go install github.com/carabiner-dev/ampel/cmd/ampel@v1.3.1
 ```
 
 **OPA:**


### PR DESCRIPTION
## Summary
- Bump ampel pin from `v1.2.1` to `v1.3.1` (released 2026-06-21) in Quick Start prerequisites
- Fix Go version in INSTALLATION.md: `1.24+` → `1.25+` to match `go.mod` (`go 1.25.11`)
- Keep pinned versions (snappy `v0.2.4`, conftest `v0.68.2` unchanged — already current)

## Context
Addresses review feedback from #656:
- @gxmiranda noted ampel was pinned to a stale version
- @marcusburghardt suggested `@latest` — decided to keep pinned versions for reproducibility and auditability per project convention

## Test plan
- [x] Docs-only change, no code impact