### PR TITLE
fix: adds required fields to gemara artifacts

### DIFF
--- a/tests/acceptance/testdata/catalog.yaml
+++ b/tests/acceptance/testdata/catalog.yaml
@@ -8,7 +8,7 @@ controls:
       - id: block-force-push
         text: Force pushes to protected branches must be blocked
         applicability:
-          - GitHub repositories
+          - github-repos
         state: Active
     state: Active
 groups:
@@ -18,9 +18,13 @@ groups:
 metadata:
   id: acceptance-test-controls
   type: ControlCatalog
-  gemara-version: 1.0.0
+  gemara-version: 1.3.0
   description: Minimal catalog for container-based acceptance testing
   author:
     id: complytime
     name: ComplyTime
     type: Software Assisted
+  applicability-groups:
+    - id: github-repos
+      title: GitHub Repositories
+      description: Applicable to GitHub-hosted repositories

--- a/tests/acceptance/testdata/policy.yaml
+++ b/tests/acceptance/testdata/policy.yaml
@@ -1,6 +1,8 @@
 title: Acceptance Test Policy
 metadata:
   id: acceptance-test-policy
+  type: Policy
+  gemara-version: 1.3.0
   description: Policy for container-based acceptance testing using the test provider
   author:
     id: complytime
@@ -25,7 +27,9 @@ imports:
     - reference-id: acceptance-test-controls
 adherence:
   evaluation-methods:
-    - type: Behavioral
+    - id: behavioral-eval
+      type: Behavioral
+      mode: Automated
       description: Automated acceptance test evaluation
       executor:
         id: test
@@ -36,7 +40,9 @@ adherence:
       requirement-id: block-force-push
       frequency: on-demand
       evaluation-methods:
-        - type: Behavioral
+        - id: behavioral-eval-plan
+          type: Behavioral
+          mode: Automated
           executor:
             id: test
             name: test-evaluator


### PR DESCRIPTION
## Summary

This PR was created to update the gemara artifacts introduced in PR #669. The `ControlCatalog` and `Policy` were missing the `type` fields and required `applicability-groups`. Once this PR is merged the tests and repo-scoped gemara schema validation should be revisited.

## Related Issues

- Supports #669 

## Review Hints

```shell
# Validate the ControlCatalog
cue vet -c -d '#ControlCatalog' github.com/gemaraproj/gemara@v1.3.0 tests/acceptance/testdata/catalog.yaml

# Validate the Policy
cue vet -c -d '#Policy' github.com/gemaraproj/gemara@v1.0.0 tests/acceptance/testdata/policy.yaml
```