### PR TITLE
fix: add missing required Gemara schema fields to policy fixtures

### DIFF
--- a/cmd/mock-oci-registry/testdata/ampel-branch-protection-policy.yaml
+++ b/cmd/mock-oci-registry/testdata/ampel-branch-protection-policy.yaml
@@ -1,6 +1,8 @@
 title: AMPEL Branch Protection Policy
 metadata:
     id: ampel-branch-protection-policy
+    type: Policy
+    gemara-version: 1.0.0
     description: AMPEL policy for integration testing with complypack support
     author:
         id: complytime
@@ -27,7 +29,9 @@ imports:
         - reference-id: ampel-branch-protection
 adherence:
     evaluation-methods:
-        - type: Behavioral
+        - id: ampel-eval
+          type: Behavioral
+          mode: Automated
           description: Ampel automated branch protection evaluation
           executor:
               id: ampel
@@ -38,6 +42,8 @@ adherence:
           requirement-id: block-force-push
           frequency: on-demand
           evaluation-methods:
-              - type: Behavioral
+              - id: ampel-eval
+                type: Behavioral
+                mode: Automated
                 executor:
                     id: ampel

--- a/cmd/mock-oci-registry/testdata/test-branch-protection-policy.yaml
+++ b/cmd/mock-oci-registry/testdata/test-branch-protection-policy.yaml
@@ -1,6 +1,8 @@
 title: Test Branch Protection Policy
 metadata:
     id: test-branch-protection-policy
+    type: Policy
+    gemara-version: 1.0.0
     description: Minimal policy for cross-repo integration testing using the Ampel provider
     author:
         id: complytime
@@ -27,7 +29,9 @@ imports:
         - reference-id: test-branch-protection
 adherence:
     evaluation-methods:
-        - type: Behavioral
+        - id: ampel-eval
+          type: Behavioral
+          mode: Automated
           description: Ampel automated branch protection evaluation
           executor:
               id: ampel
@@ -38,6 +42,8 @@ adherence:
           requirement-id: block-force-push
           frequency: on-demand
           evaluation-methods:
-              - type: Behavioral
+              - id: ampel-eval
+                type: Behavioral
+                mode: Automated
                 executor:
                     id: ampel

--- a/cmd/mock-oci-registry/testdata/test-opa-policy.yaml
+++ b/cmd/mock-oci-registry/testdata/test-opa-policy.yaml
@@ -1,6 +1,8 @@
 title: Test OPA Container Security Policy
 metadata:
     id: test-opa-container-security-policy
+    type: Policy
+    gemara-version: 1.0.0
     description: Minimal policy for OPA provider integration testing in the devcontainer
     author:
         id: complytime
@@ -27,7 +29,9 @@ imports:
         - reference-id: test-opa-controls
 adherence:
     evaluation-methods:
-        - type: Behavioral
+        - id: opa-eval
+          type: Behavioral
+          mode: Automated
           description: OPA automated container security evaluation
           executor:
               id: opa
@@ -38,13 +42,17 @@ adherence:
           requirement-id: check-run-as-nonroot
           frequency: on-demand
           evaluation-methods:
-              - type: Behavioral
+              - id: opa-eval
+                type: Behavioral
+                mode: Automated
                 executor:
                     id: opa
         - id: check-resource-limits
           requirement-id: check-resource-limits
           frequency: on-demand
           evaluation-methods:
-              - type: Behavioral
+              - id: opa-eval
+                type: Behavioral
+                mode: Automated
                 executor:
                     id: opa

--- a/internal/policy/resolver_test.go
+++ b/internal/policy/resolver_test.go
@@ -115,6 +115,8 @@ guidelines: []
 title: Test Policy
 metadata:
   id: pol-1
+  type: Policy
+  gemara-version: 1.0.0
   version: "1.0"
 contacts:
   responsible:
@@ -134,7 +136,9 @@ adherence:
       requirement-id: req-1
       frequency: daily
       evaluation-methods:
-        - type: Behavioral
+        - id: openscap-eval
+          type: Behavioral
+          mode: Automated
           executor:
             id: openscap
 `)
@@ -164,6 +168,8 @@ func TestResolvePolicyGraph_MissingOptionalLayers(t *testing.T) {
 title: Minimal Policy
 metadata:
   id: pol-min
+  type: Policy
+  gemara-version: 1.0.0
   version: "1.0"
 contacts:
   responsible:
@@ -183,7 +189,9 @@ adherence:
       requirement-id: req-min
       frequency: weekly
       evaluation-methods:
-        - type: Behavioral
+        - id: kube-eval-method
+          type: Behavioral
+          mode: Automated
           executor:
             id: kube-eval
 `)
