### PR TITLE
fix: suppress spinner escape sequences on non-TTY output

### DIFF
--- a/internal/terminal/spinner.go
+++ b/internal/terminal/spinner.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/term"
 )
 
 type stopMsg struct{}
@@ -36,17 +37,41 @@ func (m spinnerModel) View() string {
 }
 
 // Spinner renders an animated braille spinner using charmbracelet/bubbles.
+// When the output writer is not a terminal, the spinner falls back to
+// plain-text progress lines instead of escape sequences.
 // Start() launches the animation; Stop() halts it and cleans up.
 type Spinner struct {
-	program *tea.Program
+	program *tea.Program // non-nil only when writing to a TTY
+	writer  io.Writer    // non-nil only when writing to a non-TTY
+	message string       // progress message for plain-text fallback
 }
 
+// NewSpinner creates a spinner that writes to stderr.
 func NewSpinner(message string) *Spinner {
 	return NewSpinnerWriter(message, os.Stderr)
 }
 
+// isWriterTTY reports whether w is backed by a terminal file descriptor.
+func isWriterTTY(w io.Writer) bool {
+	type fder interface{ Fd() uintptr }
+	if f, ok := w.(fder); ok {
+		return term.IsTerminal(f.Fd())
+	}
+	return false
+}
+
 // NewSpinnerWriter creates a spinner that writes to w instead of stderr.
