### PR TITLE
refactor(doctor): review follow-up for #744 format rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,20 @@
   aligns with [complypack#127](https://github.com/complytime/complypack/pull/127).
   (#734)
 
+- **BREAKING**: `complyctl doctor` default output now includes
+  `[PASS]`/`[FAIL]`/`[WARN]` labels alongside emoji status indicators.
+  Scripts that parse the previous emoji-only format may need updating.
+  The warning emoji changed from `⏭️` to `⚠️`. (#611, #744)
+
 ### Added
+
+- `complyctl doctor --format text|json` flag for machine-readable
+  output. `--format text` produces grep-stable `[PASS]`/`[FAIL]`/
+  `[WARN]` labels without emoji; `--format json` produces structured
+  JSON with `checks`, `summary`, and `blocking_failure` fields.
+  `--format human` explicitly selects the default emoji output.
+  When `NO_COLOR` is set, text format is selected automatically.
+  (#611, #744)
 
 - Cross-repo integration workflow now validates EvaluationLog YAML
   output against the Gemara CUE schema with `cue vet`. Catches

--- a/cmd/complyctl/cli/cli_test.go
+++ b/cmd/complyctl/cli/cli_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/complytime/complyctl/internal/cache"
 	"github.com/complytime/complyctl/internal/complytime"
-	"github.com/complytime/complyctl/internal/doctor"
 	"github.com/complytime/complyctl/internal/policy"
 	"github.com/complytime/complyctl/internal/terminal"
 	"github.com/complytime/complyctl/internal/version"
@@ -2695,47 +2694,4 @@ func TestFormatPolicySummary_CountsOnlyNoTitleNoEval(t *testing.T) {
 	result := formatPolicySummary(meta)
 	assert.Contains(t, result, "Controls: 5 | Assessments: 3")
 	assert.NotContains(t, result, "Policy:")
-}
-
-// --- Doctor renderer helper tests ---
-
-func TestResultLabel_UsesLabelWhenSet(t *testing.T) {
-	r := doctor.CheckResult{Name: "provider/ampel", Label: "ampel"}
-	assert.Equal(t, "ampel", resultLabel(r))
-}
-
-func TestResultLabel_FallsBackToName(t *testing.T) {
-	r := doctor.CheckResult{Name: "cache", Label: ""}
-	assert.Equal(t, "cache", resultLabel(r))
-}
-
-func TestStatusEmoji(t *testing.T) {
-	tests := []struct {
-		name     string
-		status   doctor.CheckStatus
-		expected string
-	}{
-		{name: "pass", status: doctor.StatusPass, expected: complytime.StatusPassed},
-		{name: "fail", status: doctor.StatusFail, expected: complytime.StatusFailed},
-		{name: "warn", status: doctor.StatusWarn, expected: complytime.StatusError},
-		{name: "unknown", status: doctor.CheckStatus("other"), expected: complytime.StatusUnknown},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, statusEmoji(tc.status))
-		})
-	}
-}
-
-func TestCountStatusSummary(t *testing.T) {
-	var s resultSummary
-
-	countStatusSummary(doctor.StatusPass, &s)
-	countStatusSummary(doctor.StatusFail, &s)
-	countStatusSummary(doctor.StatusWarn, &s)
-	countStatusSummary(doctor.StatusPass, &s)
-
-	assert.Equal(t, 2, s.passCount)
-	assert.Equal(t, 1, s.failCount)
-	assert.Equal(t, 1, s.warnCount)
 }

--- a/cmd/complyctl/cli/doctor.go
+++ b/cmd/complyctl/cli/doctor.go
@@ -412,7 +412,7 @@ func printDiagnosticsTo(results []doctor.CheckResult, format string, w io.Writer
 	case complytime.OutputFormatJSON:
 		return printDiagnosticsJSON(results, w)
 	default:
-		return fmt.Errorf("unsupported output format: %s", format)
+		return fmt.Errorf("unsupported output format: %q", format)
 	}
 }
 

--- a/cmd/complyctl/cli/doctor.go
+++ b/cmd/complyctl/cli/doctor.go
@@ -255,9 +255,25 @@ func statusEmoji(s doctor.CheckStatus) string {
 	}
 }
 
