### PR TITLE
fix: exclude CRLF vendor files from line-ending normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,8 @@
 # Use LF line endings
 * text eol=lf
 # Tells Git to treat the file as a binary file, which prevents any line ending conversions.
+vendor/github.com/cyberphone/json-canonicalization/LICENSE -text
+vendor/github.com/digitorus/timestamp/README.md -text
 vendor/github.com/go-logfmt/logfmt/README.md -text
+vendor/github.com/theupdateframework/go-tuf/v2/LICENSE -text
 vendor/oras.land/oras-go/v2/MIGRATION_GUIDE.md -text


### PR DESCRIPTION
## Problem

All Packit checks (rpm-build and testing-farm across all 5 targets) are
failing with **SRPM build failed** on every PR, including #669.

The [SRPM build log](https://download.copr.fedorainfracloud.org/results/packit/complytime-complyctl-669/srpm-builds/10686037/builder-live.log)
shows the root cause:

```
error: Your local changes to the following files would be overwritten by checkout:
    vendor/github.com/cyberphone/json-canonicalization/LICENSE
    vendor/github.com/digitorus/timestamp/README.md
    vendor/github.com/theupdateframework/go-tuf/v2/LICENSE
Please commit your changes or stash them before you switch branches.
Aborting
```

## Root Cause

The repository `.gitattributes` enforces LF line endings globally
(`* text eol=lf`). Three vendor files introduced by the sigstore
dependencies (#670) have **CRLF line endings** from their upstream
sources.

When Packit clones the repo and checks out `main`, git's eol
normalization marks these files as modified in the working tree. When
Packit then tries to `git checkout` the PR branch, git refuses because
the "local changes" would be overwritten.

This is the same issue previously solved for `go-logfmt/README.md` and
`oras-go/MIGRATION_GUIDE.md`, which already have `-text` entries in
`.gitattributes`.

## Fix

Add `-text` entries for the three affected vendor files, telling git to
skip line-ending conversion entirely:

- `vendor/github.com/cyberphone/json-canonicalization/LICENSE`
- `vendor/github.com/digitorus/timestamp/README.md`
- `vendor/github.com/theupdateframework/go-tuf/v2/LICENSE`

## Verification

After the `.gitattributes` change, `git status` no longer shows these
files as modified, confirming the fix resolves the checkout conflict.

Refs: #669

Assisted-by: OpenCode (claude-opus-4-6)
Signed-off-by: Marcus Burghardt <maburgha@redhat.com>