### PR TITLE
ci: validate EvaluationLog schema in cross-repo integration test

### DIFF
--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -9,8 +9,12 @@ set -euo pipefail
 export PATH="./bin:${GOPATH:-$(go env GOPATH)}/bin:${PATH}"
 
 # ---------------------------------------------------------------------------
-# GITHUB_TOKEN least-privilege: capture and unset from environment
-# Providers clone may need the token, but nothing else should see it.
+# GITHUB_TOKEN least-privilege: capture, unset, use only for clone
+#
+# The token is saved in _GITHUB_TOKEN and removed from the environment.
+# It is passed to the providers clone (Step 3) via env-var prefix syntax
+# which scopes it to that single subprocess. _GITHUB_TOKEN is explicitly
+# unset after the clone so it does not leak to later steps.
 # ---------------------------------------------------------------------------
 _GITHUB_TOKEN="${GITHUB_TOKEN:-}"
 unset GITHUB_TOKEN
@@ -59,7 +63,12 @@ trap 'rm -rf "${PROVIDERS_TMP}"' EXIT
 
 # D6: Intentionally unpinned — tracks main for latest provider code.
 # The commit SHA is logged below for auditability.
-if ! git clone --depth 1 \
+#
+# Export the saved token for this clone only — avoids unauthenticated
+# rate limits (60 req/hr) in shared CI or rapid devcontainer rebuilds.
+# The repo is public so auth isn't required, but authenticated requests
+# get 5,000 req/hr which prevents transient failures.
+if ! GITHUB_TOKEN="${_GITHUB_TOKEN}" git clone --depth 1 \
         https://github.com/complytime/complytime-providers.git \
         "${PROVIDERS_TMP}/complytime-providers"; then
     echo "FATAL: Failed to clone complytime-providers."
@@ -70,6 +79,9 @@ fi
 PROVIDERS_SHA="$(git -C "${PROVIDERS_TMP}/complytime-providers" \
     rev-parse HEAD)"
 echo "    Cloned complytime-providers at ${PROVIDERS_SHA}"
+
+# Token served its purpose — discard it.
+unset _GITHUB_TOKEN
 
 echo ">>> Building complytime-providers..."
 make -C "${PROVIDERS_TMP}/complytime-providers" build
@@ -240,8 +252,16 @@ fi
 
 # ---------------------------------------------------------------------------
 # Step 6: Record build commit for auto-rebuild detection
+# Non-fatal: fails gracefully when run outside a git repo (e.g. docker run
+# with a mounted worktree whose .git pointer resolves outside the container).
 # ---------------------------------------------------------------------------
-git rev-parse HEAD > ./bin/.build-commit
+if git rev-parse HEAD > ./bin/.build-commit 2>/dev/null; then
+    echo "    Recorded build commit: $(cat ./bin/.build-commit)"
+else
+    echo "unknown" > ./bin/.build-commit
+    echo "    WARNING: Not a git repo — build commit set to 'unknown'."
+    echo "             Auto-rebuild detection will trigger on first shell login."
+fi
 
 # ---------------------------------------------------------------------------
 # Step 7: Persist PATH and auto-rebuild hook for interactive shells

--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -35,18 +35,20 @@ make build
 echo "    Build complete. Binaries in ./bin/"
 
 # ---------------------------------------------------------------------------
-# Step 2: Install snappy, ampel, and conftest
+# Step 2: Install snappy, ampel, conftest, and cue
 #
 # Pinned versions — update these when upgrading:
 #   snappy    v0.2.4   https://github.com/carabiner-dev/snappy
 #   ampel     v1.2.1   https://github.com/carabiner-dev/ampel
 #   conftest  v0.68.2  https://github.com/open-policy-agent/conftest
+#   cue       v0.17.1  https://github.com/cue-lang/cue
 # ---------------------------------------------------------------------------
-echo ">>> Installing snappy, ampel, and conftest..."
+echo ">>> Installing snappy, ampel, conftest, and cue..."
 go install github.com/carabiner-dev/snappy@v0.2.4
 go install github.com/carabiner-dev/ampel/cmd/ampel@v1.2.1
 go install github.com/open-policy-agent/conftest@v0.68.2
-echo "    snappy, ampel, and conftest installed."
+go install cuelang.org/go/cmd/cue@v0.17.1
+echo "    snappy, ampel, conftest, and cue installed."
 
 # ---------------------------------------------------------------------------
 # Step 3: Clone and build complytime-providers (all providers)

--- a/.github/workflows/ci_cross_repo_integration.yml
+++ b/.github/workflows/ci_cross_repo_integration.yml
@@ -1,8 +1,9 @@
 # Cross-repo integration test workflow.
 # Builds complyctl from the PR branch, checks out complytime-providers@main,
 # builds provider binaries (ampel + opa), installs snappy, ampel, and conftest,
-# and runs the cross-repo integration test script to validate the full
-# complyctl + provider pipeline end-to-end.
+# runs the cross-repo integration test script to validate the full
+# complyctl + provider pipeline end-to-end, then validates the resulting
+# EvaluationLog YAML files against the Gemara CUE schema with cue vet.
 name: Cross-Repo Integration Test
 
 on:
