### PR TITLE
fix: correct day-of-week in RPM spec changelog entry

### DIFF
--- a/complyctl.spec
+++ b/complyctl.spec
@@ -81,7 +81,7 @@ go test -mod=vendor -race -v ./...
 %dir %{_libexecdir}/%{app_dir}/providers
 
 %changelog
-* Mon Jul 07 2026 Marcus Burghardt <maburgha@redhat.com> - 0.0.8-2
+* Tue Jul 07 2026 Marcus Burghardt <maburgha@redhat.com> - 0.0.8-2
 - Add go.mod compatibility patch for Fedora 43 (Go 1.25)
 
 * Fri Apr 24 2026 Marcus Burghardt <maburgha@redhat.com> - 0.0.8-1


### PR DESCRIPTION
## Summary

The `%changelog` entry for `0.0.8-2` had `Mon Jul 07 2026` but July 7, 2026 is a Tuesday. `rpmbuild` rejects bogus dates with:

```
bogus date in %changelog: Mon Jul 07 2026 Marcus Burghardt <maburgha@redhat.com> - 0.0.8-2
```

This caused all Packit `rpm-build` and `testing-farm` checks to fail across all target distros (Fedora 43, 44, Rawhide, CentOS Stream 9, 10).

## Changes

- `complyctl.spec`: Change `Mon` to `Tue` in the `0.0.8-2` changelog entry

## Verification

```bash
date -d '2026-07-07' +%a  # outputs: Tue
```