### PR TITLE
fix: add text labels alongside emoji in terminal scan summary

### DIFF
--- a/internal/output/scan_summary.go
+++ b/internal/output/scan_summary.go
@@ -151,7 +151,7 @@ func FormatScanSummary(assessments []provider.AssessmentLog, assessmentTargets [
 	headers := []string{"TARGET ID", "REQUIREMENT ID", "CONTROL ID", "STATUS", "MESSAGE"}
 	var rows [][]string
 	for _, e := range entries {
-		rows = append(rows, []string{e.targetID, e.requirementID, e.controlID, e.emoji, e.message})
+		rows = append(rows, []string{e.targetID, e.requirementID, e.controlID, e.emoji + " " + e.result.String(), e.message})
 	}
 
 	conclusion := fmt.Sprintf("%d requirements: %d passed, %d failed, %d not applicable, %d skipped, %d errors",

--- a/internal/output/scan_summary_test.go
+++ b/internal/output/scan_summary_test.go
@@ -370,12 +370,12 @@ func TestFormatScanSummary_PassingWithEmptyMessage(t *testing.T) {
 	lines := strings.Split(output, "\n")
 	for _, line := range lines {
 		if strings.Contains(line, complytime.StatusPassed) {
-			// After the status emoji, only whitespace should remain (empty message)
+			// After the status text, only whitespace should remain (empty message)
 			parts := strings.Fields(line)
-			// Fields: target1, REQ-1, CTRL-1, emoji — no message field
+			// Fields: target1, REQ-1, CTRL-1, emoji, result text — no message field
 			lastField := parts[len(parts)-1]
-			assert.Equal(t, complytime.StatusPassed, lastField,
-				"StatusPassed emoji should be the last non-empty field when message is empty")
+			assert.Equal(t, "Passed", lastField,
+				"result text should be the last non-empty field when message is empty")
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Add text labels alongside emoji in the terminal scan summary STATUS column for accessibility. Screen readers, braille displays, and monochrome terminals may skip or garble emoji-only values, making the status effectively invisible for visually impaired users.

The STATUS column now displays `✅ Passed` instead of `✅`, matching the pattern already used in the markdown report (`--format pretty`).

### Changes

- **`internal/output/scan_summary.go`**: Append `result.String()` to the emoji in the STATUS column cell (`e.emoji + " " + e.result.String()`)
- **`internal/output/scan_summary_test.go`**: Update `TestFormatScanSummary_PassingWithEmptyMessage` assertion to expect the result text as the last field

### Before

```
STATUS
✅
❌
⏭️
⚠️
```

### After

```
STATUS
✅ Passed
❌ Failed
⏭️ Not Applicable
⚠️ Unknown
```

## Related Issues

- Closes #724

## Review Hints

- Single-commit PR with a one-line production code change and a test update. Review as a single commit.
- The change mirrors how the markdown report already formats status indicators (PR #708).
- `terminal.ShowPlainTable` auto-sizes columns, so the wider STATUS values adjust automatically.