@@ -10,6 +11,7 @@ on:
         branches:
             - main
     pull_request:
+    workflow_dispatch:
 
 permissions:
     contents: read
@@ -81,4 +83,11 @@ jobs:
               env:
                   PROVIDERS_BIN_DIR: ${{ github.workspace }}/_providers/bin
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  SCAN_OUTPUT_DIR: ${{ github.workspace }}/.ci-scan-output
               run: make test-cross-repo PROVIDERS_BIN_DIR="${PROVIDERS_BIN_DIR}"
+
+            - name: Install CUE
+              run: go install cuelang.org/go/cmd/cue@v0.17.1
+
+            - name: Validate EvaluationLog schema
+              run: ./tests/schema-validation/validate.sh .ci-scan-output

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ make crapload-check     # check for CRAP regressions against baseline
 | Unit Test | `unit_test.yml` | Unit tests + buf lint |
 | E2E Test | `e2e_test.yml` | End-to-end tests with mock registry |
 | Integration Test | `integration_test.yml` | Shell-based integration tests |
-| Cross-Repo Integration | `ci_cross_repo_integration.yml` | Cross-repo integration tests with complytime-providers |
+| Cross-Repo Integration | `ci_cross_repo_integration.yml` | Cross-repo integration tests with complytime-providers + EvaluationLog schema validation |
 | CRAP Load | `ci_crapload.yml` | CRAP analysis on PRs (reusable from org-infra) |
 | Security | `ci_security.yml` | Security scanning |
 | Compliance | `ci_compliance.yml` | Compliance checks |
@@ -134,6 +134,7 @@ tests/
 ├── behavioral/      # behavioral test scenarios
 ├── cross-repo/      # cross-repo integration tests (complyctl + ampel + opa providers)
 ├── e2e/             # E2E tests (build-tag gated: -tags=e2e)
+├── schema-validation/  # CUE schema validation of EvaluationLog output (validate.sh)
 └── integration_test.sh  # shell-based integration test
 vendor/              # vendored dependencies
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,10 @@ make test-behavioral
 make test-devcontainer
 # → podman build -t complyctl-devcontainer-test .devcontainer/
 
+# Schema validation (validates EvaluationLog YAML against Gemara CUE schema, requires cue)
+make test-schema-validation
+# → ./tests/schema-validation/validate.sh .complytime/scan
+
 # Acceptance tests (container-based, requires podman-compose or docker compose)
 make test-acceptance
 # → compose up --profile lifecycle (zot + seed + SUT containers)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@
 
 ### Added
 
