### PR TITLE
fix: use canonical .complytime/complytime.yaml location in test scripts

### DIFF
--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -92,7 +92,7 @@ echo ">>> Setting up test workspace..."
 mkdir -p "${HOME}/test-workspace/.complytime/ampel/granular-policies"
 
 cp tests/cross-repo/testdata/complytime.yaml \
-    "${HOME}/test-workspace/"
+    "${HOME}/test-workspace/.complytime/"
 
 cp tests/cross-repo/testdata/granular-policies/block-force-push.json \
     "${HOME}/test-workspace/.complytime/ampel/granular-policies/"
@@ -146,7 +146,7 @@ echo "    Test workspace ready at ~/test-workspace/"
 BUNDLES_DIR="${COMPLYCTL_BUNDLES_DIR:-/bundles}"
 if [[ -d "${BUNDLES_DIR}" ]]; then
     echo ">>> [optional] Registering mounted policies from ${BUNDLES_DIR}..."
-    CONFIG_FILE="${HOME}/test-workspace/complytime.yaml"
+    CONFIG_FILE="${HOME}/test-workspace/.complytime/complytime.yaml"
 
     BUNDLE_COUNT=0
     for bundle_dir in "${BUNDLES_DIR}"/*/; do

--- a/.github/workflows/ci_compliance.yml
+++ b/.github/workflows/ci_compliance.yml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       complytime_config_path:
-        description: 'Relative path of the complytime.yaml file in this repository'
+        description: 'Relative path of the complytime configuration file in this repository'
         required: false
         type: string
-        default: 'complytime.yaml'
+        default: '.complytime/complytime.yaml'
       policy_id:
         description: 'Policy ID to use for complyctl generate and scan commands'
         required: false
@@ -26,7 +26,7 @@ jobs:
       contents: read
     uses: complytime/org-infra/.github/workflows/reusable_compliance.yml@638b2037394ca0f0b860a135c7c27dce75fd3c03 # v0.5.0
     with:
-      complytime_config_path: ${{ inputs.complytime_config_path || 'complytime.yaml' }}
+      complytime_config_path: ${{ inputs.complytime_config_path || '.complytime/complytime.yaml' }}
       policy_id: ${{ inputs.policy_id || 'ampel-bp' }}
     secrets:
       source_token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/TESTING_ENVIRONMENT.md
+++ b/docs/TESTING_ENVIRONMENT.md
@@ -186,9 +186,9 @@ export GITHUB_TOKEN=<your-token>
 
 - A mock OCI registry running on `localhost:8765`, loaded with
   Gemara test catalogs and policies.
-- A test workspace at `~/test-workspace/` with a
-  `complytime.yaml` pre-configured to point at the mock
-  registry.
+- A test workspace at `~/test-workspace/` with
+  `.complytime/complytime.yaml` pre-configured to point at
+  the mock registry.
 
 ### System Packages
 
@@ -319,7 +319,7 @@ The mock OCI registry's `seedFromDirectory()` reads Gemara
 catalog and policy YAML files from the mounted bundles
 directory and serves them as OCI artifacts, exactly like
 the embedded test content. The post-create script adds
-policy entries to `complytime.yaml` pointing at the mock
+policy entries to `.complytime/complytime.yaml` pointing at the mock
 registry (`http://localhost:8765/policies/{name}`), so `complyctl
 get` populates the cache through normal code paths.
 

--- a/tests/cross-repo/cross_repo_integration_test.sh
+++ b/tests/cross-repo/cross_repo_integration_test.sh
@@ -185,10 +185,10 @@ echo "  WORK=${WORK_DIR}"
 # Generate workspace config with the correct registry port.
 # The static testdata/complytime.yaml uses port 8765 as default; sed replaces it
 # so the GEMARA_SERVICE_PORT override works end-to-end.
-sed "s|http://localhost:8765|${REGISTRY_URL}|" \
-    "${TESTDATA_DIR}/complytime.yaml" > "${WORK_DIR}/complytime.yaml"
-
 mkdir -p "${WORK_DIR}/.complytime/ampel/granular-policies"
+
+sed "s|http://localhost:8765|${REGISTRY_URL}|" \
+    "${TESTDATA_DIR}/complytime.yaml" > "${WORK_DIR}/.complytime/complytime.yaml"
 cp "${TESTDATA_DIR}/granular-policies/block-force-push.json" \
     "${WORK_DIR}/.complytime/ampel/granular-policies/"
 

--- a/tests/integration_test.sh
+++ b/tests/integration_test.sh
@@ -142,7 +142,8 @@ if ! curl -sf "${REGISTRY_URL}/v2/" >/dev/null 2>&1; then
 fi
 echo "  Mock registry ready (PID ${REGISTRY_PID})"
 
-cat > "${WORK_DIR}/complytime.yaml" <<EOF
+mkdir -p "${WORK_DIR}/.complytime"
+cat > "${WORK_DIR}/.complytime/complytime.yaml" <<EOF
 policies:
   - url: ${REGISTRY_URL}/${POLICY_ID}
     id: ${POLICY_ID}


### PR DESCRIPTION
## Summary

Fixes #684

Updates devcontainer, cross-repo integration test, integration test, and testing documentation to place `complytime.yaml` at the canonical `.complytime/complytime.yaml` location instead of the legacy workspace root.

## Changes

### Scripts
- **`.devcontainer/scripts/post-create.sh`**: Config copy destination and `CONFIG_FILE` variable updated to `.complytime/complytime.yaml`
- **`tests/cross-repo/cross_repo_integration_test.sh`**: `mkdir -p` reordered before `sed` output; config written to `.complytime/complytime.yaml`
- **`tests/integration_test.sh`**: Main workspace config moved to `.complytime/complytime.yaml` (legacy-specific tests at lines 351/384 intentionally preserved)

### Documentation
- **`docs/TESTING_ENVIRONMENT.md`**: Two stale config path references updated

## Impact

- Eliminates deprecation warnings in devcontainer sessions and CI test output
- Test infrastructure now follows the project's own workspace-configuration conventions
- No functional behavior changes (legacy fallback still works for tests that intentionally exercise it)

## Not in scope

- `complytime-providers` devcontainer has the same legacy location bug — should be tracked as a separate issue in that repository
- `tests/integration_test.sh` legacy-specific tests (`test_legacy_config_warning`, `test_new_location_preferred`) intentionally use the legacy location to validate backward compatibility