### PR TITLE
docs(proto): document Result enum semantics and Gemara mappings

### DIFF
--- a/api/plugin/plugin.pb.go
+++ b/api/plugin/plugin.pb.go
@@ -84,15 +84,41 @@ func (ConfidenceLevel) EnumDescriptor() ([]byte, []int) {
 	return file_plugin_proto_rawDescGZIP(), []int{0}
 }
 
-// Result represents the outcome of a check
+// Result represents the outcome of a single assessment step.
+// Each value maps to a specific Gemara result state used in
+// downstream report generation (OSCAL, SARIF, Markdown).
 type Result int32
 
 const (
+	// RESULT_UNSPECIFIED indicates the step was never executed.
+	// Use when a requirement exists in the assessment plan but
+	// the provider did not attempt evaluation (e.g., missing
+	// configuration, unsupported check type).
+	// Maps to Gemara NotRun.
 	Result_RESULT_UNSPECIFIED Result = 0
-	Result_RESULT_PASSED      Result = 1
-	Result_RESULT_FAILED      Result = 2
-	Result_RESULT_SKIPPED     Result = 3
-	Result_RESULT_ERROR       Result = 4
+	// RESULT_PASSED indicates the requirement was evaluated and met.
+	// The target satisfies the compliance requirement.
+	// Maps to Gemara Passed.
+	Result_RESULT_PASSED Result = 1
+	// RESULT_FAILED indicates the requirement was evaluated and not met.
+	// The target does not satisfy the compliance requirement.
+	// Maps to Gemara Failed.
+	Result_RESULT_FAILED Result = 2
+	// RESULT_SKIPPED indicates the requirement was evaluated but does
+	// not apply to the target (e.g., a server-only rule scanned against
+	// a container, or an OS-specific check on a different OS).
+	// Providers MUST report not-applicable results using this value
+	// with an AssessmentLog entry rather than silently omitting them.
+	// Omitting not-applicable results prevents complyctl from
+	// distinguishing "nothing ran" from "ran but did not apply."
+	// Maps to Gemara NotApplicable.
+	Result_RESULT_SKIPPED Result = 3
+	// RESULT_ERROR indicates the evaluation could not complete due to
+	// a tool or configuration error (e.g., scanner crash, missing
+	// binary, malformed policy). This is distinct from RESULT_FAILED:
+	// the compliance posture is unknown, not negative.
+	// Maps to Gemara Unknown.
+	Result_RESULT_ERROR Result = 4
 )
 
 // Enum value maps for Result.

--- a/api/plugin/plugin.proto
+++ b/api/plugin/plugin.proto
@@ -173,12 +173,42 @@ enum ConfidenceLevel {
   CONFIDENCE_LEVEL_HIGH = 4;
 }
 
-// Result represents the outcome of a check
+// Result represents the outcome of a single assessment step.
+// Each value maps to a specific Gemara result state used in
+// downstream report generation (OSCAL, SARIF, Markdown).
 enum Result {
+  // RESULT_UNSPECIFIED indicates the step was never executed.
+  // Use when a requirement exists in the assessment plan but
+  // the provider did not attempt evaluation (e.g., missing
+  // configuration, unsupported check type).
+  // Maps to Gemara NotRun.
   RESULT_UNSPECIFIED = 0;
+
+  // RESULT_PASSED indicates the requirement was evaluated and met.
+  // The target satisfies the compliance requirement.
+  // Maps to Gemara Passed.
   RESULT_PASSED = 1;
+
+  // RESULT_FAILED indicates the requirement was evaluated and not met.
+  // The target does not satisfy the compliance requirement.
+  // Maps to Gemara Failed.
   RESULT_FAILED = 2;
+
+  // RESULT_SKIPPED indicates the requirement was evaluated but does
+  // not apply to the target (e.g., a server-only rule scanned against
+  // a container, or an OS-specific check on a different OS).
+  // Providers MUST report not-applicable results using this value
+  // with an AssessmentLog entry rather than silently omitting them.
+  // Omitting not-applicable results prevents complyctl from
+  // distinguishing "nothing ran" from "ran but did not apply."
+  // Maps to Gemara NotApplicable.
   RESULT_SKIPPED = 3;
+
+  // RESULT_ERROR indicates the evaluation could not complete due to
+  // a tool or configuration error (e.g., scanner crash, missing
+  // binary, malformed policy). This is distinct from RESULT_FAILED:
+  // the compliance posture is unknown, not negative.
+  // Maps to Gemara Unknown.
   RESULT_ERROR = 4;
 }
 

--- a/pkg/provider/client.go
+++ b/pkg/provider/client.go
@@ -105,14 +105,33 @@ type Evidence struct {
 }
 
 // Result is the outcome of a single assessment step.
+// Each value has a 1:1 mapping to a proto Result enum value and
+// a corresponding Gemara result state used in report generation.
 type Result int32
 
 const (
+	// ResultUnspecified indicates the step was never executed.
+	// Maps to proto RESULT_UNSPECIFIED / Gemara NotRun.
 	ResultUnspecified Result = 0
-	ResultPassed      Result = 1
-	ResultFailed      Result = 2
-	ResultSkipped     Result = 3
-	ResultError       Result = 4
+
+	// ResultPassed indicates the requirement was evaluated and met.
+	// Maps to proto RESULT_PASSED / Gemara Passed.
+	ResultPassed Result = 1
+
+	// ResultFailed indicates the requirement was evaluated and not met.
+	// Maps to proto RESULT_FAILED / Gemara Failed.
+	ResultFailed Result = 2
+
+	// ResultSkipped indicates the requirement was evaluated but does
+	// not apply to the target. Providers MUST report not-applicable
+	// results with this value rather than omitting the assessment.
+	// Maps to proto RESULT_SKIPPED / Gemara NotApplicable.
+	ResultSkipped Result = 3
+
+	// ResultError indicates the evaluation could not complete due to
+	// a tool or configuration error. Compliance posture is unknown.
+	// Maps to proto RESULT_ERROR / Gemara Unknown.
+	ResultError Result = 4
 )
 
 // ConfidenceLevel indicates the evaluator's confidence in an assessment result.


### PR DESCRIPTION
Providers lacked guidance on when to use each `Result` value, especially
`RESULT_SKIPPED` vs omitting not-applicable results.  This caused
`complyctl` to conflate "nothing ran" with "ran but did not apply"
(#631 Task 1).

- Add doc comments to each Result value in plugin.proto with
  semantic meaning and corresponding Gemara state
- Add MUST directive: providers report not-applicable results
  as RESULT_SKIPPED rather than dropping them
- Mirror documentation on Go Result constants in client.go
- Update generated plugin.pb.go type/constant comments

Refs #631

Assisted-by: Claude Opus 4.6
Signed-off-by: Trevor Vaughan <tvaughan@redhat.com>
