### PR TITLE
ci(deps): bump carabiner-dev/actions from 1.2.1 to 1.2.3

### DIFF
--- a/.github/workflows/ci_cross_repo_integration.yml
+++ b/.github/workflows/ci_cross_repo_integration.yml
@@ -62,10 +62,10 @@ jobs:
               run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
             - name: Install snappy
-              uses: carabiner-dev/actions/install/snappy@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+              uses: carabiner-dev/actions/install/snappy@2a4b2cd115ede14629b03ef7e77586d3269d4c72 # v1.2.3
 
             - name: Install ampel
-              uses: carabiner-dev/actions/install/ampel@94f29392187fe5082d1195a7d4cae3a7ddf09d9c # v1.2.1
+              uses: carabiner-dev/actions/install/ampel@2a4b2cd115ede14629b03ef7e77586d3269d4c72 # v1.2.3
 
             - name: Install conftest
               run: go install github.com/open-policy-agent/conftest@v0.68.2

--- a/.github/workflows/ci_cross_repo_integration.yml
+++ b/.github/workflows/ci_cross_repo_integration.yml
@@ -61,11 +61,18 @@ jobs:
             - name: Enable Go toolchain auto-download
               run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
+            # Workaround: v1.2.3 writes unexpanded $HOME to GITHUB_PATH
+            # when using the default install-dir. Use an absolute path
+            # until upstream fix lands (carabiner-dev/actions).
             - name: Install snappy
               uses: carabiner-dev/actions/install/snappy@2a4b2cd115ede14629b03ef7e77586d3269d4c72 # v1.2.3
+              with:
+                  install-dir: /home/runner/.carabiner
 
             - name: Install ampel
               uses: carabiner-dev/actions/install/ampel@2a4b2cd115ede14629b03ef7e77586d3269d4c72 # v1.2.3
+              with:
+                  install-dir: /home/runner/.carabiner
 
             - name: Install conftest
               run: go install github.com/open-policy-agent/conftest@v0.68.2


### PR DESCRIPTION
Bump `install/snappy` and `install/ampel` together from v1.2.1 to v1.2.3.

## Why a combined PR?

These actions are co-released from the [`carabiner-dev/actions`](https://github.com/carabiner-dev/actions) monorepo and share release tags. Dependabot generates individual PRs for each action path, but bumping them independently creates a version mismatch that breaks the cross-repo integration test:

Error: provider ampel (evaluator "ampel"): required tools not found: snappy

This PR supersedes #751 and #752 by updating both action pins atomically.

## Changes

| Action | Old | New |
|--------|-----|-----|
| `install/snappy` | `94f2939...` (v1.2.1) | `2a4b2cd...` (v1.2.3) |
| `install/ampel` | `94f2939...` (v1.2.1) | `2a4b2cd...` (v1.2.3) |

Both actions now set `install-dir: /home/runner/.carabiner` explicitly to work around an upstream bug in v1.2.3 where the default `$HOME/.carabiner` is written unexpanded to `GITHUB_PATH`, making installed tools invisible to subsequent steps. Upstream issue pending on `carabiner-dev/actions`.

## Upstream release notes

- [v1.2.2](https://github.com/carabiner-dev/actions/releases/tag/v1.2.2): Ampel installer updates (v1.3.0 → v1.3.1), carabiner login action, SLSA provenance generator update
- [v1.2.3](https://github.com/carabiner-dev/actions/releases/tag/v1.2.3): Ampel installer update (v1.3.3), ampel-version input for verify action, internal pin workflow

Note: v1.2.3 has an upstream bug where the default install-dir ($HOME/.carabiner) is written unexpanded to GITHUB_PATH, making installed tools invisible to later steps. The second commit works around this by setting install-dir explicitly to /home/runner/.carabiner. Upstream issue pending on carabiner-dev/actions.

Closes #751, closes #752