@@ -210,6 +218,8 @@ func TestParsePolicyLayer_MissingAssessmentPlans(t *testing.T) {
 title: Empty Adherence
 metadata:
   id: pol-empty
+  type: Policy
+  gemara-version: 1.0.0
   version: "1.0"
 contacts:
   responsible:
@@ -235,6 +245,8 @@ func TestParsePolicyLayer_SingleAssessmentPlan(t *testing.T) {
 title: Single Plan
 metadata:
   id: pol-single
+  type: Policy
+  gemara-version: 1.0.0
   version: "1.0"
 contacts:
   responsible:
@@ -254,7 +266,9 @@ adherence:
       requirement-id: req-1
       frequency: daily
       evaluation-methods:
-        - type: Behavioral
+        - id: openscap-eval
+          type: Behavioral
+          mode: Automated
           executor:
             id: openscap
 `)
@@ -272,6 +286,8 @@ func TestParsePolicyLayer_MultiEvaluator(t *testing.T) {
 title: Multi Evaluator
 metadata:
   id: pol-multi
+  type: Policy
+  gemara-version: 1.0.0
   version: "1.0"
 contacts:
   responsible:
@@ -291,14 +307,18 @@ adherence:
       requirement-id: req-1
       frequency: daily
       evaluation-methods:
-        - type: Behavioral
+        - id: openscap-eval
+          type: Behavioral
+          mode: Automated
           executor:
             id: openscap
     - id: ap-2
       requirement-id: req-2
       frequency: weekly
       evaluation-methods:
-        - type: Behavioral
+        - id: kube-eval-method
+          type: Behavioral
+          mode: Automated
           executor:
             id: kube-eval
 `)
@@ -699,6 +719,8 @@ func validPolicyYAML() []byte {
 title: Test Policy
 metadata:
   id: pol-1
+  type: Policy
+  gemara-version: 1.0.0
   version: "1.0"
 contacts:
   responsible:
@@ -718,7 +740,9 @@ adherence:
       requirement-id: req-1
       frequency: daily
       evaluation-methods:
-        - type: Behavioral
+        - id: openscap-eval
+          type: Behavioral
+          mode: Automated
           executor:
             id: openscap
 `)


### PR DESCRIPTION
## Summary

Add required fields per the upstream [Gemara CUE schema](https://github.com/gemaraproj/gemara) to mock-oci-registry policy YAML fixtures and inline test YAML in `resolver_test.go`. These files would fail `cue vet -c -d '#Policy'` validation. They work at runtime because Go's YAML unmarshalling silently uses zero values for missing fields.

This is the same class of fix applied in PR #695 for acceptance test data.

## Changes

### Policy YAML fixtures (`cmd/mock-oci-registry/testdata/`)

Three files updated:
- `test-branch-protection-policy.yaml`
- `ampel-branch-protection-policy.yaml`
- `test-opa-policy.yaml`

**Metadata blocks** gained:
- `type: Policy` — required by `#Metadata.type`
- `gemara-version: 1.0.0` — required by `#Metadata."gemara-version"` (consistent with sibling catalogs and governance artifacts)

**Evaluation-methods entries** (both top-level and within `assessment-plans`) gained:
- `id: <evaluator>-eval` — required by `#AcceptedMethod.id`
- `mode: Automated` — required by `#AcceptedMethod.mode`

### Inline test YAML (`internal/policy/resolver_test.go`)

Six inline YAML policy fixtures updated with the same fields:
- `TestResolvePolicyGraph_AllThreeLayers` (line 114)
- `TestResolvePolicyGraph_MissingOptionalLayers` (line 163)
- `TestParsePolicyLayer_MissingAssessmentPlans` (line 209, metadata only)
- `TestParsePolicyLayer_SingleAssessmentPlan` (line 234)
- `TestParsePolicyLayer_MultiEvaluator` (line 271)
- `validPolicyYAML()` shared helper (line 698, used by 7+ tests)

## Reference

`rh-workstation-audit-policy.yaml` is already fully compliant and served as the target state model.

## Verification

```bash
# All unit tests pass
make test-unit

# Validate each policy file against the Gemara CUE schema
cue vet -c -d '#Policy' github.com/gemaraproj/gemara@v1.3.0 \
  cmd/mock-oci-registry/testdata/test-branch-protection-policy.yaml

cue vet -c -d '#Policy' github.com/gemaraproj/gemara@v1.3.0 \
  cmd/mock-oci-registry/testdata/ampel-branch-protection-policy.yaml

cue vet -c -d '#Policy' github.com/gemaraproj/gemara@v1.3.0 \
  cmd/mock-oci-registry/testdata/test-opa-policy.yaml

```
## Related Issues
Closes #696