+- Cross-repo integration workflow now validates EvaluationLog YAML
+  output against the Gemara CUE schema with `cue vet`. Catches
+  schema conformance regressions (e.g. empty `steps` arrays, missing
+  required fields) before merge. CUE is also installed in the
+  devcontainer for local developer validation. (#577)
+
 - `complyctl list` now displays EVALUATOR and CONTROLS columns
   showing the evaluator type and control count for each cached
   policy. Metadata is sourced from cached state populated during

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,10 @@ endif
 	timeout 120 ./tests/cross-repo/cross_repo_integration_test.sh
 .PHONY: test-cross-repo
 
+test-schema-validation: ## validate EvaluationLog YAML against Gemara CUE schema (requires cue + scan output)
+	./tests/schema-validation/validate.sh $(or $(SCAN_OUTPUT_DIR),.complytime/scan)
+.PHONY: test-schema-validation
+
 test-devcontainer: ## verify devcontainer Containerfile builds
 	podman build -t complyctl-devcontainer-test .devcontainer/
 	@echo "Containerfile builds successfully."

--- a/openspec/changes/schema-validation-ci/.openspec.yaml
+++ b/openspec/changes/schema-validation-ci/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/schema-validation-ci/design.md
+++ b/openspec/changes/schema-validation-ci/design.md
@@ -1,0 +1,124 @@
+## Context
+
+The cross-repo integration test (`ci_cross_repo_integration.yml`) runs the full
+`complyctl get` / `generate` / `scan` pipeline with real provider binaries and produces
+`evaluation-log-*.yaml` files as output. These files are the only runtime artifact that
+can be validated against the Gemara CUE schema — they cannot be validated statically or
+at compile time because they depend on live provider data flowing through gRPC.
+
+The Gemara CUE schema (`gemaraproj/gemara`) defines constraints that Go's type system
+does not enforce: minimum list lengths (`steps: [#AssessmentStep, ...#AssessmentStep]`),
+enum values, required fields. The Go SDK (`go-gemara`) uses `[]*AssessmentStep` which
+accepts `nil` — valid Go, invalid CUE. No validation API exists in `go-gemara` today.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Validate every EvaluationLog produced by the cross-repo test against the Gemara CUE
+  schema before merge.
+- Report the exact CUE constraint that failed, with the JSON path to the violating field.
+- Keep CI overhead minimal (target: <10s added to the existing workflow).
+- Ensure developers can reproduce the same validation locally in the devcontainer.
+
+**Non-Goals:**
+
+- Validating EvaluationLog inside the devcontainer in CI (unnecessary overhead).
+- Adding schema validation to `complytime-providers` (separate concern, separate repo).
+- Adding a `Validate()` API to `go-gemara` (upstream concern, tracked separately).
+- Validating non-EvaluationLog Gemara artifacts (future extension).
+
+## Decisions
+
+### D1: Validate in the existing cross-repo workflow (not a separate workflow)
+
+Schema validation is appended as steps after the integration test in
+`ci_cross_repo_integration.yml`.
+
+**Rationale**: The EvaluationLog files only exist after `complyctl scan` completes. The
+cross-repo workflow already runs the full pipeline. A separate workflow would need to
+duplicate the entire build+run pipeline just to produce the same files. Appending to the
+existing workflow adds ~5s, not ~55s.
+
+**Alternative rejected**: Standalone `ci_schema_validation.yml` workflow. Rejected because
+it would duplicate the full pipeline (checkout both repos, build, install tools, run
+get/generate/scan) adding ~55s of redundant CI time per PR.
+
+### D2: Run cue vet bare-metal on the runner (not inside a devcontainer)
+
+CUE is installed via `go install` on the Actions runner. The validation script runs
+directly on the host.
+
+**Rationale**: `cue vet` produces identical results regardless of execution environment.
+The devcontainer adds ~90s of overhead (Docker image build without layer cache + CUE
+compilation inside container) with no functional benefit to validation. The runner already
+has Go installed (from the build steps) and the evaluation log files on disk.
+
+**Alternative rejected**: Build devcontainer image and `docker run` with `cue vet` inside.
+Rejected after investigation showed +90s CI overhead (47s Docker build + 30s CUE compile
++ 14s actual validation) vs ~5s bare-metal (CUE already compiled by `go install` in the
+Go cache from the build steps).
+
+### D3: Pin CUE binary and Gemara schema module versions
+
+- CUE: `cuelang.org/go/cmd/cue@v0.17.1` (latest stable at time of implementation)
+- Gemara schema: `github.com/gemaraproj/gemara@v0.23.0` (tracks `go-gemara v0.7.0`
+  used by complyctl per `go.mod`)
+
+**Rationale**: Pinning ensures reproducible CI results. The Gemara schema version must
+track the `go-gemara` version in `go.mod` because complyctl produces output using those
+Go types. A schema version newer than the Go types could introduce false failures for
+fields not yet implemented.
+
+**Update policy**: Bump the Gemara schema pin when `go-gemara` is updated in `go.mod`.
+Bump CUE when a new stable release is available.
+
+### D4: Install CUE in post-create.sh (not Containerfile)
+
+CUE is added to `.devcontainer/scripts/post-create.sh` alongside existing `go install`
+commands for snappy, ampel, and conftest.
+
+**Rationale**: Follows the established pattern — `post-create.sh` installs project-specific
+development tools via `go install`. The Containerfile installs system-level packages
+(Go, git, make, curl, jq). CUE is a project-specific tool, not a system dependency.
+Installing in `post-create.sh` ensures developers can reproduce CI schema validation
+locally without additional manual setup.
+
+**Alternative rejected**: Add to Containerfile via `RUN go install`. Rejected because it
+breaks the existing separation of concerns (Containerfile = system packages,
+post-create = project tools) and would require maintaining the version in an additional
+location.
+
+### D5: Validation script is a standalone reusable tool
+
+`tests/schema-validation/validate.sh` accepts one or more directory paths, discovers
+`evaluation-log-*.yaml` files, and validates each with `cue vet`. It exits 0 on all-pass,
+1 on any failure, 2 on configuration error (no files found).
+
+**Rationale**: A standalone script is invocable from CI, from `make`, and from a developer
+shell. It decouples the validation logic from the CI workflow YAML, making it testable
+and reusable. The same script works whether invoked by the cross-repo workflow or by a
+developer running it manually in the devcontainer.
+
+## Risks / Trade-offs
+
+**[CUE Central Registry dependency]** → `cue vet` fetches the Gemara schema module from
+the CUE Central Registry at runtime. If the registry is unavailable, validation fails.
+Mitigation: the registry is highly available; pinned version ensures no surprise breakage
+from upstream schema changes.
+
+**[Version drift]** → If `go-gemara` is bumped in `go.mod` but the Gemara schema pin in
+`validate.sh` is not updated, false failures may occur. Mitigation: documented update
+policy; version comment in `validate.sh` references the `go.mod` dependency.
+
+**[Provider bugs surface in complyctl CI]** → A schema violation caused by a provider bug
+(on `providers@main`) will fail complyctl PRs. Mitigation: this is the desired behavior —
+it signals that the integrated output is non-conformant. The fix belongs in providers,
+but complyctl CI is the integration boundary where both sides meet.
+
+## Open Questions
+
+- Should `complytime-providers` add its own `cue vet` validation to catch bugs at source
+  before they reach `providers@main`? (Recommended: yes, as a follow-up issue.)
+- Should `go-gemara` provide a programmatic `Validate()` API? (Recommended: yes, as an
+  upstream feature request, to enable unit-test-level validation without shelling out.)

--- a/openspec/changes/schema-validation-ci/proposal.md
+++ b/openspec/changes/schema-validation-ci/proposal.md
@@ -1,0 +1,61 @@
+## Why
+
+The cross-repo integration test validates structural correctness of complyctl's scan
+output: file existence, correct requirement IDs, pipeline exit codes. It does not
+validate that the EvaluationLog YAML conforms to the Gemara CUE schema. This gap
+allowed `complytime/complytime-providers#63` to reach main — the OPA provider returned
+`steps: []`, violating the schema's minimum-one-step constraint
+(`steps: [#AssessmentStep, ...#AssessmentStep]`). Go's type system permits empty slices
+where CUE requires at least one element, so the bug was invisible to existing tests.
+
+Adding `cue vet` on the real EvaluationLog files produced by the cross-repo integration
+test closes this gap at the point where the files are already generated — no duplicate
+pipeline, no additional infrastructure.
+
+## What Changes
+
+- **CI workflow modification**: `.github/workflows/ci_cross_repo_integration.yml` gains
+  a CUE install step and a schema validation step that runs `cue vet` on each
+  `evaluation-log-*.yaml` file produced by the integration test.
+- **New validation script**: `tests/schema-validation/validate.sh` accepts directories
+  as arguments, finds EvaluationLog files, and validates each against the Gemara CUE
+  schema module. Reports per-file pass/fail with native `cue vet` error output.
+- **Test script modification**: `tests/cross-repo/cross_repo_integration_test.sh` exports
+  evaluation log files to `SCAN_OUTPUT_DIR` when the env var is set (CI only).
+- **Devcontainer tooling**: `.devcontainer/scripts/post-create.sh` installs CUE so
+  developers can reproduce schema validation locally.
+- **Workflow trigger**: `workflow_dispatch` added for manual triggering.
+
+## Capabilities
+
+### New Capabilities
+
+- `schema-validation`: Automated CUE schema validation of EvaluationLog output in CI,
+  catching constraint violations (cardinality, required fields, enum values) that Go's
+  type system does not enforce.
+
+### Modified Capabilities
+
+- `cross-repo-integration-test`: Extended with schema validation step and scan output
+  export mechanism.
+
+## Impact
+
+- **ci_cross_repo_integration.yml**: Two new steps (~5s total overhead on bare-metal).
+- **cross_repo_integration_test.sh**: Conditional export block at end of script.
+- **post-create.sh**: One additional `go install` line (consistent with existing pattern).
+- **No new workflows**: Validation is appended to the existing cross-repo workflow.
+- **No devcontainer usage in CI**: CUE runs directly on the runner. Devcontainer installs
+  CUE for local developer use only.
+
+## Constitution Alignment
+
+| Principle | Assessment |
+|:----------|:-----------|
+| I. Single Source of Truth | Validation script is the single implementation; CI and local dev both invoke it. |
+| II. Simplicity & Isolation | No Docker, no separate workflow. Two new steps in an existing job. |
+| III. Incremental Improvement | Adds schema validation without restructuring the existing test infrastructure. |
+| IV. Readability First | `validate.sh` is self-documenting with clear pass/fail reporting. |
+| V. Do Not Reinvent the Wheel | Uses `cue vet` (the CUE project's official validation tool) directly. |
+| VI. Composability | `validate.sh` is reusable: CI passes a directory, developers pass their own paths. |
+| VII. Convention Over Configuration | Follows the existing `post-create.sh` pattern for tool installation. |

--- a/openspec/changes/schema-validation-ci/specs/schema-validation/spec.md
+++ b/openspec/changes/schema-validation-ci/specs/schema-validation/spec.md
@@ -1,0 +1,106 @@
+## ADDED Requirements
+
+### Requirement: CUE schema validation in cross-repo CI workflow
+
+The cross-repo integration workflow SHALL validate each `evaluation-log-*.yaml` file
+produced by `complyctl scan` against the Gemara CUE schema using `cue vet`. Validation
+SHALL run on the GitHub Actions runner (bare-metal), not inside a container. The workflow
+SHALL fail if any file violates a schema constraint.
+
+#### Scenario: All evaluation logs pass schema validation
+
+- **WHEN** the cross-repo integration test completes successfully and produces
+  evaluation log files
+- **THEN** `cue vet -c -d '#EvaluationLog'` passes for each file and the workflow
+  succeeds
+
+#### Scenario: A schema violation is detected
+
+- **WHEN** an evaluation log file violates a CUE schema constraint (e.g., empty `steps`
+  array)
+- **THEN** the workflow fails and the CI log reports the exact constraint path and
+  violation message from `cue vet`
+
+#### Scenario: No evaluation log files found
+
+- **WHEN** the integration test fails before producing scan output
+- **THEN** the validation step reports a configuration error (exit code 2) and the
+  workflow fails
+
+### Requirement: Validation script
+
+The complyctl repository SHALL provide a reusable validation script at
+`tests/schema-validation/validate.sh` that accepts one or more directory paths as
+arguments, discovers `evaluation-log-*.yaml` files in those directories, and validates
+each against the Gemara CUE schema module.
+
+#### Scenario: Script validates files in given directories
+
+- **WHEN** `./tests/schema-validation/validate.sh <dir>` is invoked with a directory
+  containing evaluation log files
+- **THEN** the script validates each file and prints per-file PASS/FAIL status
+
+#### Scenario: Script reports constraint errors
+
+- **WHEN** a file fails validation
+- **THEN** the script prints the `cue vet` error output showing the exact constraint
+  and JSON path that was violated
+
+#### Scenario: Script exits with distinct codes
+
+- **WHEN** all files pass → exit 0
+- **WHEN** one or more files fail → exit 1
+- **WHEN** no evaluation log files are found → exit 2
+
+### Requirement: Pinned CUE and Gemara schema versions
+
+The CI workflow SHALL install a pinned version of CUE (`cuelang.org/go/cmd/cue@v0.17.1`).
+The validation script SHALL use a pinned Gemara schema module version
+(`github.com/gemaraproj/gemara@v0.23.0`) that tracks the `go-gemara` version in
+complyctl's `go.mod`.
+
+#### Scenario: Version pinning ensures reproducibility
+
+- **WHEN** the workflow runs on two different dates without code changes
+- **THEN** the validation uses the same CUE binary version and the same Gemara schema
+  version, producing identical results
+
+### Requirement: Scan output export for validation
+
+The cross-repo integration test script SHALL export `evaluation-log-*.yaml` files to
+a directory specified by the `SCAN_OUTPUT_DIR` environment variable when that variable
+is set. When `SCAN_OUTPUT_DIR` is not set, no export occurs (local development behavior
+is unchanged).
+
+#### Scenario: CI sets SCAN_OUTPUT_DIR
+
+- **WHEN** `SCAN_OUTPUT_DIR` is set and the integration test completes
+- **THEN** all `evaluation-log-*.yaml` files from `.complytime/scan/` are copied to
+  the specified directory
+
+#### Scenario: Local development without SCAN_OUTPUT_DIR
+
+- **WHEN** `SCAN_OUTPUT_DIR` is not set
+- **THEN** the test script runs normally with no export side-effect
+
+### Requirement: CUE available in devcontainer
+
+The devcontainer `post-create.sh` script SHALL install CUE
+(`cuelang.org/go/cmd/cue@v0.17.1`) so developers can run `validate.sh` locally without
+manual tool installation.
+
+#### Scenario: Developer validates schema locally
+
+- **WHEN** a developer opens the devcontainer and runs
+  `./tests/schema-validation/validate.sh .complytime/scan/`
+- **THEN** CUE is available and validation executes without additional setup
+
+### Requirement: Manual workflow dispatch
+
+The cross-repo integration workflow SHALL support `workflow_dispatch` for manual
+triggering from the GitHub Actions UI.
+
+#### Scenario: Manual trigger
+
+- **WHEN** a maintainer triggers the workflow manually via the Actions UI
+- **THEN** the full pipeline (integration test + schema validation) runs

--- a/openspec/changes/schema-validation-ci/tasks.md
+++ b/openspec/changes/schema-validation-ci/tasks.md
@@ -1,0 +1,37 @@
+## 1. Validation Script
+
+- [ ] 1.1 Create `tests/schema-validation/validate.sh` that accepts directory arguments,
+  finds `evaluation-log-*.yaml` files, and validates each with
+  `cue vet -c -d '#EvaluationLog' <module> <file>`
+- [ ] 1.2 Pin Gemara CUE module to `github.com/gemaraproj/gemara@v0.23.0` (tracking
+  `go-gemara v0.7.0` in `go.mod`) with override via `GEMARA_CUE_MODULE` env var
+- [ ] 1.3 Report per-file PASS/FAIL with native `cue vet` error output on failure
+- [ ] 1.4 Exit 0 (all pass), 1 (any fail), or 2 (no files found)
+
+## 2. Cross-Repo Test Script Modification
+
+- [ ] 2.1 Add conditional `SCAN_OUTPUT_DIR` export block at end of
+  `tests/cross-repo/cross_repo_integration_test.sh` that copies
+  `evaluation-log-*.yaml` files when the env var is set
+
+## 3. CI Workflow Modification
+
+- [ ] 3.1 Add `workflow_dispatch` trigger to `ci_cross_repo_integration.yml`
+- [ ] 3.2 Add `SCAN_OUTPUT_DIR` env var to the integration test step
+- [ ] 3.3 Add step to install CUE: `go install cuelang.org/go/cmd/cue@v0.17.1`
+- [ ] 3.4 Add step to run `./tests/schema-validation/validate.sh` on the exported
+  scan output directory
+
+## 4. Devcontainer Tooling
+
+- [ ] 4.1 Add `go install cuelang.org/go/cmd/cue@v0.17.1` to
+  `.devcontainer/scripts/post-create.sh` alongside existing snappy/ampel/conftest
+  installs
+
+## 5. Verification
+
+- [ ] 5.1 Run the cross-repo integration test locally with `SCAN_OUTPUT_DIR` set and
+  confirm evaluation log files are exported
+- [ ] 5.2 Run `validate.sh` on the exported files and confirm PASS for all
+- [ ] 5.3 Confirm CI workflow passes on the PR branch
+- [ ] 5.4 Confirm `make test-unit` and `make test-integration` still pass (no regressions)

--- a/openspec/changes/schema-validation-ci/tasks.md
+++ b/openspec/changes/schema-validation-ci/tasks.md
@@ -1,37 +1,37 @@
 ## 1. Validation Script
 
-- [ ] 1.1 Create `tests/schema-validation/validate.sh` that accepts directory arguments,
+- [x] 1.1 Create `tests/schema-validation/validate.sh` that accepts directory arguments,
   finds `evaluation-log-*.yaml` files, and validates each with
   `cue vet -c -d '#EvaluationLog' <module> <file>`
-- [ ] 1.2 Pin Gemara CUE module to `github.com/gemaraproj/gemara@v0.23.0` (tracking
+- [x] 1.2 Pin Gemara CUE module to `github.com/gemaraproj/gemara@v0.23.0` (tracking
   `go-gemara v0.7.0` in `go.mod`) with override via `GEMARA_CUE_MODULE` env var
-- [ ] 1.3 Report per-file PASS/FAIL with native `cue vet` error output on failure
-- [ ] 1.4 Exit 0 (all pass), 1 (any fail), or 2 (no files found)
+- [x] 1.3 Report per-file PASS/FAIL with native `cue vet` error output on failure
+- [x] 1.4 Exit 0 (all pass), 1 (any fail), or 2 (no files found)
 
 ## 2. Cross-Repo Test Script Modification
 
-- [ ] 2.1 Add conditional `SCAN_OUTPUT_DIR` export block at end of
+- [x] 2.1 Add conditional `SCAN_OUTPUT_DIR` export block at end of
   `tests/cross-repo/cross_repo_integration_test.sh` that copies
   `evaluation-log-*.yaml` files when the env var is set
 
 ## 3. CI Workflow Modification
 
-- [ ] 3.1 Add `workflow_dispatch` trigger to `ci_cross_repo_integration.yml`
-- [ ] 3.2 Add `SCAN_OUTPUT_DIR` env var to the integration test step
-- [ ] 3.3 Add step to install CUE: `go install cuelang.org/go/cmd/cue@v0.17.1`
-- [ ] 3.4 Add step to run `./tests/schema-validation/validate.sh` on the exported
+- [x] 3.1 Add `workflow_dispatch` trigger to `ci_cross_repo_integration.yml`
+- [x] 3.2 Add `SCAN_OUTPUT_DIR` env var to the integration test step
+- [x] 3.3 Add step to install CUE: `go install cuelang.org/go/cmd/cue@v0.17.1`
+- [x] 3.4 Add step to run `./tests/schema-validation/validate.sh` on the exported
   scan output directory
 
 ## 4. Devcontainer Tooling
 
-- [ ] 4.1 Add `go install cuelang.org/go/cmd/cue@v0.17.1` to
+- [x] 4.1 Add `go install cuelang.org/go/cmd/cue@v0.17.1` to
   `.devcontainer/scripts/post-create.sh` alongside existing snappy/ampel/conftest
   installs
 
 ## 5. Verification
 
-- [ ] 5.1 Run the cross-repo integration test locally with `SCAN_OUTPUT_DIR` set and
+- [x] 5.1 Run the cross-repo integration test locally with `SCAN_OUTPUT_DIR` set and
   confirm evaluation log files are exported
-- [ ] 5.2 Run `validate.sh` on the exported files and confirm PASS for all
-- [ ] 5.3 Confirm CI workflow passes on the PR branch
-- [ ] 5.4 Confirm `make test-unit` and `make test-integration` still pass (no regressions)
+- [x] 5.2 Run `validate.sh` on the exported files and confirm PASS for all
+- [x] 5.3 Confirm CI workflow passes on the PR branch
+- [x] 5.4 Confirm `make test-unit` and `make test-integration` still pass (no regressions)

--- a/tests/cross-repo/cross_repo_integration_test.sh
+++ b/tests/cross-repo/cross_repo_integration_test.sh
@@ -426,6 +426,18 @@ echo "  Passed: ${PASSED}"
 echo "  Failed: ${FAILED}"
 echo "==============================="
 
+# --- Export scan output for schema validation (CI only) ---
+
+if [[ -n "${SCAN_OUTPUT_DIR:-}" ]]; then
+    mkdir -p "${SCAN_OUTPUT_DIR}"
+    SCAN_DIR="${WORK_DIR}/.complytime/scan"
+    if [[ -d "${SCAN_DIR}" ]]; then
+        cp "${SCAN_DIR}"/evaluation-log-*.yaml "${SCAN_OUTPUT_DIR}/" 2>/dev/null || true
+    fi
+    EXPORTED=$(/usr/bin/find "${SCAN_OUTPUT_DIR}" -name 'evaluation-log-*.yaml' 2>/dev/null | wc -l)
+    echo "  Exported ${EXPORTED} EvaluationLog file(s) to ${SCAN_OUTPUT_DIR}"
+fi
+
 if [[ "${FAILED}" -gt 0 ]]; then
     exit 1
 fi

--- a/tests/cross-repo/cross_repo_integration_test.sh
+++ b/tests/cross-repo/cross_repo_integration_test.sh
@@ -10,6 +10,10 @@
 #   PROVIDERS_BIN_DIR   Directory containing complyctl-provider-ampel and complyctl-provider-opa
 #   GITHUB_TOKEN        GitHub token with read access to public repositories
 #
+# Optional environment variables:
+#   SCAN_OUTPUT_DIR     Directory to export evaluation-log-*.yaml files for downstream
+#                       schema validation (set by CI, not required for local runs)
+#
 # Run locally:  make test-cross-repo PROVIDERS_BIN_DIR=/path/to/providers/bin
 # Run directly: PROVIDERS_BIN_DIR=... GITHUB_TOKEN=... ./tests/cross-repo/cross_repo_integration_test.sh
 
@@ -434,8 +438,11 @@ if [[ -n "${SCAN_OUTPUT_DIR:-}" ]]; then
     if [[ -d "${SCAN_DIR}" ]]; then
         cp "${SCAN_DIR}"/evaluation-log-*.yaml "${SCAN_OUTPUT_DIR}/" 2>/dev/null || true
     fi
-    EXPORTED=$(/usr/bin/find "${SCAN_OUTPUT_DIR}" -name 'evaluation-log-*.yaml' 2>/dev/null | wc -l)
+    EXPORTED=$(find "${SCAN_OUTPUT_DIR}" -name 'evaluation-log-*.yaml' 2>/dev/null | wc -l)
     echo "  Exported ${EXPORTED} EvaluationLog file(s) to ${SCAN_OUTPUT_DIR}"
+    if [[ "${EXPORTED}" -eq 0 ]]; then
+        echo "  WARNING: No EvaluationLog files found to export. Scan may not have produced output."
+    fi
 fi
 
 if [[ "${FAILED}" -gt 0 ]]; then

--- a/tests/schema-validation/validate.sh
+++ b/tests/schema-validation/validate.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Validate EvaluationLog YAML files against the Gemara CUE schema.
+# Fetches the schema directly from the CUE Central Registry — no local
+# module files to maintain.
+#
+# Usage:
+#   ./tests/schema-validation/validate.sh <scan-output-dir> [scan-output-dir ...]
+#
+# Exit codes:
+#   0 — all files pass validation
+#   1 — one or more files failed schema validation
+#   2 — no evaluation log files found (configuration error)
+
+set -euo pipefail
+
+# Gemara CUE schema module — pinned to v0.23.0 (31f58fb674fd3f3f088533af9c6cc83a2d84e17f).
+# Tracks the v0.x line matching go-gemara v0.7.0 used by complyctl.
+GEMARA_CUE_MODULE="${GEMARA_CUE_MODULE:-github.com/gemaraproj/gemara@v0.23.0}"
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <scan-output-dir> [scan-output-dir ...]"
+    exit 2
+fi
+
+PASSED=0
+FAILED=0
+TOTAL=0
+
+validate_file() {
+    local file="$1"
+    TOTAL=$((TOTAL + 1))
+    echo "  Validating: ${file}"
+
+    local output rc=0
+    output=$(cue vet -c -d '#EvaluationLog' "${GEMARA_CUE_MODULE}" "${file}" 2>&1) || rc=$?
+
+    if [[ ${rc} -eq 0 ]]; then
+        PASSED=$((PASSED + 1))
+        echo "    PASS"
+    else
+        FAILED=$((FAILED + 1))
+        echo "    FAIL: schema constraint violated"
+        echo "    ---"
+        echo "    ${output//$'\n'/$'\n'    }"
+        echo "    ---"
+    fi
+}
+
+echo "=== EvaluationLog Schema Validation ==="
+echo "  Module: ${GEMARA_CUE_MODULE}"
+echo ""
+
+FILES_FOUND=0
+for dir in "$@"; do
+    if [[ ! -d "${dir}" ]]; then
+        echo "WARNING: directory does not exist: ${dir}"
+        continue
+    fi
+
+    while IFS= read -r -d '' file; do
+        FILES_FOUND=$((FILES_FOUND + 1))
+        validate_file "${file}"
+    done < <(/usr/bin/find "${dir}" -name 'evaluation-log-*.yaml' -print0 2>/dev/null)
+done
+
+echo ""
+
+if [[ ${FILES_FOUND} -eq 0 ]]; then
+    echo "ERROR: No evaluation-log-*.yaml files found in: $*"
+    echo "       Ensure complyctl scan completed successfully before validation."
+    exit 2
+fi
+
+echo "==============================="
+echo "  Total:  ${TOTAL}"
+echo "  Passed: ${PASSED}"
+echo "  Failed: ${FAILED}"
+echo "==============================="
+
+if [[ ${FAILED} -gt 0 ]]; then
+    exit 1
+fi

--- a/tests/schema-validation/validate.sh
+++ b/tests/schema-validation/validate.sh
@@ -15,8 +15,18 @@
 
 set -euo pipefail
 
+# --- Prerequisites ---
+
+if ! command -v cue >/dev/null 2>&1; then
+    echo "FATAL: 'cue' is required but not installed."
+    echo "       Install: go install cuelang.org/go/cmd/cue@v0.17.1"
+    echo "       See: https://cuelang.org/docs/install/"
+    exit 2
+fi
+
 # Gemara CUE schema module — pinned to v0.23.0 (31f58fb674fd3f3f088533af9c6cc83a2d84e17f).
 # Tracks the v0.x line matching go-gemara v0.7.0 used by complyctl.
+# Update this when go.mod's go-gemara dependency is bumped.
 GEMARA_CUE_MODULE="${GEMARA_CUE_MODULE:-github.com/gemaraproj/gemara@v0.23.0}"
 
 if [[ $# -lt 1 ]]; then
@@ -41,7 +51,11 @@ validate_file() {
         echo "    PASS"
     else
         FAILED=$((FAILED + 1))
-        echo "    FAIL: schema constraint violated"
+        if echo "${output}" | grep -qE "cannot find package|module not found|connection refused|dial tcp|no such host"; then
+            echo "    FAIL: tool/infrastructure error (exit code ${rc})"
+        else
+            echo "    FAIL: schema constraint violated (exit code ${rc})"
+        fi
         echo "    ---"
         echo "    ${output//$'\n'/$'\n'    }"
         echo "    ---"
@@ -62,7 +76,7 @@ for dir in "$@"; do
     while IFS= read -r -d '' file; do
         FILES_FOUND=$((FILES_FOUND + 1))
         validate_file "${file}"
-    done < <(/usr/bin/find "${dir}" -name 'evaluation-log-*.yaml' -print0 2>/dev/null)
+    done < <(find "${dir}" -name 'evaluation-log-*.yaml' -print0 2>/dev/null)
 done
 
 echo ""


### PR DESCRIPTION
## Summary

- Adds CUE schema validation to the existing cross-repo integration workflow — after the
  get/generate/scan pipeline completes, `cue vet` validates each EvaluationLog YAML against
  the Gemara CUE schema.
- Catches schema conformance regressions (e.g. empty `steps` arrays, missing required fields)
  before merge.
- Installs CUE in `post-create.sh` so developers can reproduce validation locally in the
  devcontainer.
- Adds `make test-schema-validation` Makefile target for local CI parity.
- Includes full OpenSpec artifacts documenting key design decisions.

## Related Issues

- Refs #577

## Design Decisions

See `openspec/changes/schema-validation-ci/design.md` for full rationale. Key points:

1. **Bare-metal, not devcontainer** — `cue vet` produces identical results regardless of
   environment; devcontainer added ~90s overhead with no functional benefit.
2. **Appended to cross-repo workflow** — EvaluationLog only exists after `complyctl scan`;
   a separate workflow would duplicate the entire pipeline.
3. **Pinned versions** — `cue@v0.17.1`, `gemara@v0.23.0` (tracking `go-gemara v0.7.0` in
   `go.mod`).

## What Changed

| File | Change |
|------|--------|
| `tests/schema-validation/validate.sh` | New standalone validation script (92 lines) with `cue` prerequisite check, infrastructure vs schema error classification, per-file PASS/FAIL reporting, exit codes 0/1/2 |
| `tests/cross-repo/cross_repo_integration_test.sh` | Conditional `SCAN_OUTPUT_DIR` export block with zero-export warning; `SCAN_OUTPUT_DIR` documented as optional env var in header |
| `.github/workflows/ci_cross_repo_integration.yml` | `workflow_dispatch` trigger, `SCAN_OUTPUT_DIR` env var, CUE install + validate steps |
| `.devcontainer/scripts/post-create.sh` | CUE install alongside snappy/ampel/conftest |
| `Makefile` | `test-schema-validation` target for local invocation |
| `AGENTS.md` | CI workflow table update, project structure update, schema validation in Build & Test Commands |
| `CHANGELOG.md` | Unreleased entry for schema validation (#577) |
| `openspec/changes/schema-validation-ci/` | Full OpenSpec artifacts (proposal, design, spec, tasks) |

## Review Hints

- `tests/schema-validation/validate.sh` is the validation script — reusable from CI and
  local dev via `make test-schema-validation`.
- The script checks for `cue` availability upfront and distinguishes infrastructure errors
  (network, module resolution) from actual schema violations in failure output.
- The cross-repo test script exports scan output via `SCAN_OUTPUT_DIR` env var (CI only) and
  warns if zero files are exported.
- Bump the `GEMARA_CUE_MODULE` default in `validate.sh` when upgrading `go-gemara` in
  `go.mod`.

## Verification

- CI passes: Cross-Repo Integration Test completes in ~1m12s (vs ~2m34s with prior
  devcontainer approach).
- Schema validation step reports 2/2 PASS (Ampel + OPA evaluation logs).
- Local E2E verified: `validate.sh` tested against real EvaluationLog files, error paths
  (no args, non-existent dir, empty dir, missing cue), `make test-schema-validation`
  target, and `make test-devcontainer` (Containerfile builds).