### PR TITLE
fix: reject duplicate evaluator-ids and self-heal missing complypack cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,3 +135,11 @@
   ensuring output displays meaningful identifiers instead of internal
   plan references. Affects EvaluationLog, OSCAL, SARIF, and Markdown
   output formats.
+- `complyctl get` now detects and rejects duplicate evaluator-ids across
+  complypack entries. Previously, multiple complypacks resolving to the
+  same evaluator-id caused non-deterministic digest selection during
+  scan, leading to unnecessary regeneration or stale artifacts (#647).
+- `complyctl get` now re-fetches complypack artifacts when the cache
+  directory is missing, even if `state.json` records a matching digest.
+  Previously, a deleted cache directory caused the sync to be permanently
+  skipped until the user manually cleared state (#649).

--- a/cmd/complyctl/cli/cli_test.go
+++ b/cmd/complyctl/cli/cli_test.go
@@ -1739,6 +1739,66 @@ func TestBuildReqToComplypackRef_ResolvesRequirements(t *testing.T) {
 	assert.Equal(t, "registry.example.com/complypacks/kyverno@sha256:def456", m["req-3"])
 }
 
+// --- validateUniqueEvaluatorIDs tests ---
+
+func TestValidateUniqueEvaluatorIDs_NoDuplicates(t *testing.T) {
+	state := &cache.State{
+		Complypacks: map[string]cache.PolicyState{
+			"complypacks/opa":   {EvaluatorID: "opa", Digest: "sha256:aaa"},
+			"complypacks/ampel": {EvaluatorID: "ampel", Digest: "sha256:bbb"},
+		},
+	}
+	complypacks := []complytime.PolicyEntry{
+		{URL: "reg.io/complypacks/opa:v1.0"},
+		{URL: "reg.io/complypacks/ampel:v1.0"},
+	}
+	err := validateUniqueEvaluatorIDs(state, complypacks)
+	assert.NoError(t, err)
+}
+
+func TestValidateUniqueEvaluatorIDs_DuplicateDetected(t *testing.T) {
+	state := &cache.State{
+		Complypacks: map[string]cache.PolicyState{
+			"complypacks/opa-a": {EvaluatorID: "opa", Digest: "sha256:aaa"},
+			"complypacks/opa-b": {EvaluatorID: "opa", Digest: "sha256:bbb"},
+		},
+	}
+	complypacks := []complytime.PolicyEntry{
+		{URL: "reg.io/complypacks/opa-a:v1.0"},
+		{URL: "reg.io/complypacks/opa-b:v2.0"},
+	}
+	err := validateUniqueEvaluatorIDs(state, complypacks)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `duplicate evaluator-id "opa"`)
+	assert.Contains(t, err.Error(), "complypacks/opa-a")
+	assert.Contains(t, err.Error(), "complypacks/opa-b")
+	assert.Contains(t, err.Error(), "remove one of the conflicting entries")
+}
+
+func TestValidateUniqueEvaluatorIDs_SingleEntry(t *testing.T) {
+	state := &cache.State{
+		Complypacks: map[string]cache.PolicyState{
+			"complypacks/opa": {EvaluatorID: "opa", Digest: "sha256:aaa"},
+		},
+	}
+	complypacks := []complytime.PolicyEntry{
+		{URL: "reg.io/complypacks/opa:v1.0"},
+	}
+	err := validateUniqueEvaluatorIDs(state, complypacks)
+	assert.NoError(t, err)
+}
+
+func TestValidateUniqueEvaluatorIDs_EmptyState(t *testing.T) {
+	state := &cache.State{
+		Complypacks: make(map[string]cache.PolicyState),
+	}
+	complypacks := []complytime.PolicyEntry{
+		{URL: "reg.io/complypacks/opa:v1.0"},
+	}
+	err := validateUniqueEvaluatorIDs(state, complypacks)
+	assert.NoError(t, err)
+}
+
 func TestBuildReqToComplypackRef_SkipsMissingDigest(t *testing.T) {
 	cacheDir := t.TempDir()
 	state := &cache.State{

--- a/cmd/complyctl/cli/get.go
+++ b/cmd/complyctl/cli/get.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -154,7 +156,8 @@ func (o *getOptions) syncPolicies(ctx context.Context, cfg *complytime.Workspace
 }
 
 // syncComplypacks fetches complypack artifacts listed in the workspace config.
-// Skips silently when no complypacks are configured.
+// Skips silently when no complypacks are configured. After sync completes,
+// validates that no two complypack entries resolved to the same evaluator-id.
 func (o *getOptions) syncComplypacks(ctx context.Context, cfg *complytime.WorkspaceConfig, baseDir string, syncOpts []cache.SyncOption) error {
 	if len(cfg.Complypacks) == 0 {
 		return nil
@@ -172,7 +175,11 @@ func (o *getOptions) syncComplypacks(ctx context.Context, cfg *complytime.Worksp
 		return fmt.Errorf("authentication setup failed: %w", err)
 	}
 
-	return syncAllComplypacks(ctx, state, credFunc, cfg.Complypacks, o.cacheDir, baseDir, syncOpts)
+	if err := syncAllComplypacks(ctx, state, credFunc, cfg.Complypacks, o.cacheDir, baseDir, syncOpts); err != nil {
+		return err
+	}
+
+	return validateUniqueEvaluatorIDs(state, cfg.Complypacks)
 }
 
 func syncAllPolicies(ctx context.Context, cacheMgr *cache.Cache, state *cache.State, credFunc auth.CredentialFunc, policies []complytime.PolicyEntry, syncOpts []cache.SyncOption) error {
@@ -326,4 +333,54 @@ func invalidateGenerationForComplypack(state *cache.State, repository, baseDir s
 
 	fmt.Fprintf(os.Stderr, "Complypack %s updated — generation cache invalidated for %s\n", repository, evalID)
 	logger.Info("Generation cache invalidated after complypack update", "repository", repository, "evaluator", evalID)
+}
+
+// validateUniqueEvaluatorIDs checks that no two complypack entries in the
+// workspace config resolved to the same evaluator-id. Evaluator-ids are
+// only known after sync (they come from the complypack's embedded
+// config.json), so this validation runs post-sync.
+//
+// Returns a descriptive error listing all conflicting repositories when
+// duplicates are found. The error causes complyctl get to exit non-zero.
+func validateUniqueEvaluatorIDs(state *cache.State, complypacks []complytime.PolicyEntry) error {
+	// Build evaluator-id → []repository map from state, scoped to the
+	// configured complypack entries.
+	evalToRepos := make(map[string][]string)
+	for _, entry := range complypacks {
+		// ParsePolicyRef cannot fail here: syncAllComplypacks already
+		// validated all entries. Skip safely if it does — the entry
+		// has no state to contribute to conflict detection.
+		ref, err := complytime.ParsePolicyRef(entry.URL)
+		if err != nil {
+			continue
+		}
+		ps, exists := state.GetComplypackState(ref.Repository)
+		if !exists || ps.EvaluatorID == "" {
+			continue
+		}
+		evalToRepos[ps.EvaluatorID] = append(evalToRepos[ps.EvaluatorID], ref.Repository)
+	}
+
+	var conflicts []string
+	for evalID, repos := range evalToRepos {
+		if len(repos) > 1 {
+			sort.Strings(repos)
+			lines := make([]string, 0, len(repos))
+			for _, r := range repos {
+				lines = append(lines, fmt.Sprintf("  - %s", r))
+			}
+			conflicts = append(conflicts, fmt.Sprintf(
+				"duplicate evaluator-id %q found in complypack entries:\n%s",
+				evalID, strings.Join(lines, "\n")))
+		}
+	}
+
+	if len(conflicts) == 0 {
+		return nil
+	}
+
+	sort.Strings(conflicts)
+	return fmt.Errorf(
+		"%s\nremove one of the conflicting entries from complytime.yaml",
+		strings.Join(conflicts, "\n"))
 }

--- a/internal/cache/complypack_sync.go
+++ b/internal/cache/complypack_sync.go
@@ -38,6 +38,19 @@ func NewComplypackSync(complypackCache *ComplypackCache, state *State, source Co
 	}
 }
 
+// cacheExistsForState checks whether the cache directory for a previously
+// synced complypack still exists on disk. Uses the evaluator-id recorded in
+// state to locate the cache via LookupByEvaluatorID. Returns false if the
+// evaluator-id is empty (state predates evaluator-id tracking) or if the
+// cache files are missing.
+func (s *ComplypackSync) cacheExistsForState(ps PolicyState) bool {
+	if ps.EvaluatorID == "" {
+		return false
+	}
+	contentPath, _, err := s.complypackCache.LookupByEvaluatorID(ps.EvaluatorID)
+	return err == nil && contentPath != ""
+}
+
 // SyncComplypack performs incremental synchronization of a complypack artifact.
 // Compares the local cached digest against the remote manifest digest; if they
 // match, sync is skipped. On change, the artifact is fetched into a temporary
@@ -66,18 +79,13 @@ func (s *ComplypackSync) SyncComplypack(ctx context.Context, repository, version
 		version = remoteVersion
 	}
 
-	// Incremental sync check: skip if local digest matches remote.
-	//
-	// Design note: we only check state digest, not whether the cache directory
-	// still exists on disk. The evaluator-id is only known after unpacking the
-	// artifact, so we cannot call LookupByEvaluatorID here (we only have the
-	// repository string at this point). If a user manually deletes the cache
-	// directory but state.json still records a matching digest, this guard will
-	// skip the sync. The user must clear state (or change the digest) to force
-	// a re-fetch. This matches the policy sync pattern where state is the
-	// source of truth for incremental checks.
+	// Incremental sync check: skip only if local digest matches remote AND
+	// the cache directory still exists on disk. The state records the
+	// evaluator-id from the previous unpack, so we can verify cache presence
+	// without re-unpacking. This mirrors the policy sync pattern where
+	// PolicyStoreExists() gates the skip (see sync.go line 85).
 	localState, exists := s.state.GetComplypackState(repository)
-	if exists && localState.Digest == remoteDigest {
+	if exists && localState.Digest == remoteDigest && s.cacheExistsForState(localState) {
 		return false, nil
 	}
 

--- a/internal/cache/complypack_sync_test.go
+++ b/internal/cache/complypack_sync_test.go
@@ -216,6 +216,75 @@ func TestComplypackSync_IncrementalSkip(t *testing.T) {
 	assert.Equal(t, "sha256:incremental111", ps.Digest)
 }
 
+// TestComplypackSync_CacheMissing_RefetchesDespiteMatchingDigest verifies that
+// when the cache directory has been deleted but state.json still records a
+// matching digest, SyncComplypack re-fetches the artifact instead of skipping.
+// This is the fix for #649: state/filesystem desynchronization.
+func TestComplypackSync_CacheMissing_RefetchesDespiteMatchingDigest(t *testing.T) {
+	tmpDir := t.TempDir()
+	cacheDir := filepath.Join(tmpDir, "cache")
+	require.NoError(t, os.MkdirAll(cacheDir, 0755))
+
+	mock := newMockComplypackSource()
+	mock.seedComplypack(
+		"example.com/complypacks/opa-bundle",
+		"io.complytime.opa",
+		"1.0.0",
+		"sha256:cache-missing-test",
+		"opa bundle content for cache-missing test",
+	)
+
+	complypackCache := cache.NewComplypackCache(cacheDir)
+	state, err := cache.LoadState(cacheDir)
+	require.NoError(t, err)
+
+	syncMgr := cache.NewComplypackSync(complypackCache, state, mock)
+
+	// First sync — should fetch and store.
+	fetched, err := syncMgr.SyncComplypack(context.Background(), "example.com/complypacks/opa-bundle", "1.0.0")
+	require.NoError(t, err)
+	assert.True(t, fetched, "first sync should fetch")
+	assert.Equal(t, 1, mock.getCopyCount())
+
+	// Verify cache exists.
+	contentPath, _, err := complypackCache.LookupByEvaluatorID("io.complytime.opa")
+	require.NoError(t, err)
+	assert.NotEmpty(t, contentPath, "cache should exist after first sync")
+
+	// Delete the cache directory to simulate user deletion.
+	complypacksDir := filepath.Join(cacheDir, "complypacks", "io.complytime.opa")
+	require.NoError(t, os.RemoveAll(complypacksDir))
+
+	// Verify cache is gone.
+	contentPath2, _, err := complypackCache.LookupByEvaluatorID("io.complytime.opa")
+	require.NoError(t, err)
+	assert.Empty(t, contentPath2, "cache should be gone after deletion")
+
+	// Reload state — it still records the old digest.
+	state2, err := cache.LoadState(cacheDir)
+	require.NoError(t, err)
+	ps, ok := state2.GetComplypackState("example.com/complypacks/opa-bundle")
+	require.True(t, ok, "state should still record the complypack")
+	assert.Equal(t, "sha256:cache-missing-test", ps.Digest,
+		"state should still have the old digest")
+
+	syncMgr2 := cache.NewComplypackSync(complypackCache, state2, mock)
+
+	// Second sync — same digest, but cache is missing. Should re-fetch.
+	fetched2, err := syncMgr2.SyncComplypack(context.Background(), "example.com/complypacks/opa-bundle", "1.0.0")
+	require.NoError(t, err)
+	assert.True(t, fetched2,
+		"sync should re-fetch when cache is missing despite matching digest")
+	assert.Equal(t, 2, mock.getCopyCount(),
+		"CopyComplypack should be called again when cache is missing")
+
+	// Verify cache is restored.
+	contentPath3, _, err := complypackCache.LookupByEvaluatorID("io.complytime.opa")
+	require.NoError(t, err)
+	assert.NotEmpty(t, contentPath3, "cache should be restored after re-fetch")
+	assert.FileExists(t, contentPath3, "content.tar.gz should exist after re-fetch")
+}
+
 // TestComplypackSync_DigestChanged verifies that when the remote digest changes,
 // a re-fetch is triggered and the cache is updated with the new content.
 func TestComplypackSync_DigestChanged(t *testing.T) {

--- a/openspec/changes/doctor-complypack-cache-check/.openspec.yaml
+++ b/openspec/changes/doctor-complypack-cache-check/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-06-30

--- a/openspec/changes/doctor-complypack-cache-check/design.md
+++ b/openspec/changes/doctor-complypack-cache-check/design.md
@@ -11,29 +11,24 @@
 ## Non-Goals
 
 - Verifying content integrity (checksums/signatures)
-- Adding a `--force` flag to `complyctl get` (separate issue)
-- Auto-healing (re-fetching missing complypacks)
+- Adding a `--force` flag to `complyctl get` (evaluated and rejected — root-cause fix in SyncComplypack is preferred)
 
 ## Decisions
 
-### D1: Check placement
+### D1: Fix the root cause in SyncComplypack
 
-Add `CheckComplypackCacheIntegrity` as a new non-blocking check in the doctor check list. It runs after `CheckComplypacks` (which validates config).
+The original design comment in `complypack_sync.go` acknowledged that sync only checked state digest, not whether the cache directory existed. The policy sync (`sync.go:85`) already gates the skip with `PolicyStoreExists()`. We added the equivalent `cacheExistsForState()` check to `SyncComplypack`, using the evaluator-id recorded in state from a previous unpack. This makes `complyctl get` self-heal when cache is deleted — no `--force` flag needed.
 
-### D2: What to verify
+A `--force` flag was evaluated and rejected because: (a) it bypasses digest comparison, which is a security-relevant integrity check; (b) it treats the symptom rather than the bug; (c) users should not need to know when to apply it.
 
-For each complypack entry in `state.json`:
-1. Resolve evaluator-id from the entry
-2. Check that `{cacheDir}/complypacks/{evaluator-id}/` exists
-3. Check that at least one version subdirectory contains `content.tar.gz`
+### D2: No new doctor check needed
 
-### D3: Non-blocking
-
-This is a WARNING-level check, not a blocking check. Missing cache doesn't prevent all operations — only scan/generate for that specific evaluator would fail.
-
-### D4: Remediation message
-
-Format: `Complypack cache missing for evaluator "{id}" — run "complyctl get" to restore`
+The existing `CheckComplypacks` already detects missing complypack caches via
+`LookupByEvaluatorID` and emits a non-blocking warning. A separate
+`CheckComplypackCacheIntegrity` was implemented and then removed during review
+because it produced duplicate warnings for the same condition. With the
+SyncComplypack root-cause fix, `complyctl get` self-heals — the existing doctor
+check is sufficient for user visibility.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/doctor-complypack-cache-check/design.md
+++ b/openspec/changes/doctor-complypack-cache-check/design.md
@@ -1,0 +1,41 @@
+## Context
+
+`complyctl doctor` runs pre-flight diagnostic checks. The existing `CheckComplypacks` verifies evaluator-id presence in config but not that cache files actually exist on disk.
+
+## Goals
+
+- Detect when `state.json` claims a complypack is cached but the files are missing
+- Provide actionable remediation advice
+- Non-blocking check (warning, not failure)
+
+## Non-Goals
+
+- Verifying content integrity (checksums/signatures)
+- Adding a `--force` flag to `complyctl get` (separate issue)
+- Auto-healing (re-fetching missing complypacks)
+
+## Decisions
+
+### D1: Check placement
+
+Add `CheckComplypackCacheIntegrity` as a new non-blocking check in the doctor check list. It runs after `CheckComplypacks` (which validates config).
+
+### D2: What to verify
+
+For each complypack entry in `state.json`:
+1. Resolve evaluator-id from the entry
+2. Check that `{cacheDir}/complypacks/{evaluator-id}/` exists
+3. Check that at least one version subdirectory contains `content.tar.gz`
+
+### D3: Non-blocking
+
+This is a WARNING-level check, not a blocking check. Missing cache doesn't prevent all operations — only scan/generate for that specific evaluator would fail.
+
+### D4: Remediation message
+
+Format: `Complypack cache missing for evaluator "{id}" — run "complyctl get" to restore`
+
+## Risks / Trade-offs
+
+- The check requires loading `state.json` which doctor already does for other checks — no additional I/O cost.
+- If #646 (version eviction) lands first, there's guaranteed to be at most one version dir, simplifying the "find content.tar.gz" logic.

--- a/openspec/changes/doctor-complypack-cache-check/proposal.md
+++ b/openspec/changes/doctor-complypack-cache-check/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+`ComplypackSync.SyncComplypack()` checks freshness by comparing `state.json` digest against remote. If the local cache directory has been deleted but `state.json` still records a matching digest, sync is permanently skipped. `LookupByEvaluatorID` then returns an empty path, the provider gets no complypack content, and scan may produce incomplete results without error.
+
+There is no user-facing detection or self-healing for this state. `complyctl doctor` currently checks whether evaluator-ids are present in complypack config but does not verify file integrity.
+
+This is tracked in [#649](https://github.com/complytime/complyctl/issues/649).
+
+## What Changes
+
+- `complyctl doctor` gains a new check that verifies each complypack entry in `state.json` has a corresponding cache directory with `content.tar.gz` present.
+- When the directory is missing, doctor emits a warning suggesting `complyctl get --force` or clearing state.
+
+## Capabilities
+
+### New Capabilities
+- `doctor-complypack-integrity`: Verify that complypack cache directories referenced by `state.json` actually exist on disk with expected content files.
+
+### Modified Capabilities
+- `doctor`: Gains an additional diagnostic check in the complypack section.
+
+### Removed Capabilities
+- None.
+
+## Impact
+
+- `internal/doctor/doctor.go` — new `CheckComplypackCacheIntegrity` function
+- `internal/doctor/doctor_test.go` — tests for the new check
+- No CLI flag changes (check is always run as part of `complyctl doctor`)
+
+## Constitution Alignment
+
+### I. Autonomous Collaboration
+
+**Assessment**: PASS
+
+Doctor proactively detects and reports the inconsistency with actionable remediation advice.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+The check is additive — existing checks are unaffected. The new check is independent and scoped to complypack cache integrity only.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+Clear diagnostic output identifying which complypack entries have missing cache directories, with suggested fix commands.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+Testable by pre-seeding `state.json` with complypack entries and verifying the check detects missing/present directories.

--- a/openspec/changes/doctor-complypack-cache-check/proposal.md
+++ b/openspec/changes/doctor-complypack-cache-check/proposal.md
@@ -1,32 +1,33 @@
 ## Why
 
-`ComplypackSync.SyncComplypack()` checks freshness by comparing `state.json` digest against remote. If the local cache directory has been deleted but `state.json` still records a matching digest, sync is permanently skipped. `LookupByEvaluatorID` then returns an empty path, the provider gets no complypack content, and scan may produce incomplete results without error.
+`ComplypackSync.SyncComplypack()` checked freshness by comparing `state.json` digest against remote but did not verify the cache directory still existed on disk. If the local cache directory was deleted but `state.json` still recorded a matching digest, sync was permanently skipped. `LookupByEvaluatorID` then returned an empty path, the provider got no complypack content, and scan could produce incomplete results without error.
 
-There is no user-facing detection or self-healing for this state. `complyctl doctor` currently checks whether evaluator-ids are present in complypack config but does not verify file integrity.
+There was no user-facing detection or self-healing for this state. `complyctl doctor` checked whether evaluator-ids were present in complypack config but did not verify file integrity.
 
 This is tracked in [#649](https://github.com/complytime/complyctl/issues/649).
 
 ## What Changes
 
-- `complyctl doctor` gains a new check that verifies each complypack entry in `state.json` has a corresponding cache directory with `content.tar.gz` present.
-- When the directory is missing, doctor emits a warning suggesting `complyctl get --force` or clearing state.
+- `SyncComplypack` gains a cache-existence check (mirroring the policy sync pattern) so `complyctl get` self-heals when cache is deleted.
+- The existing `CheckComplypacks` in doctor already detects missing caches via `LookupByEvaluatorID` — no new doctor check needed.
 
 ## Capabilities
 
 ### New Capabilities
-- `doctor-complypack-integrity`: Verify that complypack cache directories referenced by `state.json` actually exist on disk with expected content files.
+- `complypack-cache-self-heal`: `SyncComplypack` detects missing cache directories and re-fetches despite matching digest, mirroring the policy sync `PolicyStoreExists()` pattern.
 
 ### Modified Capabilities
-- `doctor`: Gains an additional diagnostic check in the complypack section.
+- `get`: Complypack sync gains cache-existence check alongside digest comparison for incremental skip decisions.
 
 ### Removed Capabilities
-- None.
+- `doctor-complypack-integrity`: Evaluated and removed — the existing `CheckComplypacks` already detects missing caches via `LookupByEvaluatorID`.
 
 ## Impact
 
-- `internal/doctor/doctor.go` — new `CheckComplypackCacheIntegrity` function
-- `internal/doctor/doctor_test.go` — tests for the new check
-- No CLI flag changes (check is always run as part of `complyctl doctor`)
+- `internal/cache/complypack_sync.go` — root-cause fix: `cacheExistsForState()` + skip guard update
+- `internal/cache/complypack_sync_test.go` — cache-missing re-fetch test
+- No doctor changes (existing `CheckComplypacks` already covers this case)
+- No CLI flag changes
 
 ## Constitution Alignment
 

--- a/openspec/changes/doctor-complypack-cache-check/specs/cache-integrity/spec.md
+++ b/openspec/changes/doctor-complypack-cache-check/specs/cache-integrity/spec.md
@@ -1,29 +1,34 @@
 ## ADDED Requirements
 
-### FR-001: Detect missing complypack cache directory
+### FR-001: Self-heal when cache directory is missing
 
 **Given** `state.json` records a complypack entry with evaluator-id `E` and digest `D`
 **And** the directory `~/.complytime/complypacks/E/` does not exist
-**When** `complyctl doctor` runs
-**Then** a warning MUST be emitted indicating the cache is missing for evaluator `E`
-**And** the warning MUST suggest running `complyctl get` to restore
+**When** `complyctl get` runs and the remote digest matches `D`
+**Then** `SyncComplypack` MUST re-fetch the artifact instead of skipping
+**And** the cache MUST be restored after sync completes
 
-### FR-002: Detect missing content.tar.gz
+### FR-002: Skip only when digest matches AND cache exists
+
+**Given** `state.json` records a complypack entry with matching remote digest
+**And** the cache directory and `content.tar.gz` exist on disk
+**When** `complyctl get` runs
+**Then** `SyncComplypack` MUST skip the fetch (incremental sync)
+
+### FR-003: Doctor warns when cache is missing
 
 **Given** `state.json` records a complypack entry with evaluator-id `E`
-**And** the evaluator directory exists but contains no `content.tar.gz`
+**And** `LookupByEvaluatorID(E)` returns an empty path
 **When** `complyctl doctor` runs
-**Then** a warning MUST be emitted indicating the complypack content is incomplete
+**Then** the existing `CheckComplypacks` MUST emit a warning for evaluator `E`
+**And** the warning MUST suggest running `complyctl get`
 
-### FR-003: Pass when cache is consistent
-
-**Given** `state.json` records a complypack entry with evaluator-id `E`
-**And** `~/.complytime/complypacks/E/{version}/content.tar.gz` exists
-**When** `complyctl doctor` runs
-**Then** the complypack cache integrity check MUST pass
+Note: A separate `CheckComplypackCacheIntegrity` was evaluated and removed
+because `CheckComplypacks` already covers this case. Adding a second check
+produced duplicate warnings for the same condition.
 
 ### FR-004: Handle empty state (no complypacks configured)
 
-**Given** `state.json` has no complypack entries (or does not exist)
-**When** `complyctl doctor` runs
-**Then** the complypack cache integrity check MUST be skipped without error
+**Given** no complypack entries exist in the workspace config
+**When** `complyctl get` or `complyctl doctor` runs
+**Then** complypack checks MUST be skipped without error

--- a/openspec/changes/doctor-complypack-cache-check/specs/cache-integrity/spec.md
+++ b/openspec/changes/doctor-complypack-cache-check/specs/cache-integrity/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### FR-001: Detect missing complypack cache directory
+
+**Given** `state.json` records a complypack entry with evaluator-id `E` and digest `D`
+**And** the directory `~/.complytime/complypacks/E/` does not exist
+**When** `complyctl doctor` runs
+**Then** a warning MUST be emitted indicating the cache is missing for evaluator `E`
+**And** the warning MUST suggest running `complyctl get` to restore
+
+### FR-002: Detect missing content.tar.gz
+
+**Given** `state.json` records a complypack entry with evaluator-id `E`
+**And** the evaluator directory exists but contains no `content.tar.gz`
+**When** `complyctl doctor` runs
+**Then** a warning MUST be emitted indicating the complypack content is incomplete
+
+### FR-003: Pass when cache is consistent
+
+**Given** `state.json` records a complypack entry with evaluator-id `E`
+**And** `~/.complytime/complypacks/E/{version}/content.tar.gz` exists
+**When** `complyctl doctor` runs
+**Then** the complypack cache integrity check MUST pass
+
+### FR-004: Handle empty state (no complypacks configured)
+
+**Given** `state.json` has no complypack entries (or does not exist)
+**When** `complyctl doctor` runs
+**Then** the complypack cache integrity check MUST be skipped without error

--- a/openspec/changes/doctor-complypack-cache-check/tasks.md
+++ b/openspec/changes/doctor-complypack-cache-check/tasks.md
@@ -1,0 +1,19 @@
+## 1. Add cache integrity check to doctor
+
+- [ ] 1.1 Add `CheckComplypackCacheIntegrity(cacheDir string, state *cache.State) []DiagnosticResult` to `internal/doctor/doctor.go`
+- [ ] 1.2 For each complypack in `state.Complypacks`: resolve evaluator-id, check directory existence, check `content.tar.gz` presence
+- [ ] 1.3 Return warning-level results for missing directories or content
+- [ ] 1.4 Wire the new check into the doctor check list (non-blocking)
+
+## 2. Unit tests
+
+- [ ] 2.1 [P] `TestCheckComplypackCacheIntegrity_AllPresent` — pass case
+- [ ] 2.2 [P] `TestCheckComplypackCacheIntegrity_MissingDir` — warning emitted
+- [ ] 2.3 [P] `TestCheckComplypackCacheIntegrity_MissingContent` — warning emitted
+- [ ] 2.4 [P] `TestCheckComplypackCacheIntegrity_EmptyState` — skipped cleanly
+
+## 3. Verification
+
+- [ ] 3.1 Run `go test -race ./internal/doctor/`
+- [ ] 3.2 Run `go vet ./...`
+- [ ] 3.3 E2E: manually delete a complypack dir, run `complyctl doctor`, verify warning appears

--- a/openspec/changes/doctor-complypack-cache-check/tasks.md
+++ b/openspec/changes/doctor-complypack-cache-check/tasks.md
@@ -1,19 +1,19 @@
-## 1. Add cache integrity check to doctor
+## 1. Fix root cause: SyncComplypack cache-existence check
 
-- [ ] 1.1 Add `CheckComplypackCacheIntegrity(cacheDir string, state *cache.State) []DiagnosticResult` to `internal/doctor/doctor.go`
-- [ ] 1.2 For each complypack in `state.Complypacks`: resolve evaluator-id, check directory existence, check `content.tar.gz` presence
-- [ ] 1.3 Return warning-level results for missing directories or content
-- [ ] 1.4 Wire the new check into the doctor check list (non-blocking)
+- [x] 1.1 Add `cacheExistsForState(ps PolicyState) bool` to `ComplypackSync` in `internal/cache/complypack_sync.go`
+- [x] 1.2 Update incremental skip guard: require `cacheExistsForState(localState)` alongside digest match
+- [x] 1.3 [P] `TestComplypackSync_CacheMissing_RefetchesDespiteMatchingDigest` — re-fetches when cache deleted
 
-## 2. Unit tests
+## 2. Doctor check (evaluated and removed)
 
-- [ ] 2.1 [P] `TestCheckComplypackCacheIntegrity_AllPresent` — pass case
-- [ ] 2.2 [P] `TestCheckComplypackCacheIntegrity_MissingDir` — warning emitted
-- [ ] 2.3 [P] `TestCheckComplypackCacheIntegrity_MissingContent` — warning emitted
-- [ ] 2.4 [P] `TestCheckComplypackCacheIntegrity_EmptyState` — skipped cleanly
+A separate `CheckComplypackCacheIntegrity` was implemented and then removed during
+review. The existing `CheckComplypacks` already detects missing complypack caches
+via `LookupByEvaluatorID`. Adding a second check produced duplicate warnings for
+the same condition. With the SyncComplypack root-cause fix in place, `complyctl get`
+self-heals automatically — a redundant doctor check adds noise without unique value.
 
 ## 3. Verification
 
-- [ ] 3.1 Run `go test -race ./internal/doctor/`
-- [ ] 3.2 Run `go vet ./...`
-- [ ] 3.3 E2E: manually delete a complypack dir, run `complyctl doctor`, verify warning appears
+- [x] 3.1 Run `go test -race ./internal/cache/`
+- [x] 3.2 Run `go vet ./...`
+- [x] 3.3 E2E: delete complypack dir → `complyctl doctor` warns → `complyctl get` re-fetches → `complyctl doctor` passes

--- a/openspec/changes/reject-duplicate-evaluator-id/.openspec.yaml
+++ b/openspec/changes/reject-duplicate-evaluator-id/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: unbound-force
+created: 2026-06-30

--- a/openspec/changes/reject-duplicate-evaluator-id/design.md
+++ b/openspec/changes/reject-duplicate-evaluator-id/design.md
@@ -21,7 +21,7 @@ Evaluator-ids are embedded in the complypack's `config.json`, which is only avai
 
 ### D2: Validation location
 
-Add a `validateUniqueEvaluatorIDs(state *cache.State) error` function called after `syncAllComplypacks` returns successfully. On error, `complyctl get` exits non-zero.
+Add a `validateUniqueEvaluatorIDs(state *cache.State, complypacks []complytime.PolicyEntry) error` function called after `syncAllComplypacks` returns successfully. The `complypacks` parameter scopes validation to configured entries only (state may contain entries from previous configs). On error, `complyctl get` exits non-zero.
 
 ### D3: Error format
 
@@ -29,7 +29,7 @@ Add a `validateUniqueEvaluatorIDs(state *cache.State) error` function called aft
 Error: duplicate evaluator-id "opa" found in complypack entries:
   - ghcr.io/org-a/complypack-opa@v1
   - ghcr.io/org-b/complypack-opa@v2
-Remove one of the conflicting entries from complytime.yaml.
+remove one of the conflicting entries from complytime.yaml
 ```
 
 ## Risks / Trade-offs

--- a/openspec/changes/reject-duplicate-evaluator-id/design.md
+++ b/openspec/changes/reject-duplicate-evaluator-id/design.md
@@ -1,0 +1,38 @@
+## Context
+
+`complypackDigestsByEvaluator()` builds a map keyed by evaluator-id. With duplicate evaluator-ids, Go map semantics mean last-writer-wins with non-deterministic iteration order, causing silent data loss.
+
+## Goals
+
+- Detect duplicate evaluator-ids after complypack sync (when evaluator-ids are known from config.json)
+- Fail fast with a clear error before generation state is written
+- No false positives for valid configurations
+
+## Non-Goals
+
+- Validating evaluator-ids at config load time (evaluator-id is only known after fetching the artifact)
+- Supporting intentional multi-repository evaluator-id sharing (not a valid use case)
+
+## Decisions
+
+### D1: Validate after sync, not at config load
+
+Evaluator-ids are embedded in the complypack's `config.json`, which is only available after fetch. Validation must happen post-sync when `state.json` has all evaluator-ids populated.
+
+### D2: Validation location
+
+Add a `validateUniqueEvaluatorIDs(state *cache.State) error` function called after `syncAllComplypacks` returns successfully. On error, `complyctl get` exits non-zero.
+
+### D3: Error format
+
+```
+Error: duplicate evaluator-id "opa" found in complypack entries:
+  - ghcr.io/org-a/complypack-opa@v1
+  - ghcr.io/org-b/complypack-opa@v2
+Remove one of the conflicting entries from complytime.yaml.
+```
+
+## Risks / Trade-offs
+
+- **Breaking existing configs**: If someone has duplicate evaluator-ids today (unknowingly), this will surface it as an error. This is intentional — the previous behavior was silently broken.
+- **Post-sync validation**: Resources are spent fetching both complypacks before detecting the conflict. Acceptable — evaluator-id is only known after fetch.

--- a/openspec/changes/reject-duplicate-evaluator-id/proposal.md
+++ b/openspec/changes/reject-duplicate-evaluator-id/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+`complypackDigestsByEvaluator()` in `scan.go` builds a `map[string]string` (evaluator-id → digest) by iterating `state.Complypacks`. If two complypack entries in `complytime.yaml` resolve to the same evaluator-id (different repository URLs, same evaluator-id in their config), the map holds only one digest — last-writer-wins from Go map iteration, which is non-deterministic.
+
+This causes generation state to record an arbitrary digest. On subsequent scans, `IsFresh()` may trigger unnecessary regeneration or skip when it shouldn't.
+
+This is tracked in [#647](https://github.com/complytime/complyctl/issues/647).
+
+## What Changes
+
+- Add config validation in `complyctl get` (after all complypacks are fetched) that detects when multiple complypack entries resolve to the same evaluator-id.
+- When detected, emit a clear error identifying the conflicting entries and refuse to proceed with sync.
+- Alternatively: detect at `complyctl scan` time and error early.
+
+## Capabilities
+
+### New Capabilities
+- `config-evaluator-id-validation`: Detects and rejects complypack configurations where multiple entries resolve to the same evaluator-id.
+
+### Modified Capabilities
+- `get`: Validates evaluator-id uniqueness after complypack sync completes.
+
+### Removed Capabilities
+- None.
+
+## Impact
+
+- `cmd/complyctl/cli/get.go` or `internal/complytime/config.go` — validation logic
+- Config validation tests
+- No breaking changes to complytime.yaml schema (just stricter validation)
+
+## Constitution Alignment
+
+### I. Autonomous Collaboration
+
+**Assessment**: PASS
+
+Clear error message identifies the conflicting entries with their repository URLs and shared evaluator-id.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+Validation is additive. Existing valid configs are unaffected.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+Fail-fast with actionable error rather than silent non-deterministic behavior.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+Testable with mock state containing duplicate evaluator-ids.

--- a/openspec/changes/reject-duplicate-evaluator-id/specs/config-validation/spec.md
+++ b/openspec/changes/reject-duplicate-evaluator-id/specs/config-validation/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### FR-001: Detect duplicate evaluator-id across complypack entries
+
+**Given** `state.json` contains two complypack entries with different repositories
+**And** both entries have the same evaluator-id `E`
+**When** `complyctl get` completes complypack synchronization
+**Then** an error MUST be emitted identifying both repositories and the shared evaluator-id
+**And** the command MUST exit with non-zero status
+
+### FR-002: Error message is actionable
+
+**Given** a duplicate evaluator-id conflict is detected
+**When** the error is displayed
+**Then** the message MUST include both repository URLs
+**And** the message MUST include the shared evaluator-id
+**And** the message MUST suggest removing one of the conflicting entries from `complytime.yaml`
+
+### FR-003: No conflict when evaluator-ids are unique
+
+**Given** all complypack entries resolve to distinct evaluator-ids
+**When** validation runs
+**Then** no error is produced and the command proceeds normally
+
+### FR-004: Single complypack entry always passes
+
+**Given** only one complypack entry exists in the configuration
+**When** validation runs
+**Then** no error is produced

--- a/openspec/changes/reject-duplicate-evaluator-id/tasks.md
+++ b/openspec/changes/reject-duplicate-evaluator-id/tasks.md
@@ -1,19 +1,19 @@
 ## 1. Add evaluator-id uniqueness validation
 
-- [ ] 1.1 Add `validateUniqueEvaluatorIDs(state *cache.State, complypacks []complytime.PolicyEntry) error` to `cmd/complyctl/cli/get.go`
-- [ ] 1.2 Build a map of evaluator-id → []repository from `state.Complypacks`
-- [ ] 1.3 For entries with len > 1, format error listing all conflicting repositories
-- [ ] 1.4 Call `validateUniqueEvaluatorIDs` after `syncAllComplypacks` returns in `syncComplypacks`
+- [x] 1.1 Add `validateUniqueEvaluatorIDs(state *cache.State, complypacks []complytime.PolicyEntry) error` to `cmd/complyctl/cli/get.go`
+- [x] 1.2 Build a map of evaluator-id → []repository from `state.Complypacks`
+- [x] 1.3 For entries with len > 1, format error listing all conflicting repositories
+- [x] 1.4 Call `validateUniqueEvaluatorIDs` after `syncAllComplypacks` returns in `syncComplypacks`
 
 ## 2. Unit tests
 
-- [ ] 2.1 [P] `TestValidateUniqueEvaluatorIDs_NoDuplicates` — passes cleanly
-- [ ] 2.2 [P] `TestValidateUniqueEvaluatorIDs_DuplicateDetected` — returns error with both repos
-- [ ] 2.3 [P] `TestValidateUniqueEvaluatorIDs_SingleEntry` — passes
-- [ ] 2.4 [P] `TestValidateUniqueEvaluatorIDs_EmptyState` — passes
+- [x] 2.1 [P] `TestValidateUniqueEvaluatorIDs_NoDuplicates` — passes cleanly
+- [x] 2.2 [P] `TestValidateUniqueEvaluatorIDs_DuplicateDetected` — returns error with both repos
+- [x] 2.3 [P] `TestValidateUniqueEvaluatorIDs_SingleEntry` — passes
+- [x] 2.4 [P] `TestValidateUniqueEvaluatorIDs_EmptyState` — passes
 
 ## 3. Verification
 
-- [ ] 3.1 Run `go test -race ./cmd/complyctl/cli/`
-- [ ] 3.2 Run `go vet ./...`
-- [ ] 3.3 E2E: configure two complypacks with same evaluator-id, run `complyctl get`, verify error
+- [x] 3.1 Run `go test -race ./cmd/complyctl/cli/`
+- [x] 3.2 Run `go vet ./...`
+- [x] 3.3 E2E: configure two complypacks with same evaluator-id, run `complyctl get`, verify error

--- a/openspec/changes/reject-duplicate-evaluator-id/tasks.md
+++ b/openspec/changes/reject-duplicate-evaluator-id/tasks.md
@@ -1,0 +1,19 @@
+## 1. Add evaluator-id uniqueness validation
+
+- [ ] 1.1 Add `validateUniqueEvaluatorIDs(state *cache.State, complypacks []complytime.PolicyEntry) error` to `cmd/complyctl/cli/get.go`
+- [ ] 1.2 Build a map of evaluator-id → []repository from `state.Complypacks`
+- [ ] 1.3 For entries with len > 1, format error listing all conflicting repositories
+- [ ] 1.4 Call `validateUniqueEvaluatorIDs` after `syncAllComplypacks` returns in `syncComplypacks`
+
+## 2. Unit tests
+
+- [ ] 2.1 [P] `TestValidateUniqueEvaluatorIDs_NoDuplicates` — passes cleanly
+- [ ] 2.2 [P] `TestValidateUniqueEvaluatorIDs_DuplicateDetected` — returns error with both repos
+- [ ] 2.3 [P] `TestValidateUniqueEvaluatorIDs_SingleEntry` — passes
+- [ ] 2.4 [P] `TestValidateUniqueEvaluatorIDs_EmptyState` — passes
+
+## 3. Verification
+
+- [ ] 3.1 Run `go test -race ./cmd/complyctl/cli/`
+- [ ] 3.2 Run `go vet ./...`
+- [ ] 3.3 E2E: configure two complypacks with same evaluator-id, run `complyctl get`, verify error

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -16,6 +16,7 @@ Build tag: `e2e`.
 | `PolicyCache` | OCI layout structure, state.json tracking |
 | `MultiplePolicies` | Multi-policy fetch + list |
 | `ScanDefaultFormat` | No --format = EvaluationLog only |
+| `ScanTargetArg` | Positional target argument with policy inference |
 | `InvalidFormat` | `--format pdf` rejected |
 | `MissingPolicy` | Uncached policy fails with clear message |
 | `MockRegistryOCICompliance` | v2 endpoint, catalog, tags, manifests, 404s |
@@ -24,10 +25,15 @@ Build tag: `e2e`.
 | `Help` | CLI help output structure |
 | `Version` | Version command output |
 | `ListFilterByPolicyID` | `--policy-id` filter on list |
+| `GetSkipVerify` | `--skip-verify` flag accepted, no verification warnings |
+| `ListVerifiedColumn` | VERIFIED column present in list output |
+| `DuplicateComplypackEvaluatorID` | Two complypacks with same evaluator-id → non-zero exit with actionable error |
 
 ## Mock Registry
 
 The in-process mock registry (`helpers_test.go`) implements OCI Distribution Spec v2 endpoints with these seeded policies:
+
+**Policies:**
 
 | Repository | Layers | Tags |
 |:---|:---|:---|
@@ -36,6 +42,15 @@ The in-process mock registry (`helpers_test.go`) implements OCI Distribution Spe
 | `cis-benchmark` | catalog | v2.0.0, latest |
 
 The policy layer uses evaluator ID `test`, which routes to the `complyctl-provider-test` binary.
+
+**Complypacks:**
+
+| Repository | Evaluator ID | Tags |
+|:---|:---|:---|
+| `complypacks/opa-a` | `opa` | v1.0.0, latest |
+| `complypacks/opa-b` | `opa` | v1.0.0, latest |
+
+Both complypack repositories use evaluator ID `opa` (intentional duplicate for `DuplicateComplypackEvaluatorID` testing). Complypack artifacts include a config blob with `evaluator-id` and `version`, a content blob (tar.gz), and the `application/vnd.complypack.artifact.v1` artifact type.
 
 ## Manual Walkthrough
 
@@ -195,5 +210,6 @@ rm ~/.complytime/providers/complyctl-provider-test
 1. Add a `TestE2E_*` function in `e2e_test.go` using helpers from `helpers_test.go`.
 2. Use `startMockRegistry(t)` for an isolated in-process registry per test.
 3. Use `installTestPlugin(t, homeDir)` to deploy the test provider.
-4. Use `runComplytime(t, binary, workDir, env, args...)` to execute commands.
-5. Run: `make test-e2e`
+4. Use `runComplytime(t, binary, workDir, env, args...)` to execute commands (fatals on non-zero exit). For tests expecting failure, use `exec.Command` directly and assert `err != nil`.
+5. To seed complypack artifacts, use the `addComplypackArtifact` closure inside `startMockRegistry`. See `DuplicateComplypackEvaluatorID` for an example.
+6. Run: `make test-e2e`

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -672,3 +672,51 @@ func TestE2E_ListVerifiedColumn(t *testing.T) {
 	assert.Contains(t, out, "VERIFIED", "list output must include VERIFIED column header")
 	assert.Contains(t, out, testPolicyID)
 }
+
+// TestE2E_DuplicateComplypackEvaluatorID verifies that complyctl get exits
+// non-zero when two complypack entries resolve to the same evaluator-id.
+// Covers FR-001 and FR-002 from the reject-duplicate-evaluator-id spec.
+func TestE2E_DuplicateComplypackEvaluatorID(t *testing.T) {
+	binary := locateBinary(t)
+	srv := startMockRegistry(t)
+	defer srv.Close()
+
+	homeDir := t.TempDir()
+	workDir := t.TempDir()
+	env := buildEnv(homeDir)
+
+	// Configure two complypacks that both resolve to evaluator-id "opa".
+	configYAML := fmt.Sprintf(`policies:
+  - url: %s/nist-800-53-r5
+    id: nist-800-53-r5
+complypacks:
+  - url: %s/complypacks/opa-a
+  - url: %s/complypacks/opa-b
+targets:
+  - id: e2e-target
+    policies:
+      - nist-800-53-r5
+    variables:
+      env: test
+`, srv.URL, srv.URL, srv.URL)
+	configDir := filepath.Join(workDir, ".complytime")
+	require.NoError(t, os.MkdirAll(configDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "complytime.yaml"), []byte(configYAML), 0644))
+
+	cmd := exec.Command(binary, "get")
+	cmd.Dir = workDir
+	cmd.Env = env
+	output, err := cmd.CombinedOutput()
+
+	require.Error(t, err, "get must fail when two complypacks share the same evaluator-id")
+	outStr := string(output)
+	t.Log(outStr)
+	assert.Contains(t, outStr, `duplicate evaluator-id "opa"`,
+		"error must identify the conflicting evaluator-id")
+	assert.Contains(t, outStr, "complypacks/opa-a",
+		"error must list the first conflicting repository")
+	assert.Contains(t, outStr, "complypacks/opa-b",
+		"error must list the second conflicting repository")
+	assert.Contains(t, outStr, "remove one of the conflicting entries",
+		"error must suggest remediation")
+}

--- a/tests/e2e/helpers_test.go
+++ b/tests/e2e/helpers_test.go
@@ -5,6 +5,9 @@
 package e2e
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
@@ -20,6 +23,34 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// Complypack OCI media types — must match the constants in
+// vendor/github.com/complytime/complypack/pkg/complypack/mediatype.go
+// and cmd/mock-oci-registry/main.go.
+const (
+	complypackArtifactType = "application/vnd.complypack.artifact.v1"
+	complypackConfigType   = "application/vnd.complypack.config.v1+json"
+	complypackContentType  = "application/vnd.complypack.content.v1.tar+gzip"
+)
+
+// buildDummyTarGz creates a minimal in-memory tar.gz archive containing a
+// single file. Used to produce valid complypack content blobs for E2E tests.
+func buildDummyTarGz(name string, content []byte) []byte {
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	_ = tw.WriteHeader(&tar.Header{
+		Name: name,
+		Size: int64(len(content)),
+		Mode: 0o644,
+	})
+	_, _ = tw.Write(content)
+
+	_ = tw.Close()
+	_ = gw.Close()
+	return buf.Bytes()
+}
 
 // testPolicyYAML is a valid Gemara Policy with two assessment-plans bound to
 // the "test" evaluator.  Used by all mock registry seeds.
@@ -158,6 +189,56 @@ func startMockRegistry(t *testing.T) *httptest.Server {
 		repos[repoName] = repo
 	}
 
+	// addComplypackArtifact seeds a ComplyPack OCI artifact with proper
+	// config and artifactType so complypack.Unpack() succeeds after sync.
+	addComplypackArtifact := func(repoName string, tags []string, evaluatorID, version string, content []byte) {
+		repo := &ociRepo{
+			tags:  make(map[string]*ociArtifact),
+			blobs: make(map[string]*ociBlob),
+		}
+
+		configJSON, _ := json.Marshal(map[string]string{
+			"evaluator-id": evaluatorID,
+			"version":      version,
+		})
+		configDigest := ociDigest(configJSON)
+		repo.blobs[configDigest] = &ociBlob{data: configJSON, mediaType: complypackConfigType}
+
+		contentDigest := ociDigest(content)
+		repo.blobs[contentDigest] = &ociBlob{data: content, mediaType: complypackContentType}
+
+		manifest := map[string]interface{}{
+			"schemaVersion": 2,
+			"mediaType":     "application/vnd.oci.image.manifest.v1+json",
+			"artifactType":  complypackArtifactType,
+			"annotations": map[string]string{
+				"complypack.evaluator-id": evaluatorID,
+			},
+			"config": ociDescriptor{
+				MediaType: complypackConfigType,
+				Digest:    configDigest,
+				Size:      int64(len(configJSON)),
+			},
+			"layers": []ociDescriptor{
+				{
+					MediaType: complypackContentType,
+					Digest:    contentDigest,
+					Size:      int64(len(content)),
+				},
+			},
+		}
+		manifestData, _ := json.Marshal(manifest)
+		art := &ociArtifact{
+			manifestBytes:  manifestData,
+			manifestDigest: ociDigest(manifestData),
+		}
+
+		for _, tag := range tags {
+			repo.tags[tag] = art
+		}
+		repos[repoName] = repo
+	}
+
 	// Seed: nist-800-53-r5 with catalog + policy layers
 	addArtifact("nist-800-53-r5", []string{"v1.0.0", "latest"}, []struct {
 		mt   string
@@ -218,6 +299,13 @@ controls:
 `),
 		},
 	})
+
+	// Seed: two complypacks with the SAME evaluator-id ("opa") for
+	// duplicate evaluator-id validation E2E testing.
+	addComplypackArtifact("complypacks/opa-a", []string{"v1.0.0", "latest"},
+		"opa", "1.0.0", buildDummyTarGz("policy_a.rego", []byte("package test_a")))
+	addComplypackArtifact("complypacks/opa-b", []string{"v1.0.0", "latest"},
+		"opa", "1.0.0", buildDummyTarGz("policy_b.rego", []byte("package test_b")))
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v2/", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Two complypack cache reliability fixes:

- **#647**: `complyctl get` now validates that no two complypack entries resolve to the same evaluator-id after sync. Previously, duplicate evaluator-ids caused non-deterministic digest selection in `complypackDigestsByEvaluator()`, leading to unnecessary regeneration or stale artifacts during scan.

- **#649**: The incremental skip guard in `SyncComplypack` now verifies the cache directory exists on disk alongside the digest comparison, mirroring the policy sync pattern (`PolicyStoreExists`). Previously, a deleted cache directory with a matching `state.json` digest caused sync to be permanently skipped.

A separate `CheckComplypackCacheIntegrity` doctor check was evaluated and removed — the existing `CheckComplypacks` already detects missing caches via `LookupByEvaluatorID`. A `--force` flag was evaluated and rejected in favor of the root-cause fix.

## Changes

| File | Change |
|------|--------|
| `cmd/complyctl/cli/get.go` | `validateUniqueEvaluatorIDs()` called post-sync |
| `cmd/complyctl/cli/cli_test.go` | 4 unit tests for validation |
| `internal/cache/complypack_sync.go` | `cacheExistsForState()` + skip guard update |
| `internal/cache/complypack_sync_test.go` | Cache-missing re-fetch regression test |
| `tests/e2e/e2e_test.go` | E2E test: duplicate evaluator-id `complyctl get` exits non-zero |
| `tests/e2e/helpers_test.go` | Complypack seeding infrastructure for E2E mock registry |
| `tests/e2e/README.md` | Updated test table, mock registry seeds, adding-new-tests guidance |
| `CHANGELOG.md` | Entries for both fixes |
| `openspec/changes/reject-duplicate-evaluator-id/` | Design + tasks updated (3.3 now checked) |
| `openspec/changes/doctor-complypack-cache-check/` | Design, proposal, spec, tasks updated |

## Testing

- `go vet ./...` — pass
- `make lint` — 0 issues
- `make test-unit` — pass
- `make test-e2e` — all 15 tests pass (including new `DuplicateComplypackEvaluatorID`)
- Devcontainer full workflow: get → list → doctor → providers → generate → scan — all pass
- E2E verified: delete cache → doctor warns → get re-fetches → doctor passes
- E2E verified: two complypacks with same evaluator-id → `complyctl get` exits non-zero with actionable error

### Rebase notes

Rebased onto `upstream/main` (556c12e1). Resolved conflict in `cmd/complyctl/cli/get.go` where upstream added `baseDir`/`syncOpts` parameters (#551, #641, #670) to the complypack sync chain while this branch modified the same `syncComplypacks` method. Resolution: kept upstream signatures, added `validateUniqueEvaluatorIDs()` call after `syncAllComplypacks()`.

## Design Decisions

- **Validate after sync, not at config load** (D1): evaluator-ids are only known after fetching the artifact
- **No `--force` flag** (D1 of #649): bypassing digest comparison is a security risk; root-cause fix is preferred
- **No separate doctor check** (D2 of #649): `CheckComplypacks` already covers missing cache detection

Fixes #647
Fixes #649