### PR TITLE
fix(policy): warn when split-layer catalog load fails

### DIFF
--- a/internal/policy/resolver.go
+++ b/internal/policy/resolver.go
@@ -5,6 +5,8 @@ package policy
 import (
 	"fmt"
 
+	"github.com/charmbracelet/log"
+
 	"github.com/complytime/complyctl/internal/complytime"
 	"github.com/gemaraproj/go-gemara"
 	"github.com/goccy/go-yaml"
@@ -207,7 +209,14 @@ func (r *Resolver) extractSplitMetadata(
 
 	catalogData, catalogLoadErr := r.loader.LoadLayerByMediaType(
 		policyID, version, complytime.MediaTypeCatalog)
-	if catalogLoadErr == nil {
+	if catalogLoadErr != nil {
+		// Catalog layer unavailable — could be genuinely absent or
+		// corrupted after sync. Log a warning so the user knows the
+		// control count may be inaccurate rather than silently
+		// defaulting to zero.
+		log.Warn("catalog layer unavailable, control count will be 0",
+			"policy", policyID, "error", catalogLoadErr)
+	} else {
 		catalog, catErr := parseControlCatalog(catalogData)
 		if catErr != nil {
 			return PolicyMetadata{}, fmt.Errorf(

--- a/internal/policy/resolver.go
+++ b/internal/policy/resolver.go
@@ -215,7 +215,8 @@ func (r *Resolver) extractSplitMetadata(
 		// control count may be inaccurate rather than silently
 		// defaulting to zero.
 		log.Warn("catalog layer unavailable, control count will be 0",
-			"policy", policyID, "error", catalogLoadErr)
+			"policy", policyID, "version", version,
+			"error", catalogLoadErr)
 	} else {
 		catalog, catErr := parseControlCatalog(catalogData)
 		if catErr != nil {

--- a/internal/policy/resolver_test.go
+++ b/internal/policy/resolver_test.go
@@ -809,7 +809,8 @@ func TestResolver_ExtractPolicyMetadata_SplitMissingCatalog(
 	// bundleShape defaults to false (split-layer).
 	policyMediaType := "application/vnd.gemara.policy.v1+yaml"
 	ml.layers["split-nocat/v1/"+policyMediaType] = validPolicyYAML()
-	// No catalog layer registered -> catalog load fails silently.
+	// No catalog layer registered -> catalog load fails with a
+	// warning log; ControlCount defaults to 0.
 
 	r := NewResolver(ml)
 	meta, err := r.ExtractPolicyMetadata("split-nocat", "v1")


### PR DESCRIPTION
## Summary

`extractSplitMetadata` in `internal/policy/resolver.go` silently swallowed catalog layer load errors, defaulting `ControlCount` to `0` without any indication to the user. This made it impossible to distinguish "policy has no catalog layer" from "catalog layer exists but failed to load" (e.g., post-sync disk corruption).

This PR adds a `log.Warn` when `LoadLayerByMediaType` fails for the catalog layer, following the warning pattern already used in `internal/cache/`. The behavior is unchanged — `ControlCount` defaults to `0` and no error is returned — but the user now sees a warning in the log output.

This addresses the catalog error handling asymmetry between `extractBundleMetadata` (which reports catalog issues via the files map) and `extractSplitMetadata` (which previously swallowed them). Identified during review of #711.

## Related Issues

- Follow-up to #711

## Review Hints

- This is a 2-file, 12-line change. The only behavioral difference is a new `log.Warn` — return values are unchanged.
- The existing `TestResolver_ExtractPolicyMetadata_SplitMissingCatalog` test covers the return-value contract (ControlCount=0, no error). The warning log is not directly tested, consistent with how `internal/cache/` handles its `log.Warn` calls (none are tested for output).
- The `charmbracelet/log` import is new to `internal/policy/` but follows the established pattern in `internal/cache/retention.go` and `internal/cache/complypack.go`.