### PR TITLE
feat: add Homebrew formula and macOS binary releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@
 # re-run resilience), semver ordering, CI check status,
 # and unreleased commits before creating an annotated tag.
 #
+# After release, publishes a source-build Homebrew Formula
+# to complytime/homebrew-tap for macOS/Linux installation.
+#
 # See: https://github.com/complytime/complyctl/issues/699
 # Fixes: https://github.com/complytime/complyctl/issues/654
 # Fixes: https://github.com/complytime/complyctl/issues/655
@@ -63,3 +66,100 @@ jobs:
         permissions:
             contents: write
             id-token: write
+
+    homebrew:
+        name: Publish Homebrew Formula
+        needs: [preflight, release]
+        if: needs.preflight.outputs.tag != ''
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        steps:
+            - name: Generate Homebrew tap token
+              id: homebrew-token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  app-id: ${{ secrets.APP_ID }}
+                  private-key: ${{ secrets.PRIVATE_KEY }}
+                  repositories: homebrew-tap
+                  owner: complytime # zizmor: ignore[github-app] — scoped by repositories: homebrew-tap above
+                  permission-contents: write
+
+            - name: Publish Homebrew formula
+              env:
+                  TAP_TOKEN: ${{ steps.homebrew-token.outputs.token }}
+                  TAG: ${{ needs.preflight.outputs.tag }}
+              run: |
+                  set -euo pipefail
+
+                  # Defense-in-depth: validate tag format locally even though
+                  # preflight already validates upstream.
+                  if ! [[ "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+                      echo "::error::TAG does not match expected semver format: ${TAG}"
+                      exit 1
+                  fi
+
+                  VERSION="${TAG#v}"
+
+                  TARBALL_URL="https://github.com/complytime/complyctl/archive/refs/tags/${TAG}.tar.gz"
+                  HTTP_CODE=$(curl -sL -o /tmp/source.tar.gz -w "%{http_code}" --fail --retry 3 "${TARBALL_URL}")
+                  if [ "${HTTP_CODE}" != "200" ]; then
+                      echo "::error::Failed to download source tarball (HTTP ${HTTP_CODE})"
+                      exit 1
+                  fi
+                  SHA256=$(sha256sum /tmp/source.tar.gz | awk '{print $1}')
+                  if [ ${#SHA256} -ne 64 ]; then
+                      echo "::error::SHA256 checksum has unexpected length: ${SHA256}"
+                      exit 1
+                  fi
+
+                  cat > complyctl.rb <<'FORMULA'
+                  class Complyctl < Formula
+                    desc "CLI for streamlining end-to-end compliance workflows"
+                    homepage "https://github.com/complytime/complyctl"
+                    url "TARBALL_URL_PLACEHOLDER"
+                    sha256 "SHA256_PLACEHOLDER"
+                    license "Apache-2.0"
+                    head "https://github.com/complytime/complyctl.git", branch: "main"
+
+                    depends_on "go" => :build
+
+                    def install
+                      ldflags = %W[
+                        -X github.com/complytime/complyctl/internal/version.version=#{version}
+                        -X github.com/complytime/complyctl/internal/version.buildDate=#{time.iso8601}
+                        -X github.com/complytime/complyctl/internal/version.gitTreeState=clean
+                      ]
+                      system "go", "build", *std_go_args(ldflags:), "./cmd/complyctl"
+                      generate_completions_from_executable(bin/"complyctl", "completion")
+                    end
+
+                    test do
+                      assert_match version.to_s, shell_output("#{bin}/complyctl version")
+                    end
+                  end
+                  FORMULA
+
+                  # These substitutions are safe because TAG is validated
+                  # by the semver regex above (defense-in-depth) and SHA256
+                  # is computed locally from sha256sum output. If the TAG
+                  # validation is removed, TARBALL_URL becomes an injection
+                  # vector via sed replacement.
+                  sed -i "s|TARBALL_URL_PLACEHOLDER|${TARBALL_URL}|" complyctl.rb
+                  sed -i "s|SHA256_PLACEHOLDER|${SHA256}|" complyctl.rb
+
+                  # Use gh CLI for clone and push to avoid embedding
+                  # the token in git config or process arguments.
+                  GH_TOKEN="${TAP_TOKEN}" gh repo clone complytime/homebrew-tap tap-repo -- --depth 1
+                  cd tap-repo
+                  mkdir -p Formula
+                  cp ../complyctl.rb Formula/complyctl.rb
+                  git config user.name "github-actions[bot]"
+                  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+                  git add Formula/complyctl.rb
+                  git commit -m "complyctl ${VERSION}" || { echo "No changes to commit"; exit 0; }
+                  # gh configures a credential helper that supplies the
+                  # token via GH_TOKEN without persisting it in git config.
+                  GH_TOKEN="${TAP_TOKEN}" gh auth setup-git
+                  git push origin main
+                  echo "::notice::Published Formula for complyctl ${VERSION} to homebrew-tap"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,8 +79,8 @@ jobs:
               id: homebrew-token
               uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
               with:
-                  app-id: ${{ secrets.APP_ID }}
-                  private-key: ${{ secrets.PRIVATE_KEY }}
+                  client-id: ${{ secrets.APP_ID_HOMEBREW_FORMULA_PUBLISHER }}
+                  private-key: ${{ secrets.PRIVATE_KEY_APP_HOMEBREW_FORMULA_PUBLISHER }}
                   repositories: homebrew-tap
                   owner: complytime # zizmor: ignore[github-app] — scoped by repositories: homebrew-tap above
                   permission-contents: write

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,7 +18,11 @@ builds:
       env:
           - CGO_ENABLED=0
       goos:
+          - darwin
           - linux
+      goarch:
+          - amd64
+          - arm64
       ldflags:
           - "-X github.com/complytime/complyctl/internal/version.version={{ .Version }}"
           - "-X github.com/complytime/complyctl/internal/version.gitTreeState={{ .GitTreeState }}"
@@ -26,7 +30,7 @@ builds:
           - "-X github.com/complytime/complyctl/internal/version.buildDate={{ .Date }}"
 
 archives:
-    - format: tar.gz
+    - formats: [tar.gz]
       # this name template makes the OS and Arch compatible with the results of `uname`.
       name_template: >-
           {{ .ProjectName }}_

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,10 @@ make test-schema-validation
 # Acceptance tests (container-based, requires podman-compose or docker compose)
 make test-acceptance
 # → compose up --profile lifecycle (zot + seed + SUT containers)
+
+# Homebrew formula smoke test (requires brew, macOS/Linux)
+make test-homebrew
+# → ./tests/homebrew_test.sh
 ```
 
 ### Lint & Format
@@ -95,7 +99,7 @@ make crapload-check     # check for CRAP regressions against baseline
 | Behavioral | `behavioral_assessment.yml` | Behavioral assessment reports |
 | Scheduled | `ci_scheduled.yml` | Daily OSV-Scanner and Scorecards |
 | Acceptance Test | `acceptance_test.yml` | Container-based acceptance tests with real OCI registry |
-| Release | `release.yml` | Release automation (reusable preflight + GoReleaser from org-infra) |
+| Release | `release.yml` | Release automation (reusable preflight + GoReleaser from org-infra) + Homebrew formula publishing |
 
 ## Project Structure
 
@@ -139,6 +143,7 @@ tests/
 ├── cross-repo/      # cross-repo integration tests (complyctl + ampel + opa providers)
 ├── e2e/             # E2E tests (build-tag gated: -tags=e2e)
 ├── schema-validation/  # CUE schema validation of EvaluationLog output (validate.sh)
+├── homebrew_test.sh     # Homebrew formula smoke test (requires brew)
 └── integration_test.sh  # shell-based integration test
 vendor/              # vendored dependencies
 ```
@@ -311,6 +316,7 @@ packages organized by domain responsibility.
 ## Recent Changes
 - custom-trusted-root: `VerificationConfig` gains `TrustedRoot string` field with `yaml:"trusted_root,omitempty"` tag in `internal/complytime/config.go`; `ValidateVerificationConfig()` enforces mutual exclusivity with `key` (error: "trusted_root cannot be used with key-based verification"), requires `issuer` + `identity` (error: "trusted_root requires issuer and identity for keyless verification"), and validates file existence via `filepath.Clean` + `os.Stat`; `NewKeylessVerifier()` in `internal/cache/verify.go` gains `trustedRootPath string` parameter — when non-empty, calls `root.NewTrustedRootFromPath(trustedRootPath)` instead of TUF fetch, wrapping errors with `"failed to load trusted root from %s: %w"`; `buildVerifierFromConfig()` in `cmd/complyctl/cli/get.go` passes `cfg.TrustedRoot` to `NewKeylessVerifier()`; THR02.MIT05 added to threat model for user-supplied trust anchor without TUF integrity protection; fixes #768
 - multi-target-report-filenames: `BuildReportFilename(prefix, policyID, targetID, ext string) string` in `internal/output/filename.go` centralizes report filename construction for all four formatters (EvaluationLog, OSCAL, SARIF, Markdown); sanitizes via `complytime.FilenameSafe`, timestamps via `time.Now().Format("20060102-150405")`, omits targetID segment when empty; OSCAL/SARIF/Markdown formatters migrated from inline `fmt.Sprintf` to shared helper, adding targetID to filenames; fixes #773 (multi-target scans overwrote report files)
+- homebrew-formula-and-go-install: macOS binary releases (darwin/amd64, darwin/arm64) added to GoReleaser build matrix; source-build Homebrew Formula auto-published to `complytime/homebrew-tap` on release via GitHub App token; `go install` documented in `docs/INSTALLATION.md`; `make test-homebrew` target and `tests/homebrew_test.sh` for formula validation; shell completions (Bash, Zsh, Fish) installed by Formula (#713)
 - fix-doctor-target-variable-oneofs: `DescribeResponse` proto gains `optional_target_variable_groups` field 7 (pipe-delimited one-of groups, e.g. `"url|input_path"`); `ProviderHealth` struct gains `OptionalTargetVariableGroups []string`; `CheckVariables()` validates optional groups as at-least-one-present per target instead of requiring all; resolves contradiction where `doctor` required both `url` and `input_path` while `scan` rejected configs with both set; OPA provider update tracked in complytime-providers#145; fixes #759
 - registry-host-verification-fix: **BREAKING** -- `BuildLookupRef()` gains `registryHost` parameter prepended to OCI references for signature verification; `Sync`/`ComplypackSync` structs gain `registryHost` field populated from `ref.Registry` at construction; `NewSync`/`NewComplypackSync` constructors gain `registryHost string` parameter; all `VerifyFunc` invocations now receive host-qualified `registryRef` resolving against the configured registry instead of Docker Hub; fail-closed when `registryHost` is empty with verifier configured (returns error containing "registry host"); defense-in-depth with `ValidateOCIRef` config-time check; THR02 mitigations updated (MIT02 refined, MIT04 added for fail-closed); fixes #767
 - digest-format-validation: `ValidateDigest()` in `internal/cache/state.go` validates OCI digest format (`algorithm:hex`) using `opencontainers/go-digest`; `UpdatePolicyStateWithVerification` and `UpdateComplypackStateWithVerification` now return `error`, rejecting malformed digests at write time; `LoadState` warns and excludes entries with malformed digests while preserving valid and empty-digest entries; `internal/cache/cachetest/digests.go` provides canonical test digest constants; defense-in-depth per NIST 800-53 SI-10 (#677)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,16 @@
   empty-digest entries. Defense-in-depth per NIST 800-53 SI-10
   input validation. (#677)
 
+- macOS binary releases: darwin/amd64 and darwin/arm64 archives now
+  included in GoReleaser release matrix. (#713)
+
+- Homebrew formula: `brew install complytime/tap/complyctl` installs
+  complyctl via source build from the `complytime/homebrew-tap`
+  repository. Formula is auto-published by the release workflow. (#713)
+
+- `go install` documented as an installation method in
+  `docs/INSTALLATION.md`. (#713)
+
 - Cross-repo integration workflow now validates EvaluationLog YAML
   output against the Gemara CUE schema with `cue vet`. Catches
   schema conformance regressions (e.g. empty `steps` arrays, missing

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,13 @@ test-devcontainer: ## verify devcontainer Containerfile builds
 	@echo "Containerfile builds successfully."
 .PHONY: test-devcontainer
 
+TIMEOUT := $(shell command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null || echo "")
+
+test-homebrew: ## verify Homebrew formula builds and installs from HEAD (requires brew, macOS/Linux)
+	@command -v brew >/dev/null 2>&1 || { echo "ERROR: brew not found. Install Homebrew first."; exit 1; }
+	$(if $(TIMEOUT),$(TIMEOUT) 300) ./tests/homebrew_test.sh
+.PHONY: test-homebrew
+
 ACCEPTANCE_COMPOSE = $(COMPOSE) -f tests/acceptance/compose.yaml --profile lifecycle
 
 test-acceptance: build build-test-provider build-acceptance-test ## run container-based acceptance tests (requires podman-compose or docker compose)

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,5 +1,57 @@
 # Installation
 
+## Homebrew (macOS / Linux)
+
+```bash
+brew install complytime/tap/complyctl
+```
+
+To upgrade:
+
+```bash
+brew upgrade complytime/tap/complyctl
+```
+
+Shell completions for Bash, Zsh, and Fish are installed automatically.
+
+### Verifying the Homebrew installation
+
+After installing, confirm the binary is linked and functional:
+
+```bash
+# Check version and build metadata
+complyctl version
+
+# Run the formula's built-in test (version output match)
+brew test complyctl
+
+# Verify shell completions were generated
+ls "$(brew --prefix)/share/zsh/site-functions/_complyctl" 2>/dev/null && echo "zsh completions OK"
+ls "$(brew --prefix)/etc/bash_completion.d/complyctl" 2>/dev/null && echo "bash completions OK"
+ls "$(brew --prefix)/share/fish/vendor_completions.d/complyctl.fish" 2>/dev/null && echo "fish completions OK"
+```
+
+For contributors testing a formula from a feature branch before release:
+
+```bash
+make test-homebrew
+```
+
+This installs from the current branch via `brew install --HEAD`,
+runs `brew test`, and cleans up automatically. See
+`tests/homebrew_test.sh` for details.
+
+## go install
+
+If you already have a Go toolchain:
+
+```bash
+go install github.com/complytime/complyctl/cmd/complyctl@latest
+```
+
+This builds from source on your machine. Version information will show
+`(devel)` unless you pass `-ldflags` manually.
+
 ## Binary
 
 The latest binary release can be downloaded from <https://github.com/complytime/complyctl/releases/latest>.
@@ -19,7 +71,7 @@ cosign verify-blob \
 
 ### Prerequisites
 
-- **Go** 1.25+
+- **Go** 1.26+
 - **Make**
 - **buf** CLI (optional, for protobuf regeneration)
 

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -18,7 +18,7 @@ GoReleaser is configured in [.goreleaser.yaml](https://github.com/complytime/com
 The `homebrew` job in the release workflow automatically publishes or updates `Formula/complyctl.rb` in the [homebrew-tap](https://github.com/complytime/homebrew-tap) repository.
 
 **Prerequisites:**
-- The GitHub App (secrets: `APP_ID`, `PRIVATE_KEY`) must have `Contents:write` permission on `complytime/homebrew-tap`
+- The GitHub App (secrets: `APP_ID_HOMEBREW_FORMULA_PUBLISHER`, `PRIVATE_KEY_APP_HOMEBREW_FORMULA_PUBLISHER`) must have `Contents:write` permission on `complytime/homebrew-tap`
 - If the App installation is scoped to specific repos, `homebrew-tap` must be included
 
 **Failure modes:**

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -11,6 +11,30 @@ complyctl uses the org-wide release infrastructure from [org-infra](https://gith
 
 GoReleaser is configured in [.goreleaser.yaml](https://github.com/complytime/complyctl/blob/main/.goreleaser.yaml).
 
+3. **Homebrew Formula Publishing** -- after the release job completes, a third job downloads the source tarball for the tag, computes its SHA256, templates a source-build Homebrew Formula, and pushes it to `complytime/homebrew-tap`.
+
+### Homebrew Formula Publishing
+
+The `homebrew` job in the release workflow automatically publishes or updates `Formula/complyctl.rb` in the [homebrew-tap](https://github.com/complytime/homebrew-tap) repository.
+
+**Prerequisites:**
+- The GitHub App (secrets: `APP_ID`, `PRIVATE_KEY`) must have `Contents:write` permission on `complytime/homebrew-tap`
+- If the App installation is scoped to specific repos, `homebrew-tap` must be included
+
+**Failure modes:**
+- Tarball download failure (HTTP != 200) -- the step exits with an error
+- SHA256 length mismatch -- the step exits with an error
+- GitHub App token generation failure -- the step fails visibly
+- No changes to commit (re-run of the same version) -- exits 0 silently, which is safe
+
+**Re-runs:** Safe. If the Formula is already up-to-date, `git commit` exits with "No changes to commit" and the job succeeds without pushing.
+
+**Manual recovery:** If the automation fails, manually create and push the Formula:
+1. Download the source tarball: `curl -sL -o source.tar.gz https://github.com/complytime/complyctl/archive/refs/tags/vX.Y.Z.tar.gz`
+2. Compute SHA256: `sha256sum source.tar.gz`
+3. Update `Formula/complyctl.rb` in the `homebrew-tap` repo with the new `url` and `sha256`
+4. Commit and push
+
 ### Creating a Release
 
 To create a release, a project maintainer triggers the workflow manually:

--- a/openspec/changes/homebrew-formula-and-go-install/.openspec.yaml
+++ b/openspec/changes/homebrew-formula-and-go-install/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/homebrew-formula-and-go-install/design.md
+++ b/openspec/changes/homebrew-formula-and-go-install/design.md
@@ -1,0 +1,102 @@
+## Context
+
+complyctl is a Go CLI tool built with Cobra. The existing release pipeline uses
+GoReleaser v2 (invoked via GitHub Actions) to cross-compile, archive, generate
+SBOMs, and sign checksums with Sigstore/cosign. Today it only builds for
+linux/amd64. The `complytime/homebrew-tap` repository exists but is empty
+(contains only a LICENSE file).
+
+Homebrew Casks (pre-built binary distribution) were ruled out because:
+- Casks trigger macOS Gatekeeper quarantine on unsigned binaries.
+- Apple Developer signing requires a paid account and secret management that
+  is not yet in place for this project.
+- The deprecated GoReleaser `brews` section (which generated "hackyish"
+  formulas installing pre-built binaries) is fully deprecated in v2.16.
+
+Cross-repo authentication uses a GitHub App (secrets: `APP_ID`, `PRIVATE_KEY`)
+with `actions/create-github-app-token` to mint short-lived installation tokens.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Users can install complyctl on macOS/Linux with a single `brew install` command.
+- Go developers can install with `go install` (zero infrastructure).
+- The Homebrew Formula is updated automatically on each release (no manual
+  Formula maintenance).
+- Shell completions (Bash, Zsh, Fish) are installed by the Formula.
+- No Apple Developer signing or notarization is required.
+- GoReleaser config passes `goreleaser check` without deprecation warnings.
+
+**Non-Goals:**
+- Homebrew-core submission (third-party tap is sufficient for now).
+- Homebrew Cask support (deferred until signing infrastructure exists).
+- Windows package manager support (scoop, chocolatey).
+- Migrating the release workflow to org-infra reusable workflows (separate
+  concern; would force all repos into Homebrew publishing).
+- Source-build verification or reproducible builds.
+
+## Decisions
+
+### 1. Source-build Formula (not Cask, not pre-built Formula)
+
+**Choice**: Generate a Homebrew Formula that runs `go build` on the user's machine.
+
+**Alternatives considered**:
+| Approach | Pros | Cons |
+|----------|------|------|
+| `homebrew_casks` (GoReleaser) | Official GoReleaser path; fast install | Requires signing/notarization or xattr workaround |
+| `brews` (GoReleaser, deprecated) | Automated; pre-built binary via Formula | Deprecated in v2.16; will be removed in v3 |
+| Source-build Formula (custom step) | No signing needed; no deprecation; proper Homebrew pattern | Slower install; requires Go on user's machine (auto-installed by Homebrew) |
+| No Homebrew, just `go install` | Zero maintenance | Poor UX for non-Go users; no completions; no `brew upgrade` |
+
+**Rationale**: Source-build avoids all Gatekeeper/signing concerns permanently.
+Homebrew auto-installs Go as a build dependency so users don't need it
+pre-installed. The install time (~30s) is acceptable for a CLI tool.
+
+### 2. Custom workflow step (not GoReleaser pipe)
+
+**Choice**: A shell step in `release.yml` that templates the Formula and pushes
+to the tap repo.
+
+**Rationale**: GoReleaser's native Formula generation (`brews`) is deprecated
+and produces formulas that download pre-built binaries (not source-build). A
+custom step gives full control over the Ruby Formula content and avoids the
+deprecation.
+
+### 3. GitHub App token (not PAT, not GITHUB_TOKEN)
+
+**Choice**: Use `actions/create-github-app-token` with the org's existing
+`APP_ID`/`PRIVATE_KEY` secrets to push to `homebrew-tap`.
+
+**Rationale**: Short-lived tokens with minimal scope. No long-lived PATs to
+rotate. Consistent with existing cross-repo patterns in the org.
+
+### 4. ldflags: version, buildDate, and gitTreeState
+
+**Choice**: The Formula injects `version.version`, `version.buildDate`, and
+`version.gitTreeState=clean` via ldflags. It does NOT inject `commit` because
+source tarballs have no `.git` directory.
+
+**Rationale**: Homebrew downloads source archives (not git clones). The `commit`
+field is unavailable at build time and will show as empty, which the version
+template handles gracefully. `gitTreeState` is hardcoded to `clean` because
+source tarballs are always a clean snapshot of the tagged commit — without this,
+the version output shows a trailing `+` with no state value (e.g., `1.2.3+`)
+which looks broken.
+
+### 5. macOS binaries in GoReleaser (in addition to Formula)
+
+**Choice**: Add `darwin` to `goos` and explicit `amd64`/`arm64` to `goarch` in
+the GoReleaser build matrix.
+
+**Rationale**: Users who prefer direct binary downloads (without Homebrew or Go)
+can still grab platform-specific archives from GitHub Releases. Also enables
+future Cask migration if signing is adopted.
+
+## Risks / Trade-offs
+
+- **[Slower install]** → Source builds take ~30s vs instant for pre-built. Acceptable for a CLI tool installed once.
+- **[Go dependency size]** → Homebrew downloads Go toolchain (~300MB) if not already installed. One-time cost; shared across other Go formulas.
+- **[Formula fragility]** → The workflow templates Ruby via heredoc. If Homebrew API changes, the Formula may need manual updates. Mitigated by using stable Homebrew DSL (`std_go_args`, `generate_completions_from_executable`).
+- **[Tag-before-tarball race]** → The Formula step curls the source tarball right after GoReleaser creates the release. GitHub may have a brief propagation delay. Mitigated by the tarball being created by `git tag` (happens in preflight job, well before the Formula step runs).
+- **[GitHub App access]** → If the App's installation doesn't include `homebrew-tap`, the push will fail. Pre-merge checklist item for admins.

--- a/openspec/changes/homebrew-formula-and-go-install/design.md
+++ b/openspec/changes/homebrew-formula-and-go-install/design.md
@@ -13,7 +13,8 @@ Homebrew Casks (pre-built binary distribution) were ruled out because:
 - The deprecated GoReleaser `brews` section (which generated "hackyish"
   formulas installing pre-built binaries) is fully deprecated in v2.16.
 
-Cross-repo authentication uses a GitHub App (secrets: `APP_ID`, `PRIVATE_KEY`)
+Cross-repo authentication uses a GitHub App (secrets:
+`APP_ID_HOMEBREW_FORMULA_PUBLISHER`, `PRIVATE_KEY_APP_HOMEBREW_FORMULA_PUBLISHER`)
 with `actions/create-github-app-token` to mint short-lived installation tokens.
 
 ## Goals / Non-Goals
@@ -66,7 +67,7 @@ deprecation.
 ### 3. GitHub App token (not PAT, not GITHUB_TOKEN)
 
 **Choice**: Use `actions/create-github-app-token` with the org's existing
-`APP_ID`/`PRIVATE_KEY` secrets to push to `homebrew-tap`.
+`APP_ID_HOMEBREW_FORMULA_PUBLISHER`/`PRIVATE_KEY_APP_HOMEBREW_FORMULA_PUBLISHER` secrets to push to `homebrew-tap`.
 
 **Rationale**: Short-lived tokens with minimal scope. No long-lived PATs to
 rotate. Consistent with existing cross-repo patterns in the org.

--- a/openspec/changes/homebrew-formula-and-go-install/proposal.md
+++ b/openspec/changes/homebrew-formula-and-go-install/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+macOS users currently have no streamlined way to install complyctl. The only
+options are downloading a Linux-only binary from GitHub Releases or building
+from source with a full Go toolchain and Make. This creates friction for
+developer onboarding—especially for non-Go developers—and is inconsistent with
+the project's adoption of Homebrew as the standard macOS package manager for
+local tooling (uv, bun, node, opencode, etc.). Issue #713.
+
+## What Changes
+
+- Release pipeline produces macOS (darwin) binaries for amd64 and arm64 in
+  addition to existing Linux builds.
+- A source-build Homebrew Formula is automatically generated and pushed to the
+  `complytime/homebrew-tap` repository on each release, enabling
+  `brew install complytime/tap/complyctl`.
+- `go install github.com/complytime/complyctl/cmd/complyctl@latest` is
+  documented as a zero-infrastructure alternative for Go developers.
+- Shell completions (Bash, Zsh, Fish) are installed automatically via the
+  Formula.
+
+## Capabilities
+
+### New Capabilities
+- `homebrew-formula`: Automated source-build Homebrew Formula published to the
+  complytime/homebrew-tap repository on each release. Builds from source using
+  Go (avoids Gatekeeper/signing entirely). Installs shell completions.
+- `go-install`: Documented `go install` path as a cross-platform alternative
+  requiring no tap or external infrastructure.
+- `macos-binaries`: Cross-compilation of darwin/amd64 and darwin/arm64 release
+  archives alongside existing Linux builds.
+
+### Modified Capabilities
+<!-- No existing spec-level behavior changes. The release pipeline gains new
+     steps but existing release semantics are preserved. -->
+
+## Impact
+
+- `.goreleaser.yaml`: Build matrix gains darwin + explicit goarch; deprecated
+  `format` key updated to `formats`.
+- `.github/workflows/release.yml`: New steps for GitHub App token generation
+  and Formula publishing to the tap repo.
+- `docs/INSTALLATION.md`: Gains Homebrew and `go install` sections.
+- `CHANGELOG.md`: New entries under Unreleased.
+- `complytime/homebrew-tap` repository: Needs a `Formula/` directory; the
+  GitHub App must have Contents:write access to this repo.
+- No runtime behavior changes to complyctl itself.

--- a/openspec/changes/homebrew-formula-and-go-install/specs/go-install/spec.md
+++ b/openspec/changes/homebrew-formula-and-go-install/specs/go-install/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: go install produces working binary
+The module path `github.com/complytime/complyctl/cmd/complyctl` SHALL be
+installable via `go install ...@latest` and produce a functional complyctl
+binary.
+
+#### Scenario: Install latest
+- **WHEN** user runs `go install github.com/complytime/complyctl/cmd/complyctl@latest`
+- **THEN** a `complyctl` binary is placed in `$GOPATH/bin` (or `$GOBIN`) and
+  runs successfully
+
+#### Scenario: Install specific version
+- **WHEN** user runs `go install github.com/complytime/complyctl/cmd/complyctl@v1.2.3`
+- **THEN** the installed binary corresponds to the tagged version
+
+### Requirement: Version output indicates devel for go install
+When installed via `go install` without custom ldflags, the version output
+SHALL indicate a development build rather than showing empty or misleading
+version information.
+
+#### Scenario: Default go install version string
+- **WHEN** user installs via `go install ...@latest` without passing ldflags
+- **THEN** `complyctl version` shows `(devel)` or the module version from
+  Go's build info (not an empty string)
+
+### Requirement: go install is documented
+The `docs/INSTALLATION.md` file SHALL include a section documenting the
+`go install` command and noting that version information will show `(devel)`.
+
+#### Scenario: Documentation present
+- **WHEN** user opens `docs/INSTALLATION.md`
+- **THEN** there is a "go install" section with the exact command and a note
+  about version behavior

--- a/openspec/changes/homebrew-formula-and-go-install/specs/homebrew-formula/spec.md
+++ b/openspec/changes/homebrew-formula-and-go-install/specs/homebrew-formula/spec.md
@@ -41,7 +41,7 @@ GoReleaser completes successfully.
 
 ### Requirement: Formula authentication uses GitHub App
 The workflow SHALL mint a short-lived token via `actions/create-github-app-token`
-using org secrets `APP_ID` and `PRIVATE_KEY` to push to the tap repository.
+using org secrets `APP_ID_HOMEBREW_FORMULA_PUBLISHER` and `PRIVATE_KEY_APP_HOMEBREW_FORMULA_PUBLISHER` to push to the tap repository.
 The token MUST be scoped to the `homebrew-tap` repository only.
 
 #### Scenario: Token generation

--- a/openspec/changes/homebrew-formula-and-go-install/specs/homebrew-formula/spec.md
+++ b/openspec/changes/homebrew-formula-and-go-install/specs/homebrew-formula/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: Formula installs complyctl from source
+The release workflow SHALL generate a Homebrew Formula that builds complyctl
+from the tagged source tarball using `go build` with the project's standard
+ldflags (version, buildDate).
+
+#### Scenario: Successful brew install
+- **WHEN** user runs `brew install complytime/tap/complyctl`
+- **THEN** Homebrew downloads the source tarball, compiles with Go, and places
+  the `complyctl` binary in the Homebrew bin directory
+
+#### Scenario: Version output matches release tag
+- **WHEN** user runs `complyctl version` after installing via Homebrew
+- **THEN** the Version field MUST contain the release version (e.g., "1.2.3")
+
+### Requirement: Formula installs shell completions
+The Formula SHALL generate and install shell completions for Bash, Zsh, and
+Fish using `generate_completions_from_executable(bin/"complyctl", "completion")`.
+
+#### Scenario: Zsh completion available
+- **WHEN** user installs complyctl via Homebrew on a system with Zsh
+- **THEN** `complyctl <TAB>` provides subcommand completions without additional
+  configuration
+
+### Requirement: Formula is published automatically on release
+The release workflow SHALL push an updated Formula to
+`complytime/homebrew-tap` (branch: main, path: `Formula/complyctl.rb`) after
+GoReleaser completes successfully.
+
+#### Scenario: First release with Homebrew
+- **WHEN** maintainer triggers the release workflow for a new tag
+- **THEN** a commit is pushed to `complytime/homebrew-tap` containing
+  `Formula/complyctl.rb` with the correct url and sha256 for the tagged source
+  tarball
+
+#### Scenario: Subsequent release updates existing Formula
+- **WHEN** maintainer triggers the release workflow for a newer tag
+- **THEN** the existing `Formula/complyctl.rb` in the tap is overwritten with
+  updated url and sha256 values
+
+### Requirement: Formula authentication uses GitHub App
+The workflow SHALL mint a short-lived token via `actions/create-github-app-token`
+using org secrets `APP_ID` and `PRIVATE_KEY` to push to the tap repository.
+The token MUST be scoped to the `homebrew-tap` repository only.
+
+#### Scenario: Token generation
+- **WHEN** the release job reaches the "Generate Homebrew tap token" step
+- **THEN** a token is created with Contents:write access to `complytime/homebrew-tap`
+
+#### Scenario: Token not available
+- **WHEN** the GitHub App does not have access to `homebrew-tap`
+- **THEN** the push step fails with a clear authentication error (non-silent
+  failure)
+
+### Requirement: No macOS signing or Gatekeeper workaround needed
+Because the Formula builds from source on the user's machine, the installed
+binary SHALL NOT be subject to Gatekeeper quarantine. No `xattr` removal, code
+signing, or notarization is required.
+
+#### Scenario: Unsigned binary runs without warning
+- **WHEN** user installs via `brew install complytime/tap/complyctl` and runs
+  `complyctl version`
+- **THEN** macOS does not display any Gatekeeper warning or quarantine dialog

--- a/openspec/changes/homebrew-formula-and-go-install/specs/macos-binaries/spec.md
+++ b/openspec/changes/homebrew-formula-and-go-install/specs/macos-binaries/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: macOS binaries included in release archives
+GoReleaser SHALL produce release archives for darwin/amd64 and darwin/arm64
+in addition to existing linux builds. Archives MUST use tar.gz format.
+
+#### Scenario: Release contains macOS archives
+- **WHEN** maintainer triggers the release workflow
+- **THEN** the GitHub Release page includes downloadable archives named
+  `complyctl_darwin_x86_64.tar.gz` and `complyctl_darwin_arm64.tar.gz`
+
+#### Scenario: macOS binary is functional
+- **WHEN** user downloads and extracts the darwin/arm64 archive on an Apple
+  Silicon Mac
+- **THEN** the `complyctl` binary executes and `complyctl version` outputs
+  version information
+
+### Requirement: CGO disabled for cross-compilation
+All builds (including darwin) SHALL set `CGO_ENABLED=0` to ensure static
+linking and reliable cross-compilation without a macOS SDK.
+
+#### Scenario: Static binary
+- **WHEN** GoReleaser builds the darwin/arm64 target on an ubuntu runner
+- **THEN** the resulting binary has no dynamic library dependencies and runs
+  on macOS without additional shared libraries
+
+### Requirement: Archive naming follows uname convention
+Archive names SHALL use the existing name template that maps architecture
+identifiers to `uname`-compatible names (amd64 → x86_64).
+
+#### Scenario: Consistent naming
+- **WHEN** a release is created
+- **THEN** the darwin/amd64 archive is named `complyctl_darwin_x86_64.tar.gz`
+  (not `complyctl_darwin_amd64.tar.gz`)

--- a/openspec/changes/homebrew-formula-and-go-install/tasks.md
+++ b/openspec/changes/homebrew-formula-and-go-install/tasks.md
@@ -7,7 +7,7 @@
 
 ## 2. Release Workflow — Homebrew Publishing
 
-- [x] 2.1 Add "Generate Homebrew tap token" step using `actions/create-github-app-token` with `APP_ID`/`PRIVATE_KEY` secrets, scoped to `homebrew-tap`
+- [x] 2.1 Add "Generate Homebrew tap token" step using `actions/create-github-app-token` with `APP_ID_HOMEBREW_FORMULA_PUBLISHER`/`PRIVATE_KEY_APP_HOMEBREW_FORMULA_PUBLISHER` secrets, scoped to `homebrew-tap`
 - [x] 2.2 Add "Publish Homebrew formula" step that computes source tarball SHA256, templates the Formula, and pushes to `complytime/homebrew-tap` repo
 - [x] 2.3 Verify Formula Ruby uses `std_go_args(ldflags:)` with version, buildDate, and gitTreeState=clean (no commit)
 - [x] 2.4 Verify Formula includes `generate_completions_from_executable(bin/"complyctl", "completion")`

--- a/openspec/changes/homebrew-formula-and-go-install/tasks.md
+++ b/openspec/changes/homebrew-formula-and-go-install/tasks.md
@@ -1,0 +1,27 @@
+## 1. GoReleaser Configuration
+
+- [x] 1.1 Add `darwin` to `goos` list in `.goreleaser.yaml`
+- [x] 1.2 Add explicit `goarch` entries: `amd64`, `arm64`
+- [x] 1.3 Update deprecated `format: tar.gz` to `formats: [tar.gz]`
+- [x] 1.4 Validate with `goreleaser check` (zero warnings)
+
+## 2. Release Workflow — Homebrew Publishing
+
+- [x] 2.1 Add "Generate Homebrew tap token" step using `actions/create-github-app-token` with `APP_ID`/`PRIVATE_KEY` secrets, scoped to `homebrew-tap`
+- [x] 2.2 Add "Publish Homebrew formula" step that computes source tarball SHA256, templates the Formula, and pushes to `complytime/homebrew-tap` repo
+- [x] 2.3 Verify Formula Ruby uses `std_go_args(ldflags:)` with version, buildDate, and gitTreeState=clean (no commit)
+- [x] 2.4 Verify Formula includes `generate_completions_from_executable(bin/"complyctl", "completion")`
+- [x] 2.5 Verify Formula includes a `test` block asserting version output
+
+## 3. Documentation
+
+- [x] 3.1 Add "Homebrew (macOS / Linux)" section to `docs/INSTALLATION.md` with `brew install complytime/tap/complyctl`
+- [x] 3.2 Add "go install" section to `docs/INSTALLATION.md` with the `go install` command and devel-version note
+- [x] 3.3 Add CHANGELOG entries under Unreleased/Added for macOS binaries, Homebrew formula, and `go install`
+
+## 4. Pre-merge Verification
+
+- [x] 4.1 Run `goreleaser check` — must pass clean
+- [x] 4.2 Run `goreleaser release --snapshot --clean` — verify darwin archives are produced
+- [ ] 4.3 Confirm GitHub App has Contents:write on `homebrew-tap` (admin check)
+- [x] 4.4 Confirm `complytime/homebrew-tap` repo has `Formula/` directory or that the workflow creates it via `mkdir -p`

--- a/tests/homebrew_test.sh
+++ b/tests/homebrew_test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Verify the Homebrew formula builds and installs complyctl from
+# the current branch. Requires Homebrew (brew) on the host.
+#
+# Uses a local tap (homebrew-complyctl-test) because Homebrew
+# rejects standalone .rb files outside of taps.
+#
+# Run locally:  make test-homebrew
+# Run directly: ./tests/homebrew_test.sh [branch]
+
+set -euo pipefail
+
+# Fail early if brew is not available (the Makefile also checks,
+# but this script can be invoked directly).
+if ! command -v brew >/dev/null 2>&1; then
+    echo "ERROR: brew not found. Install Homebrew first: https://brew.sh"
+    exit 1
+fi
+
+BRANCH="${1:-$(git rev-parse --abbrev-ref HEAD)}"
+TAP_NAME="complyctl-test/test"
+
+# Validate branch name to prevent injection into Ruby heredoc.
+if [[ ! "${BRANCH}" =~ ^[a-zA-Z0-9/_.-]+$ ]]; then
+    echo "ERROR: Branch name '${BRANCH}' contains unsupported characters"
+    exit 1
+fi
+
+# Resolve the git remote URL for the current branch so we clone from
+# the correct fork (not always upstream where the branch may not exist).
+TRACKING_REMOTE="$(git config "branch.${BRANCH}.remote" 2>/dev/null || echo "origin")"
+REPO_URL="$(git remote get-url "${TRACKING_REMOTE}" 2>/dev/null || git remote get-url origin)"
+# Ensure HTTPS URL for Homebrew (it does not support git@ SSH URLs).
+REPO_URL="${REPO_URL/git@github.com:/https://github.com/}"
+REPO_URL="${REPO_URL%.git}.git"
+
+# Warn if complyctl is already installed via Homebrew.
+if brew list complyctl &>/dev/null; then
+    echo "WARNING: complyctl is already installed via Homebrew."
+    echo "This test will uninstall it. Re-install after with: brew install complytime/tap/complyctl"
+fi
+
+cleanup() {
+    brew uninstall complyctl 2>/dev/null || true
+    brew cleanup complyctl 2>/dev/null || true
+    brew untap "${TAP_NAME}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Create a local tap with the Formula.
+TAP_DIR="$(brew --repository)/Library/Taps/complyctl-test/homebrew-test"
+mkdir -p "${TAP_DIR}/Formula"
+
+# Initialize a git repo in the tap (Homebrew requires taps to be git repos).
+if [ ! -d "${TAP_DIR}/.git" ]; then
+    git -C "${TAP_DIR}" init -q
+fi
+
+cat > "${TAP_DIR}/Formula/complyctl.rb" <<RUBY
+class Complyctl < Formula
+  desc "CLI for streamlining end-to-end compliance workflows"
+  homepage "https://github.com/complytime/complyctl"
+  head "${REPO_URL}", branch: "${BRANCH}"
+  license "Apache-2.0"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[
+      -X github.com/complytime/complyctl/internal/version.version=test
+      -X github.com/complytime/complyctl/internal/version.buildDate=#{time.iso8601}
+      -X github.com/complytime/complyctl/internal/version.gitTreeState=clean
+    ]
+    system "go", "build", *std_go_args(ldflags:), "./cmd/complyctl"
+    generate_completions_from_executable(bin/"complyctl", "completion")
+  end
+
+  test do
+    assert_match "Version:", shell_output("#{bin}/complyctl version 2>&1")
+  end
+end
+RUBY
+
+# Commit the formula so Homebrew recognizes the tap.
+git -C "${TAP_DIR}" add -A
+git -C "${TAP_DIR}" commit -q -m "add complyctl formula" --allow-empty 2>/dev/null || true
+
+echo "=== Installing complyctl from branch '${BRANCH}' via Homebrew ==="
+HOMEBREW_NO_AUTO_UPDATE=1 brew install --HEAD "${TAP_NAME}/complyctl"
+
+echo "=== Verifying installation ==="
+VERSION_OUTPUT="$(complyctl version 2>/dev/null)"
+echo "${VERSION_OUTPUT}"
+if ! echo "${VERSION_OUTPUT}" | grep -q "Version:"; then
+    echo "FAIL: version output does not contain version information"
+    exit 1
+fi
+
+echo "=== Running brew test ==="
+brew test complyctl
+
+echo "=== PASS: Homebrew formula validated successfully ==="


### PR DESCRIPTION
## Summary

Add a source-build Homebrew Formula and macOS binary releases for complyctl.

Changes:
- Add darwin/amd64 and darwin/arm64 to the GoReleaser build matrix
- Add a "Publish Homebrew formula" step to the release workflow that
  generates a source-build Formula and pushes it to `complytime/homebrew-tap`
- Mint a short-lived GitHub App token via `actions/create-github-app-token`
  for cross-repo push (uses existing `APP_ID`/`PRIVATE_KEY` secrets)
- Fix deprecated `archives.format` → `formats` (GoReleaser v2)
- Document Homebrew and `go install` as installation methods
- Include OpenSpec artifacts documenting the architectural decisions

After merge, users install with:

```bash
brew install complytime/tap/complyctl
```

The Formula builds from source on the user's machine (Homebrew auto-installs
Go). This avoids macOS Gatekeeper/signing entirely — no Apple Developer
certificate, no `xattr` workaround needed.

## Related Issues

- Closes #713

## Review Hints

- The key design decision (Formula vs Cask) is documented in
  `openspec/changes/homebrew-formula-and-go-install/design.md` — start there
  for context on why source-build was chosen over pre-built binary distribution.

- The release workflow's "Publish Homebrew formula" step uses a heredoc to
  template the Ruby Formula file. The YAML indentation is handled by the `|`
  block scalar (18 spaces stripped by YAML, leaving correct Ruby formatting).

**Test results:**

- [x] `goreleaser check` passes clean (zero deprecation warnings)
- [x] `goreleaser release --snapshot --clean` produces all 4 archives
      (darwin/amd64, darwin/arm64, linux/amd64, linux/arm64)
- [x] darwin/arm64 binary runs locally (`complyctl version` reports correct metadata)
- [x] `complyctl completion {bash,zsh,fish}` generates completions successfully
- [ ] CI passes on this PR
- [ ] First release after merge publishes formula to `complytime/homebrew-tap`

> [!IMPORTANT]
> **Admin pre-merge checklist:**
> - [ ] Verify the GitHub App (`APP_ID`/`PRIVATE_KEY`) has `Contents: write`
>   permission on the `homebrew-tap` repository
> - [ ] If the App installation is scoped to specific repos (not all org repos),
>   add `homebrew-tap` to the list
