### PR TITLE
fix: add go.mod compat patch for Fedora 43 in RPM spec

### DIFF
--- a/complyctl.spec
+++ b/complyctl.spec
@@ -28,6 +28,15 @@ Providers are distributed separately via the complytime-providers package.
 %prep
 %goprep -k
 
+# Fedora 43 ships Go 1.25 but go.mod may require Go 1.26+ due to
+# transitive dependency requirements. Lower the directive to the
+# system Go major.minor so rpmbuild succeeds with GOTOOLCHAIN=local.
+# Fedora 43 EOL: 2026-12-09 — remove this block after EOL.
+# Reference: https://packages.fedoraproject.org/pkgs/golang/golang/
+%if 0%{?fedora} == 43
+sed -i 's/^go [0-9].*/go 1.25/' go.mod
+%endif
+
 %build
 BUILD_DATE_GO=$(date -u +'%%Y-%%m-%%dT%%H:%%M:%%SZ')
 
@@ -71,6 +80,9 @@ go test -mod=vendor -race -v ./...
 %dir %{_libexecdir}/%{app_dir}/providers
 
 %changelog
+* Mon Jul 07 2026 Marcus Burghardt <maburgha@redhat.com> - 0.0.8-2
+- Add go.mod compatibility patch for Fedora 43 (Go 1.25)
+
 * Fri Apr 24 2026 Marcus Burghardt <maburgha@redhat.com> - 0.0.8-1
 - Simplify spec for core-only delivery after provider split
 - Remove openscap-provider sub-package (moved to complytime-providers)


### PR DESCRIPTION
## Problem

Packit RPM builds fail on Fedora 43 with:

```
go: go.mod requires go >= 1.26 (running go 1.25.11; GOTOOLCHAIN=local)
```

This happens when dependencies (e.g. `complypack v0.0.6` in #690) declare `go 1.26` in their `go.mod`. Since Go 1.21+, the `go` directive acts as a minimum version requirement across the entire dependency graph, so complyctl's `go.mod` is transitively raised to `go 1.26`. Fedora 43 ships Go 1.25.11 and RPM builds use `GOTOOLCHAIN=local`, so the build refuses to proceed.

## Investigation

Go versions across all Packit targets:

| Target | Go Version | Status |
|--------|-----------|--------|
| Fedora Rawhide | 1.26.4 | OK |
| Fedora 44 | 1.26.4 | OK |
| **Fedora 43** | **1.25.11** | **Needs patch** |
| CentOS Stream 10 | 1.26.4 | OK |
| CentOS Stream 9 | 1.26.4 | OK |

Only Fedora 43 is affected. Fedora 43 EOL is **2026-12-09**.

## Fix

Add a conditional `sed` in `%prep` to lower the `go` directive for Fedora 43 builds:

```spec
%if 0%{?fedora} == 43
sed -i 's/^go [0-9].*/go 1.25/' go.mod
%endif
```

The pattern `s/^go [0-9].*/go 1.25/` matches any `go X.Y.Z` line, so it handles future go.mod bumps (1.27, 1.28, etc.) without needing spec updates. Using `go 1.25` (major.minor only) is sufficient since Go 1.25.11 on the system satisfies it.

## Lifecycle

This block should be removed after Fedora 43 reaches EOL on 2026-12-09, along with the `f43` entries in `.packit.yaml`.

## Maintenance pattern

This same approach can be reused when future Fedora releases lag behind the Go version required by dependencies:

1. Check Go versions: https://packages.fedoraproject.org/pkgs/golang/golang/
2. Add a `%if 0%{?fedora} == NN` block with the appropriate Go major.minor
3. Remove the block after the affected Fedora release reaches EOL

Refs: #690

Assisted-by: OpenCode (claude-opus-4-6)