+// When w is a terminal, an animated braille spinner is used. Otherwise,
+// Start prints a plain-text progress line and Stop prints "done",
+// consistent with the progress output of complyctl get.
+// When w is nil, the spinner is fully silent (no output).
 func NewSpinnerWriter(message string, w io.Writer) *Spinner {
+	if w == nil {
+		return &Spinner{}
+	}
+	if !isWriterTTY(w) {
+		return &Spinner{writer: w, message: message}
+	}
 	s := spinner.New()
 	s.Spinner = spinner.MiniDot
 	m := spinnerModel{spinner: s, message: message}
@@ -58,13 +83,30 @@ func NewSpinnerWriter(message string, w io.Writer) *Spinner {
 	return &Spinner{program: p}
 }
 
+// Start begins the spinner. On a TTY it launches the animated braille
+// spinner, on a non-TTY it prints the progress message, and with a nil
+// writer it is a silent no-op.
 func (s *Spinner) Start() {
-	go func() {
-		_, _ = s.program.Run()
-	}()
+	if s.program != nil {
+		go func() {
+			_, _ = s.program.Run()
+		}()
+		return
+	}
+	if s.writer != nil {
+		fmt.Fprintf(s.writer, "%s\n", s.message)
+	}
 }
 
+// Stop halts the spinner. On a TTY it stops the animated program, on a
+// non-TTY it prints "done", and with a nil writer it is a silent no-op.
 func (s *Spinner) Stop() {
-	s.program.Send(stopMsg{})
-	s.program.Wait()
+	if s.program != nil {
+		s.program.Send(stopMsg{})
+		s.program.Wait()
+		return
+	}
+	if s.writer != nil {
+		fmt.Fprintln(s.writer, "done")
+	}
 }

--- a/internal/terminal/spinner_test.go
+++ b/internal/terminal/spinner_test.go
@@ -3,6 +3,7 @@
 package terminal
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -47,8 +48,64 @@ func TestSpinnerModelTickAdvancesFrame(t *testing.T) {
 	assert.Contains(t, view2, "working")
 }
 
-func TestNewSpinnerWriter(t *testing.T) {
+func TestNewSpinnerWriter_NilWriter(t *testing.T) {
 	s := NewSpinnerWriter("test msg", nil)
 	require.NotNil(t, s)
-	require.NotNil(t, s.program)
+	assert.Nil(t, s.program, "nil writer should produce a silent spinner")
+	assert.Nil(t, s.writer, "nil writer should not set fallback writer")
+
+	// Start and Stop must be safe no-ops.
+	s.Start()
+	s.Stop()
+}
+
+func TestNewSpinnerWriter_NonTTY(t *testing.T) {
+	var buf bytes.Buffer
+	s := NewSpinnerWriter("test msg", &buf)
+	require.NotNil(t, s)
+	assert.Nil(t, s.program,
+		"non-TTY writer should not create a bubbletea program")
+	assert.NotNil(t, s.writer,
+		"non-TTY writer should set fallback writer")
+}
+
+func TestSpinner_NonTTY_PlainOutput(t *testing.T) {
+	var buf bytes.Buffer
+	s := NewSpinnerWriter("Generating policy artifacts...", &buf)
+
+	s.Start()
+	output := buf.String()
+	assert.Equal(t, "Generating policy artifacts...\n", output,
+		"Start should print message followed by newline")
+
+	s.Stop()
+	output = buf.String()
+	assert.Equal(t,
+		"Generating policy artifacts...\ndone\n", output,
+		"Stop should append done followed by newline")
+}
+
+func TestSpinner_NonTTY_NoEscapeSequences(t *testing.T) {
+	var buf bytes.Buffer
+	s := NewSpinnerWriter("Scanning targets...", &buf)
+
+	s.Start()
+	s.Stop()
+
+	output := buf.String()
+	assert.NotContains(t, output, "\x1b",
+		"non-TTY output must not contain ANSI escape sequences")
+	assert.NotContains(t, output, "\x1b[",
+		"non-TTY output must not contain CSI escape sequences")
+}
+
+func TestIsWriterTTY_Buffer(t *testing.T) {
+	var buf bytes.Buffer
+	assert.False(t, isWriterTTY(&buf),
+		"bytes.Buffer should not be detected as a TTY")
+}
+
+func TestIsWriterTTY_Nil(t *testing.T) {
+	assert.False(t, isWriterTTY(nil),
+		"nil writer should not be detected as a TTY")
 }


### PR DESCRIPTION
## Summary

The progress spinner (used by `generate` and `scan`) writes animated braille frames and raw ANSI escape sequences (cursor hide/show, erase-line, mouse-tracking codes) to stderr unconditionally. When stderr is redirected to a file or captured in CI logs, this produces garbled output full of control codes.

This fix adds TTY detection to the spinner. When stderr is a terminal, the animated bubbletea spinner works as before. When it is not (piped, redirected, CI), the spinner falls back to plain-text progress lines: the message on start, `"done"` on stop — consistent with `complyctl get`'s existing progress output pattern. A nil writer produces a fully silent no-op spinner.

**Files changed:**
- `internal/terminal/spinner.go` — TTY detection via `isWriterTTY()`, three-mode `Spinner` (animated / plain-text / silent)
- `internal/terminal/spinner_test.go` — 6 new tests covering non-TTY output, escape sequence absence, nil writer safety

Zero call-site changes — `scan.go` and `generate.go` use `terminal.NewSpinner()` unchanged.

## Related Issues

- Closes #613

## Review Hints

- The core logic change is in `NewSpinnerWriter()` (`spinner.go:67-83`): a nil check, then an `isWriterTTY()` check, with the existing bubbletea path as the TTY branch.

- `isWriterTTY()` uses the same `interface{ Fd() uintptr }` type assertion pattern that bubbletea itself uses in `tty_unix.go:25` for output TTY detection.

- `Start()` and `Stop()` branch on `s.program != nil` (TTY) vs `s.writer != nil` (non-TTY) vs both nil (silent). The nil-guard ordering means the zero-value `Spinner{}` is safe.

- The existing `IsTTY()` in `table.go` is left untouched — it checks stdout, not stderr, and was retained for future use per spec 001. The spinner needs its own writer-fd-based check.

- To verify:
  ```bash
  # Run all spinner tests (includes 6 new non-TTY tests)
  go test -mod=vendor -run "TestSpinner_NonTTY|TestIsWriterTTY|TestNewSpinnerWriter" -v ./internal/terminal/

  # Full unit test suite
  make test-unit

  # Full end-to-end verification (requires devcontainer or configured workspace)
  # Non-TTY: should show plain text, no escape codes
  ./bin/complyctl scan 2>/tmp/stderr.log && cat -v /tmp/stderr.log
  # TTY: should show animated spinner as before
  ./bin/complyctl scan