### PR TITLE
ci(deps): bump complytime/org-infra reusable workflows from v0.6.0 to v0.7.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
     preflight:
         name: Preflight
-        uses: complytime/org-infra/.github/workflows/reusable_release_preflight.yml@aff4817ed6f0364e7f899bfb63ec6db42e69fde2 # v0.6.0
+        uses: complytime/org-infra/.github/workflows/reusable_release_preflight.yml@7e13c504ba68fd7b80634e367a8170fb4041663b # v0.7.0
         with:
             tag: ${{ inputs.tag }}
             ci_checks: '["unit-test", "e2e-test", "integration-test"]'
@@ -42,7 +42,7 @@ jobs:
         name: Release
         needs: preflight
         if: needs.preflight.outputs.tag != ''
-        uses: complytime/org-infra/.github/workflows/reusable_release_goreleaser.yml@aff4817ed6f0364e7f899bfb63ec6db42e69fde2 # v0.6.0
+        uses: complytime/org-infra/.github/workflows/reusable_release_goreleaser.yml@7e13c504ba68fd7b80634e367a8170fb4041663b # v0.7.0
         with:
             tag: ${{ needs.preflight.outputs.tag }}
         permissions:


### PR DESCRIPTION
Bumps org-infra reusable workflows from v0.6.0 to v0.7.0.

### Why

The v1.0.0 release workflow [failed](https://github.com/complytime/complyctl/actions/runs/30375819666/job/90331111728) at the "Verify semver ordering" step because pip 25.x (now shipped on `ubuntu-latest` runner images) removed the `--hash` CLI option from `pip install`. The preflight workflow was using `pip install --hash=sha256:...` on the command line, which returns exit code 2 on pip 25.x.

### Fix

[org-infra v0.7.0](https://github.com/complytime/org-infra/releases/tag/v0.7.0) fixes this by writing the pinned dependency with its hash to a temporary requirements file and installing via `-r`, which is compatible with both pip 24.x and 25.x.

### Impact

Unblocks the v1.0.0 release.