-// printDiagnosticsHuman renders results with emoji status indicators followed
-// by a grep-stable [STATUS] label. This is the default interactive mode.
-func printDiagnosticsHuman(results []doctor.CheckResult, w io.Writer) error {
+// statusFormatter returns the status prefix for a check result line.
+// Human format uses emoji + label; text format uses label only.
+type statusFormatter func(doctor.CheckStatus) string
+
+// humanStatusPrefix returns emoji followed by a bracketed label
+// (e.g., "✅ [PASS]").
+func humanStatusPrefix(s doctor.CheckStatus) string {
+	return statusEmoji(s) + " " + statusLabel(s)
+}
+
+// textStatusPrefix returns a bracketed label only (e.g., "[PASS]").
+func textStatusPrefix(s doctor.CheckStatus) string {
+	return statusLabel(s)
+}
+
+// renderDiagnostics walks the grouped result tree and writes each check
+// using the provided status formatter. Shared by human and text renderers
+// to avoid duplicating the tree-walk structure.
+func renderDiagnostics(results []doctor.CheckResult, w io.Writer, fmtStatus statusFormatter) error {
 	fmt.Fprintln(w, "Running workspace diagnostics...")
 	fmt.Fprintln(w)
 
@@ -280,16 +296,16 @@ func printDiagnosticsHuman(results []doctor.CheckResult, w io.Writer) error {
 		fmt.Fprintln(w, string(group))
 
 		for _, r := range checks {
-			fmt.Fprintf(w, "  %s %s %s: %s\n", statusEmoji(r.Status), statusLabel(r.Status), resultLabel(r), r.Message)
+			fmt.Fprintf(w, "  %s %s: %s\n", fmtStatus(r.Status), resultLabel(r), r.Message)
 
 			for _, child := range r.Children {
-				fmt.Fprintf(w, "      %s %s %s: %s\n", statusEmoji(child.Status), statusLabel(child.Status), resultLabel(child), child.Message)
+				fmt.Fprintf(w, "      %s %s: %s\n", fmtStatus(child.Status), resultLabel(child), child.Message)
 
 				// Grandchildren (verbose detail) are rendered but not
 				// counted in the summary (D5 — stable count regardless
 				// of --verbose).
 				for _, gc := range child.Children {
-					fmt.Fprintf(w, "          %s %s %s\n", statusEmoji(gc.Status), statusLabel(gc.Status), gc.Message)
+					fmt.Fprintf(w, "          %s %s\n", fmtStatus(gc.Status), gc.Message)
 				}
 			}
 		}
@@ -304,50 +320,16 @@ func printDiagnosticsHuman(results []doctor.CheckResult, w io.Writer) error {
 	return nil
 }
 
+// printDiagnosticsHuman renders results with emoji status indicators followed
+// by a grep-stable [STATUS] label. This is the default interactive mode.
+func printDiagnosticsHuman(results []doctor.CheckResult, w io.Writer) error {
+	return renderDiagnostics(results, w, humanStatusPrefix)
+}
+
 // printDiagnosticsText renders results with bracketed [STATUS] labels and no
 // emoji. Used for --format text and when NO_COLOR is set.
 func printDiagnosticsText(results []doctor.CheckResult, w io.Writer) error {
-	fmt.Fprintln(w, "Running workspace diagnostics...")
-	fmt.Fprintln(w)
-
-	grouped := make(map[doctor.CheckGroup][]doctor.CheckResult)
-	for _, r := range results {
-		grouped[r.Group] = append(grouped[r.Group], r)
-	}
-
-	firstSection := true
-	for _, group := range doctor.GroupOrder() {
-		checks, ok := grouped[group]
-		if !ok {
-			continue
-		}
-
-		if !firstSection {
-			fmt.Fprintln(w)
-		}
-		firstSection = false
-		fmt.Fprintln(w, string(group))
-
-		for _, r := range checks {
-			fmt.Fprintf(w, "  %s %s: %s\n", statusLabel(r.Status), resultLabel(r), r.Message)
-
-			for _, child := range r.Children {
-				fmt.Fprintf(w, "      %s %s: %s\n", statusLabel(child.Status), resultLabel(child), child.Message)
-
-				for _, gc := range child.Children {
-					fmt.Fprintf(w, "          %s %s\n", statusLabel(gc.Status), gc.Message)
-				}
-			}
-		}
-	}
-
-	s := summarizeResults(results)
-	fmt.Fprintf(w, "\n%d checks: %d passed, %d failed, %d warnings\n", s.total, s.passCount, s.failCount, s.warnCount)
-
-	if s.blockingFailure {
-		return fmt.Errorf("one or more blocking checks failed")
-	}
-	return nil
+	return renderDiagnostics(results, w, textStatusPrefix)
 }
 
 // convertResult converts a doctor.CheckResult to a checkOutput for JSON

--- a/cmd/complyctl/cli/doctor_test.go
+++ b/cmd/complyctl/cli/doctor_test.go
@@ -17,20 +17,22 @@ import (
 
 // --- statusLabel ---
 
-func TestStatusLabel_Pass(t *testing.T) {
-	assert.Equal(t, "[PASS]", statusLabel(doctor.StatusPass))
-}
-
-func TestStatusLabel_Fail(t *testing.T) {
-	assert.Equal(t, "[FAIL]", statusLabel(doctor.StatusFail))
-}
-
-func TestStatusLabel_Warn(t *testing.T) {
-	assert.Equal(t, "[WARN]", statusLabel(doctor.StatusWarn))
-}
-
-func TestStatusLabel_Unknown(t *testing.T) {
-	assert.Equal(t, "[UNKNOWN]", statusLabel(doctor.CheckStatus("bogus")))
+func TestStatusLabel(t *testing.T) {
+	tests := []struct {
+		name   string
+		status doctor.CheckStatus
+		want   string
+	}{
+		{"pass", doctor.StatusPass, "[PASS]"},
+		{"fail", doctor.StatusFail, "[FAIL]"},
+		{"warn", doctor.StatusWarn, "[WARN]"},
+		{"unknown", doctor.CheckStatus("bogus"), "[UNKNOWN]"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, statusLabel(tt.status))
+		})
+	}
 }
 
 // --- resolveFormat ---
@@ -85,6 +87,33 @@ func TestResolveFormat_HumanFlagOverridesNOCOLOR(t *testing.T) {
 	got, err := resolveFormat(complytime.OutputFormatHuman)
 	require.NoError(t, err)
 	assert.Equal(t, "", got, "--format human must produce human output even with NO_COLOR")
+}
+
+// --- resultLabel ---
+
+func TestResultLabel_UsesLabelWhenSet(t *testing.T) {
+	r := doctor.CheckResult{Name: "provider/ampel", Label: "ampel"}
+	assert.Equal(t, "ampel", resultLabel(r))
+}
+
+func TestResultLabel_FallsBackToName(t *testing.T) {
+	r := doctor.CheckResult{Name: "cache", Label: ""}
+	assert.Equal(t, "cache", resultLabel(r))
+}
+
+// --- countStatusSummary ---
+
+func TestCountStatusSummary(t *testing.T) {
+	var s resultSummary
+
+	countStatusSummary(doctor.StatusPass, &s)
+	countStatusSummary(doctor.StatusFail, &s)
+	countStatusSummary(doctor.StatusWarn, &s)
+	countStatusSummary(doctor.StatusPass, &s)
+
+	assert.Equal(t, 2, s.passCount)
+	assert.Equal(t, 1, s.failCount)
+	assert.Equal(t, 1, s.warnCount)
 }
 
 // --- printDiagnosticsHuman ---
@@ -419,12 +448,20 @@ func TestSummarizeResults_GrandchildrenNotCounted(t *testing.T) {
 
 // --- statusEmoji ---
 
-func TestStatusEmoji_KnownStatuses(t *testing.T) {
-	assert.Equal(t, complytime.StatusPassed, statusEmoji(doctor.StatusPass))
-	assert.Equal(t, complytime.StatusFailed, statusEmoji(doctor.StatusFail))
-	assert.Equal(t, complytime.StatusError, statusEmoji(doctor.StatusWarn))
-}
-
-func TestStatusEmoji_UnknownStatus(t *testing.T) {
-	assert.Equal(t, complytime.StatusUnknown, statusEmoji(doctor.CheckStatus("bogus")))
+func TestStatusEmoji(t *testing.T) {
+	tests := []struct {
+		name   string
+		status doctor.CheckStatus
+		want   string
+	}{
+		{"pass", doctor.StatusPass, complytime.StatusPassed},
+		{"fail", doctor.StatusFail, complytime.StatusFailed},
+		{"warn", doctor.StatusWarn, complytime.StatusError},
+		{"unknown", doctor.CheckStatus("bogus"), complytime.StatusUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, statusEmoji(tt.status))
+		})
+	}
 }

--- a/cmd/complyctl/cli/doctor_test.go
+++ b/cmd/complyctl/cli/doctor_test.go
@@ -311,6 +311,39 @@ func TestPrintDiagnosticsJSON_ChildrenIncluded(t *testing.T) {
 	assert.Equal(t, 2, out.Summary.Total, "children should be counted in summary")
 }
 
+func TestPrintDiagnosticsJSON_GrandchildrenSerialized(t *testing.T) {
+	results := []doctor.CheckResult{
+		{
+			Name: "parent", Status: doctor.StatusPass, Message: "ok",
+			Group: doctor.GroupProviders,
+			Children: []doctor.CheckResult{
+				{
+					Name: "child", Status: doctor.StatusPass, Message: "ok",
+					Children: []doctor.CheckResult{
+						{Name: "grandchild", Status: doctor.StatusFail, Message: "detail"},
+					},
+				},
+			},
+		},
+	}
+	var buf bytes.Buffer
+	err := printDiagnosticsJSON(results, &buf)
+	require.NoError(t, err)
+
+	var out diagnosticOutput
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &out))
+
+	// Grandchildren must appear in JSON output (full structure serialized)
+	require.Len(t, out.Checks[0].Children, 1)
+	require.Len(t, out.Checks[0].Children[0].Children, 1)
+	assert.Equal(t, "grandchild", out.Checks[0].Children[0].Children[0].Name)
+	assert.Equal(t, doctor.StatusFail, out.Checks[0].Children[0].Children[0].Status)
+
+	// But grandchildren must NOT be counted in summary (D5)
+	assert.Equal(t, 2, out.Summary.Total, "grandchildren must not be counted (D5)")
+	assert.Equal(t, 0, out.Summary.Failed, "grandchild fail must not inflate summary")
+}
+
 func TestPrintDiagnosticsText_GrepPattern(t *testing.T) {
 	results := []doctor.CheckResult{
 		{Name: "config", Status: doctor.StatusFail, Message: "missing policy", Blocking: true, Group: doctor.GroupWorkspace},


### PR DESCRIPTION
Follow-up to #744 addressing review feedback from @yvonnedevlinrh, @em-redhat, and @marcusburghardt.

**Depends on**: #744 (branch will be rebased onto main after #744 merges)

### Changes

1. **`%q` format consistency** — `printDiagnosticsTo` error message uses `%q` instead of `%s`, matching `resolveFormat` (review feedback from @em-redhat)

2. **Table-driven tests** — Convert individual `statusLabel` and `statusEmoji` test functions to table-driven style per TC-006 SHOULD convention; move doctor helper tests from `cli_test.go` to `doctor_test.go` (review feedback from @em-redhat)

3. **CHANGELOG entries** — Add breaking change entry (human output format gains labels, warning emoji changed) and feature entry (`--format text|json`, `--format human`, `NO_COLOR` auto-detection) per documentation gate

4. **Grandchild JSON serialization test** — `convertResult()` recursively serializes grandchildren in JSON, but `summarizeResults()` excludes them from counts (D5). Add `TestPrintDiagnosticsJSON_GrandchildrenSerialized` verifying both sides of the D5 contract

5. **DRY renderer refactor** — Extract shared grouped tree-walk into `renderDiagnostics()` with a `statusFormatter` callback, eliminating ~30 lines of duplicated structure between `printDiagnosticsHuman` and `printDiagnosticsText`

Assisted-by: OpenCode (claude-opus-4-6)
Signed-off-by: Marcus Burghardt <maburgha@redhat.com>
