### PR TITLE
feat: add cosign verification acceptance tests with private Sigstore stack

### DIFF
--- a/.github/workflows/acceptance_verify_test.yml
+++ b/.github/workflows/acceptance_verify_test.yml
@@ -1,0 +1,50 @@
+name: acceptance-verify-test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same ref: these heavyweight container
+# jobs are expensive and only the latest push matters.
+concurrency:
+  group: acceptance-verify-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  acceptance-verify-test:
+    runs-on: ubuntu-latest
+    # 20 minutes gives margin over the provisioning critical path
+    # (mysql start_period 90s + Trillian/CTFE tree creation + Fulcio/Rekor
+    # readiness + sign-seed + the 3-minute verify-sut test timeout), which
+    # can approach 15 minutes on a cold runner with no build-layer cache.
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: "./go.mod"
+
+      - name: Run verification acceptance tests
+        run: make test-acceptance-verify COMPOSE="docker compose"
+
+      # Workflow-level safety net: if the job is killed by timeout-minutes
+      # before the Makefile target's inline log dump runs, capture the
+      # compose service logs so failures are diagnosable.
+      - name: Dump verification stack logs on failure
+        if: ${{ failure() }}
+        run: >
+          docker compose -f tests/acceptance/compose.yaml
+          --profile verification logs --no-color

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ complyctl.log
 .complytime/**
 !.complytime/complytime.yaml
 
+# Test output
+.test-output/
+
 # Outputs
 assessment-plan.json
 assessment-results.*

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# Trivy misconfig suppressions for K8s Deployment test fixtures.
-# These files are intentionally non-compliant or minimally compliant
-# to validate OPA provider policy evaluation. They are not deployed
-# infrastructure.
+# Trivy misconfig suppressions for intentionally non-compliant files.
+# Covers:
+#   - K8s Deployment test fixtures (OPA provider validation — not deployed infrastructure)
+#   - Acceptance test Dockerfiles (ephemeral test-only containers — not production images)
+#   - Vendored Dockerfiles (referenced for tooling, never built in production)
 
 misconfigurations:
   - id: KSV-0118
@@ -83,11 +84,24 @@ misconfigurations:
       - "tests/cross-repo/testdata/test-deployment-bad.yaml"
       - "tests/cross-repo/testdata/test-deployment-good.yaml"
     statement: Intentional test fixture for OPA provider validation
+  - id: DS-0001
+    paths:
+      - "tests/acceptance/Dockerfile.generate-pki"
+      - "tests/acceptance/Dockerfile.sign-seed"
+      - "tests/acceptance/Dockerfile.verify-sut"
+    statement: UBI base images intentionally float on :latest for automatic errata coverage; pinning by digest is deferred per AGENTS.md project convention
   - id: DS-0002
     paths:
+      - "tests/acceptance/Dockerfile.createtree"
+      - "tests/acceptance/Dockerfile.generate-pki"
+      - "tests/acceptance/Dockerfile.sign-seed"
       - "vendor/go.opentelemetry.io/otel/dependencies.Dockerfile"
-    statement: Vendored OTel file used only as renovate-friendly image reference, not a production Dockerfile
+    statement: Ephemeral test-only init containers require root for privileged volume writes and PKI generation; not production infrastructure
   - id: DS-0026
     paths:
+      - "tests/acceptance/Dockerfile.createtree"
+      - "tests/acceptance/Dockerfile.generate-pki"
+      - "tests/acceptance/Dockerfile.sign-seed"
+      - "tests/acceptance/Dockerfile.verify-sut"
       - "vendor/go.opentelemetry.io/otel/dependencies.Dockerfile"
-    statement: Vendored OTel file used only as renovate-friendly image reference, not a production Dockerfile
+    statement: Ephemeral acceptance test containers; Compose service_completed_successfully and depends_on provide lifecycle management; no HEALTHCHECK needed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,13 @@ make test-acceptance
 # Homebrew formula smoke test (requires brew, macOS/Linux)
 make test-homebrew
 # → ./tests/homebrew_test.sh
+
+# Verification acceptance tests (requires Sigstore infrastructure)
+make test-acceptance-verify
+# → compose up --profile verification (zot + Sigstore + sign-seed + verify-sut)
+
+# All acceptance tests (lifecycle + verification, sequential)
+make test-acceptance-all
 ```
 
 ### Lint & Format
@@ -84,22 +91,23 @@ make crapload-check     # check for CRAP regressions against baseline
 
 ### CI Workflow Structure
 
-| Workflow | File | Purpose |
-| ---------- | ------ | --------- |
-| CI | `ci_checks.yml` | Standardized CI via org-infra reusable workflow |
-| Unit Test | `unit_test.yml` | Unit tests + buf lint |
-| E2E Test | `e2e_test.yml` | End-to-end tests with mock registry |
-| Integration Test | `integration_test.yml` | Shell-based integration tests |
-| Cross-Repo Integration | `ci_cross_repo_integration.yml` | Cross-repo integration tests with complytime-providers + EvaluationLog schema validation |
-| CRAP Load | `ci_crapload.yml` | CRAP analysis on PRs (reusable from org-infra) |
-| Security | `ci_security.yml` | Security scanning |
-| Compliance | `ci_compliance.yml` | Compliance checks |
-| Dependencies | `ci_dependencies.yml` | Dependency management |
-| SonarCloud | `ci_sonarcloud.yml` | Code quality analysis |
-| Behavioral | `behavioral_assessment.yml` | Behavioral assessment reports |
-| Scheduled | `ci_scheduled.yml` | Daily OSV-Scanner and Scorecards |
-| Acceptance Test | `acceptance_test.yml` | Container-based acceptance tests with real OCI registry |
-| Release | `release.yml` | Release automation (reusable preflight + GoReleaser from org-infra) + Homebrew formula publishing |
+| Workflow               | File                            | Purpose                                                                                           |
+| ----------             | ------                          | ---------                                                                                         |
+| CI                     | `ci_checks.yml`                 | Standardized CI via org-infra reusable workflow                                                   |
+| Unit Test              | `unit_test.yml`                 | Unit tests + buf lint                                                                             |
+| E2E Test               | `e2e_test.yml`                  | End-to-end tests with mock registry                                                               |
+| Integration Test       | `integration_test.yml`          | Shell-based integration tests                                                                     |
+| Cross-Repo Integration | `ci_cross_repo_integration.yml` | Cross-repo integration tests with complytime-providers + EvaluationLog schema validation          |
+| CRAP Load              | `ci_crapload.yml`               | CRAP analysis on PRs (reusable from org-infra)                                                    |
+| Security               | `ci_security.yml`               | Security scanning                                                                                 |
+| Compliance             | `ci_compliance.yml`             | Compliance checks                                                                                 |
+| Dependencies           | `ci_dependencies.yml`           | Dependency management                                                                             |
+| SonarCloud             | `ci_sonarcloud.yml`             | Code quality analysis                                                                             |
+| Behavioral             | `behavioral_assessment.yml`     | Behavioral assessment reports                                                                     |
+| Scheduled              | `ci_scheduled.yml`              | Daily OSV-Scanner and Scorecards                                                                  |
+| Acceptance Test        | `acceptance_test.yml`           | Container-based acceptance tests with real OCI registry                                           |
+| Acceptance Verify Test | `acceptance_verify_test.yml`    | Container-based verification acceptance tests with Sigstore infrastructure                        |
+| Release                | `release.yml`                   | Release automation (reusable preflight + GoReleaser from org-infra) + Homebrew formula publishing |
 
 ## Project Structure
 
@@ -139,6 +147,8 @@ scripts/             # maintenance scripts (SPDX checks, workflow setup)
 specs/               # Speckit strategic specifications (NNN-*/  format)
 tests/
 ├── acceptance/      # Container-based acceptance tests (compose + zot)
+│   └── testdata/
+│       └── sigstore/    # PKI README (keys generated at runtime into pki-material volume)
 ├── behavioral/      # behavioral test scenarios
 ├── cross-repo/      # cross-repo integration tests (complyctl + ampel + opa providers)
 ├── e2e/             # E2E tests (build-tag gated: -tags=e2e)
@@ -315,6 +325,7 @@ packages organized by domain responsibility.
 
 ## Recent Changes
 - json-evallog: `complyctl scan --log-format yaml|json` flag and `COMPLYTIME_LOG_FORMAT` env var select EvaluationLog serialization format; `EvalLogFormatEnvVar` constant in `internal/complytime/consts.go`; shadow structs in `internal/output/evaluator.go` gain `json:` tags (kebab-case matching go-gemara); `Write(outDir, logFormat string)` branches on format using `json.MarshalIndent` for JSON path; `scanOptions.logFormat` field, flag registration with shell completion, env var override (flag precedence), and `validateLogFormat()` in `cmd/complyctl/cli/scan.go`; YAML remains default (#795)
+- ctfe-keyless-verify: The verification acceptance stack now provisions a real RFC6962 CT log so keyless signatures carry a genuine SCT that the production sigstore-go verifier (requires >=1 SCT + >=1 transparency-log entry) accepts. Fulcio switched from `--ca=ephemeralca` to `--ca=fileca` with PKI keys generated at runtime by the `generate-pki` service into the `pki-material` volume (superseding the earlier ephemeral-CA/committed-PKI designs). New `ctfe` service (`gcr.io/trillian-opensource-ci/ctfe`, reuses the existing mysql+trillian backend) plus a `createtree-init` service (built from `Dockerfile.createtree`, `createtree@v1.6.1`) that provisions the Trillian tree and renders `ct_server.cfg`; `sign-seed.sh` sets `SIGSTORE_CT_LOG_PUBLIC_KEY_FILE` for cosign SCT self-verify and builds `trusted_root.json` from the runtime-generated CA+CTFE keys plus the runtime Rekor key. `internal/cache/verify.go` fixed to honor the `http://` plain-HTTP registry scheme, emit PublicKey verification material for keyed bundles, hex-decode the Rekor bundle logID, and use the signature-layer (simplesigning payload) digest as the message-signature/artifact digest; `make test-acceptance-verify` dumps all verification-profile service logs on failure (#678)
 - custom-trusted-root: `VerificationConfig` gains `TrustedRoot string` field with `yaml:"trusted_root,omitempty"` tag in `internal/complytime/config.go`; `ValidateVerificationConfig()` enforces mutual exclusivity with `key` (error: "trusted_root cannot be used with key-based verification"), requires `issuer` + `identity` (error: "trusted_root requires issuer and identity for keyless verification"), and validates file existence via `filepath.Clean` + `os.Stat`; `NewKeylessVerifier()` in `internal/cache/verify.go` gains `trustedRootPath string` parameter — when non-empty, calls `root.NewTrustedRootFromPath(trustedRootPath)` instead of TUF fetch, wrapping errors with `"failed to load trusted root from %s: %w"`; `buildVerifierFromConfig()` in `cmd/complyctl/cli/get.go` passes `cfg.TrustedRoot` to `NewKeylessVerifier()`; THR02.MIT05 added to threat model for user-supplied trust anchor without TUF integrity protection; fixes #768
 - multi-target-report-filenames: `BuildReportFilename(prefix, policyID, targetID, ext string) string` in `internal/output/filename.go` centralizes report filename construction for all four formatters (EvaluationLog, OSCAL, SARIF, Markdown); sanitizes via `complytime.FilenameSafe`, timestamps via `time.Now().Format("20060102-150405")`, omits targetID segment when empty; OSCAL/SARIF/Markdown formatters migrated from inline `fmt.Sprintf` to shared helper, adding targetID to filenames; fixes #773 (multi-target scans overwrote report files)
 - homebrew-formula-and-go-install: macOS binary releases (darwin/amd64, darwin/arm64) added to GoReleaser build matrix; source-build Homebrew Formula auto-published to `complytime/homebrew-tap` on release via GitHub App token; `go install` documented in `docs/INSTALLATION.md`; `make test-homebrew` target and `tests/homebrew_test.sh` for formula validation; shell completions (Bash, Zsh, Fish) installed by Formula (#713)
@@ -326,6 +337,7 @@ packages organized by domain responsibility.
 - doctor-grouped-output: `complyctl doctor` output redesigned with grouped sections and nested sub-results; `CheckResult` gains `Children []CheckResult` field, `Label string` field, and `CheckGroup` type with `GroupOrder()` function for section ordering; `Run()` assembles result tree via `attachByEvaluatorID()` and `attachByPolicyID()` helpers; `CheckPolicyVersions` emits per-policy `policy/<eid>` warnings for unreachable registries instead of `registry/<reg>` with silent skip; `CheckComplypacks` lists each complypack individually by evaluator-id; `printDiagnostics` in `cmd/complyctl/cli/doctor.go` rewritten as nested tree walk with summary counts at depth 0–1 (excludes verbose detail grandchildren); string-parsing helpers (`partitionVariables`, `buildChildMap`, `filterParents`, `extractEvaluatorID`) removed (#692)
 - doctor-machine-readable-output: `complyctl doctor` gains `--format text|json` flag; `resolveFormat()` auto-selects `text` when `NO_COLOR` is set; three renderers: `printDiagnosticsHuman` (emoji), `printDiagnosticsText` (plain label), `printDiagnosticsJSON` (structured JSON with `checks`, `summary`, `blocking_failure`); `statusLabel()` maps `CheckStatus` to grep-stable `[PASS]`/`[FAIL]`/`[WARN]`; `OutputFormatText`/`OutputFormatJSON` constants in `internal/complytime/consts.go` (#611)
 - doctor-human-format-refactor: `complyctl doctor --format` gains explicit `human` option (three-value set: `human|text|json`); `OutputFormatHuman` constant in `internal/complytime/consts.go`; `summarizeResults()` extracts shared counting logic across renderers into `resultSummary` struct; `statusEmoji()` centralises emoji mapping; `printDiagnosticsTo()` rejects unrecognised format values instead of falling back to human; flag help text and shell completion updated (#744)
+- acceptance-verify-tests: Container-based verification acceptance test stack (`tests/acceptance/` verification profile, `make test-acceptance-verify`, `acceptance_verify_test.yml`); private Sigstore infrastructure (dex-idp, fulcio with runtime-generated `--ca=fileca` keys, rekor-server backed by mysql + trillian-log-server + trillian-log-signer, plus a Trillian CTFE CT log — see the ctfe-keyless-verify entry above) + sign-seed compose service that signs OCI artifacts (keyed and keyless) and generates `trusted_root.json` at runtime; test scenarios cover keyed verification (happy path, wrong key), keyless verification (happy path, wrong identity), and configuration behavior; keyless verification is active (not skip-gated) via the runtime-generated trust root; `test-acceptance-verify-clean` teardown target; `test-acceptance-all` runs lifecycle + verification sequentially; test PKI is generated at runtime by the `generate-pki` Compose service into the `pki-material` volume, trusted_root.json assembled at runtime (#678)
 - ci-step-summary-report: Emoji status indicators added to `--format pretty` markdown report; `resultEmoji()` helper maps `gemara.Result` to `complytime.Status*` constants; `writeControlsTable()` prefixes Result column with emoji for control and requirement rows; `writeSummary()` prefixes counts table headers with emoji; `writeFindings()` prefixes group headers with emoji; report now directly usable as GitHub Actions Step Summary via `cat report-*.md >> $GITHUB_STEP_SUMMARY` (#697)
 - complypack-cache-versioning: `COMPLYTIME_CACHE_VERSIONS` env var configures retention count (default 1) for complypack cache versions per evaluator-id; `NewComplypackCache()` gains `*State` parameter for state-driven lookup and timestamp-based eviction ordering; `evictOldVersions()` becomes retention-count-aware (orphaned dirs first, then oldest by `LastUpdated`); `LookupByEvaluatorID()` resolves from state.json with directory-scan fallback; `SyncComplypack()` checks local cache before remote fetch with re-verification when verifier is configured, returns `(true, nil)` for cache hits to trigger generation invalidation; `EvaluatorIDToVersion()` reverse lookup on `*State`; `CacheRetentionCount()` in `internal/cache/retention.go`; `CheckComplypacks()` extended with `walkCacheSize()` and `findOrphanedVersions()` for cache health reporting; `complyctl doctor` reports cache size and orphaned/untracked versions (#676)
 - bundle-metadata-cli: `complyctl list` gains EVALUATOR and CONTROLS columns sourced from `PolicyState` metadata in `state.json`; `complyctl get` prints post-sync summary to stderr after fresh fetch showing policy title, evaluator, control count, and assessment count; `PolicyState` gains `PolicyTitle`/`PolicyEvaluator`/`ControlCount`/`AssessmentCount` fields populated at sync time via `SetPolicyMetadata()`; `policy.Resolver.ExtractPolicyMetadata()` extracts display metadata without building full `DependencyGraph`; `policyLayerResult.Title` added to `parsePolicyLayer()` output; upgrade backfill for pre-existing caches without metadata; `formatPolicySummary()` helper for testable stderr output (#506)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,19 @@
   go-gemara schema. The `COMPLYTIME_LOG_FORMAT` environment
   variable provides an alternative to the flag; the flag takes
   precedence when both are set. (#795)
-
+- Container-based acceptance test stack for live keyless signature
+  verification. A private Sigstore deployment (Dex OIDC, Fulcio with a
+  committed `--ca=fileca` root, Rekor backed by MySQL + Trillian, and a
+  Trillian CTFE RFC6962 CT log) signs OCI policy artifacts keyless and
+  keyed, so the acceptance tests exercise the production sigstore-go
+  verifier end to end (SCT + transparency-log inclusion). Test PKI is
+  committed under `tests/acceptance/testdata/sigstore/` and
+  `trusted_root.json` is assembled at runtime. Policies are signed by
+  their resolved manifest digest (not by tag) so the signature tag
+  matches the digest the verifier resolves regardless of the
+  non-deterministic `org.opencontainers.image.created` annotation
+  `oras push` stamps on each push. Run with
+  `make test-acceptance-verify`. (#678)
 - `complyctl doctor --format text|json` flag for machine-readable
   output. `--format text` produces grep-stable `[PASS]`/`[FAIL]`/
   `[WARN]` labels without emoji; `--format json` produces structured
@@ -125,6 +137,16 @@
   tags. (#506)
 
 ### Fixed
+
+- `complyctl get` signature verification now works against plain-HTTP
+  (`http://`) registries, verifies keyed cosign signatures signed with
+  `--tlog-upload=false`, and correctly matches Rekor transparency-log
+  entries. Previously, verification defaulted to HTTPS (failing on
+  plain-HTTP registries), rejected keyed signatures with a "missing
+  verification material" error, and failed to match Rekor entries
+  because the transparency-log ID was not hex-decoded. Verification now
+  uses the signature-layer (simple-signing) digest as the artifact
+  digest, matching what cosign records in the transparency log. (#678)
 
 - `complyctl scan` no longer overwrites report files when scanning
   multiple targets under the same policy. OSCAL, SARIF, and Markdown

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,65 @@ test-acceptance-clean: ## tear down acceptance test containers and volumes
 	$(ACCEPTANCE_COMPOSE) down -v --remove-orphans
 .PHONY: test-acceptance-clean
 
+VERIFICATION_COMPOSE = $(COMPOSE) -f tests/acceptance/compose.yaml --profile verification
+
+# Compose derives volume names as <project>_<volume>. The project name
+# defaults to the compose file's directory basename (acceptance) but can be
+# overridden via COMPOSE_PROJECT_NAME; honor that so the stale-volume cleanup
+# below matches the actual volumes regardless of project name.
+COMPOSE_PROJECT ?= $(if $(COMPOSE_PROJECT_NAME),$(COMPOSE_PROJECT_NAME),acceptance)
+
+test-acceptance-verify: build build-test-provider build-acceptance-test ## run verification acceptance tests (keyed cosign signing)
+	@$(VERIFICATION_COMPOSE) down -v --remove-orphans 2>/dev/null || true ; \
+	$(CONTAINER_ENGINE) volume rm -f $(COMPOSE_PROJECT)_verification-shared $(COMPOSE_PROJECT)_ctfe-config $(COMPOSE_PROJECT)_pki-material 2>/dev/null || true ; \
+	$(CONTAINER_ENGINE) volume create $(COMPOSE_PROJECT)_pki-material ; \
+	$(CONTAINER_ENGINE) build -q -f tests/acceptance/Dockerfile.generate-pki \
+		-t localhost/acceptance-pki-gen:latest tests/acceptance/ ; \
+	$(CONTAINER_ENGINE) run --rm -v $(COMPOSE_PROJECT)_pki-material:/pki \
+		localhost/acceptance-pki-gen:latest ; \
+	$(VERIFICATION_COMPOSE) up --build -d || { \
+		echo "=== container status (up failed) ===" ; \
+		$(CONTAINER_ENGINE) ps -a 2>&1 || true ; \
+		echo "=== all verification service logs ===" ; \
+		$(VERIFICATION_COMPOSE) logs 2>&1 || true ; \
+		$(VERIFICATION_COMPOSE) down -v ; \
+		exit 1 ; \
+	} ; \
+	sut=$$($(CONTAINER_ENGINE) ps -aq --filter name=verify-sut | head -1) ; \
+	if [ -z "$$sut" ]; then \
+		echo "ERROR: verify-sut container not found" ; \
+		echo "=== container status ===" ; \
+		$(CONTAINER_ENGINE) ps -a 2>&1 || true ; \
+		echo "=== all verification service logs ===" ; \
+		$(VERIFICATION_COMPOSE) logs 2>&1 || true ; \
+		$(VERIFICATION_COMPOSE) down -v ; \
+		exit 1 ; \
+	fi ; \
+	rc=$$($(CONTAINER_ENGINE) wait $$sut) ; \
+	echo "=== container status ===" ; \
+	$(CONTAINER_ENGINE) ps -a 2>&1 || true ; \
+	echo "=== all verification service logs ===" ; \
+	$(VERIFICATION_COMPOSE) logs 2>&1 || true ; \
+	echo "=== verify-sut logs ===" ; \
+	$(CONTAINER_ENGINE) logs $$sut ; \
+	$(VERIFICATION_COMPOSE) down -v ; \
+	exit $$rc
+.PHONY: test-acceptance-verify
+
+test-acceptance-verify-clean: ## tear down verification test containers and volumes
+	$(VERIFICATION_COMPOSE) down -v --remove-orphans
+.PHONY: test-acceptance-verify-clean
+
+test-acceptance-all: ## run all acceptance tests (lifecycle + verification) with guaranteed teardown of both profiles
+	@rc=0 ; \
+	$(MAKE) test-acceptance || rc=$$? ; \
+	$(MAKE) test-acceptance-verify || rc=$$? ; \
+	echo "=== ensuring both acceptance profiles are torn down ===" ; \
+	$(MAKE) test-acceptance-clean 2>/dev/null || true ; \
+	$(MAKE) test-acceptance-verify-clean 2>/dev/null || true ; \
+	exit $$rc
+.PHONY: test-acceptance-all
+
 ##@ Compilation
 
 all: clean vendor test-unit build ## compile from scratch
@@ -174,7 +233,7 @@ format:
 .PHONY: format
 
 vet:
-	go vet ./...
+	go vet -mod=vendor ./...
 .PHONY: vet
 
 lint: ## run linters (golangci-lint + goimports check)

--- a/cmd/complyctl/cli/get_verify_test.go
+++ b/cmd/complyctl/cli/get_verify_test.go
@@ -21,7 +21,7 @@ import (
 // mockVerifyFunc returns a no-op VerifyFunc for testing. Each call
 // returns a distinct func value so callers can compare identity.
 func mockVerifyFunc() cache.VerifyFunc {
-	return func(_ context.Context, _ string) (
+	return func(_ context.Context, _ string, _ bool) (
 		*cache.VerificationResult, error,
 	) {
 		return &cache.VerificationResult{Verified: true}, nil

--- a/docs/TESTING_ENVIRONMENT.md
+++ b/docs/TESTING_ENVIRONMENT.md
@@ -171,16 +171,16 @@ export GITHUB_TOKEN=<your-token>
 
 ### Binaries
 
-| Binary | Location |
-| -------- | ---------- |
-| `complyctl` | `./bin/` |
-| `mock-oci-registry` | `./bin/` |
-| `snappy` | `$GOPATH/bin` |
-| `ampel` | `$GOPATH/bin` |
-| `conftest` | `$GOPATH/bin` |
-| `complyctl-provider-ampel` | `~/.local/share/complytime/providers/` |
+| Binary                        | Location                               |
+|-------------------------------|----------------------------------------|
+| `complyctl`                   | `./bin/`                               |
+| `mock-oci-registry`           | `./bin/`                               |
+| `snappy`                      | `$GOPATH/bin`                          |
+| `ampel`                       | `$GOPATH/bin`                          |
+| `conftest`                    | `$GOPATH/bin`                          |
+| `complyctl-provider-ampel`    | `~/.local/share/complytime/providers/` |
 | `complyctl-provider-openscap` | `~/.local/share/complytime/providers/` |
-| `complyctl-provider-opa` | `~/.local/share/complytime/providers/` |
+| `complyctl-provider-opa`      | `~/.local/share/complytime/providers/` |
 
 ### Test Content
 
@@ -457,10 +457,71 @@ services under the `lifecycle` profile:
   (`go test -tags=acceptance ./tests/acceptance/...`) against the
   live registry. The compose stack exits with the SUT's exit code.
 
+### Verification Profile
+
+The verification profile extends the shared zot registry with
+Sigstore infrastructure for testing artifact signature verification.
+The compose stack (`tests/acceptance/compose.yaml`, `--profile
+verification`) runs these additional services:
+
+- **dex-idp** -- OIDC identity provider for keyless signing
+- **fulcio** -- certificate authority that issues signing
+  certificates from OIDC tokens (runs `--ca=fileca` against the
+  runtime-generated test PKI (pki-material volume))
+- **ctfe** -- RFC6962 Certificate Transparency log so keyless
+  signatures carry a real SCT the verifier requires; reuses the
+  mysql+trillian backend and shares Fulcio's committed root
+- **createtree-init** -- one-shot init that provisions the
+  Trillian tree and renders the CTFE config before `ctfe` starts
+- **rekor-server** -- transparency log recording signing events
+- **mysql** / **trillian-log-server** / **trillian-log-signer**
+  -- storage backend Rekor and the CT log require (neither has
+  an in-memory storage path)
+- **sign-seed** -- init container that pushes and signs OCI
+  artifacts in zot using cosign (keyed and keyless), generates
+  `trusted_root.json` at runtime, then exits
+- **verify-sut** -- test binary exercising the verification
+  scenarios (keyed happy path, wrong key, keyless happy path,
+  keyless wrong identity, configuration behavior) against the
+  signed artifacts
+
+Test PKI is generated at runtime by the `generate-pki` service
+into the `pki-material` Docker volume;
+`sign-seed` builds the `trusted_root.json` trust anchor at runtime
+from the generated keys plus the live Rekor key. This PKI is
+test-only with zero security value.
+
+```bash
+# Run verification acceptance tests
+make test-acceptance-verify
+
+# Specify a different compose command
+make test-acceptance-verify COMPOSE="docker compose"
+
+# Run all acceptance tests (lifecycle first, then verification)
+make test-acceptance-all
+
+# Tear down verification containers and volumes
+make test-acceptance-verify-clean
+```
+
+Prerequisites are the same as the lifecycle profile: `podman-compose`
+or `docker compose` (v2) and a container runtime.
+
 ### CI
 
 The `acceptance_test.yml` workflow runs `make test-acceptance` on
 every push and PR using `docker compose`.
+
+The `acceptance_verify_test.yml` workflow runs
+`make test-acceptance-verify` on every push and PR using
+`docker compose` with a 20-minute timeout to accommodate the
+Sigstore provisioning critical path (MySQL health check,
+Trillian/CTFE tree creation, Fulcio/Rekor readiness, artifact
+signing, and the 3-minute verification test). The job typically
+completes in well under this budget; the margin absorbs cold
+runners with no build-layer cache. Superseded runs on the same
+ref are cancelled automatically.
 
 ## See Also
 

--- a/internal/cache/complypack_sync.go
+++ b/internal/cache/complypack_sync.go
@@ -11,6 +11,8 @@ import (
 	ocistore "oras.land/oras-go/v2/content/oci"
 
 	"github.com/complytime/complypack/pkg/complypack"
+
+	"github.com/complytime/complyctl/internal/registry"
 )
 
 // ComplypackSync provides incremental sync for complypack artifacts.
@@ -22,6 +24,7 @@ type ComplypackSync struct {
 	source          ComplypackSource
 	verifier        VerifyFunc
 	registryHost    string
+	insecure        bool
 	dataDir         string
 }
 
@@ -37,12 +40,17 @@ func NewComplypackSync(complypackCache *ComplypackCache, state *State, source Co
 	for _, opt := range opts {
 		opt(cfg)
 	}
+	// Detect plain-HTTP registries from the raw scheme while normalizing the
+	// host, so signature verification (go-containerregistry) can be told to
+	// speak HTTP instead of defaulting to HTTPS, mirroring the oras-go pull path.
+	host, insecure := registry.SplitHostScheme(registryHost)
 	return &ComplypackSync{
 		complypackCache: complypackCache,
 		state:           state,
 		source:          source,
 		verifier:        cfg.verifier,
-		registryHost:    registryHost,
+		registryHost:    host,
+		insecure:        insecure,
 		dataDir:         dataDir,
 	}
 }
@@ -155,7 +163,7 @@ func (s *ComplypackSync) SyncComplypack(ctx context.Context, repository, version
 	var verifyResult *VerificationResult
 	if s.verifier != nil {
 		registryRef := BuildLookupRef(s.registryHost, repository, tag, digest)
-		vr, verifyErr := s.verifier(ctx, registryRef)
+		vr, verifyErr := s.verifier(ctx, registryRef, s.insecure)
 		if verifyErr != nil {
 			return false, fmt.Errorf("complypack %s: verification failed: %w", repository, verifyErr)
 		}
@@ -236,7 +244,7 @@ func (s *ComplypackSync) tryLocalCacheHit(
 	var verifyResult *VerificationResult
 	if s.verifier != nil {
 		registryRef := BuildLookupRef(s.registryHost, repository, tag, digest)
-		vr, verifyErr := s.verifier(ctx, registryRef)
+		vr, verifyErr := s.verifier(ctx, registryRef, s.insecure)
 		if verifyErr != nil {
 			return false, verifyErr
 		}

--- a/internal/cache/complypack_sync_test.go
+++ b/internal/cache/complypack_sync_test.go
@@ -296,7 +296,7 @@ func TestComplypackSync_LocalCacheHit_WithVerifier(t *testing.T) {
 	cpCache3 := cache.NewComplypackCache(cacheDir, state3)
 
 	verifyCalled := false
-	mockVerifier := func(_ context.Context, _ string) (*cache.VerificationResult, error) {
+	mockVerifier := func(_ context.Context, _ string, _ bool) (*cache.VerificationResult, error) {
 		verifyCalled = true
 		return &cache.VerificationResult{Verified: true}, nil
 	}
@@ -921,7 +921,7 @@ func TestComplypackSync_RegistryHost_PassedToVerifier(t *testing.T) {
 	// Track all refs passed to the verifier across call sites.
 	// All SyncComplypack calls below are sequential, so no mutex is needed.
 	var capturedRefs []string
-	capturingVerifier := func(_ context.Context, registryRef string) (*cache.VerificationResult, error) {
+	capturingVerifier := func(_ context.Context, registryRef string, _ bool) (*cache.VerificationResult, error) {
 		capturedRefs = append(capturedRefs, registryRef)
 		return &cache.VerificationResult{Verified: true}, nil
 	}
@@ -988,7 +988,7 @@ func TestComplypackSync_EmptyRegistryHost_FailClosed(t *testing.T) {
 	repository := "example.com/complypacks/opa-bundle"
 	mock.seedComplypack(repository, "io.complytime.opa", "1.0.0", cachetest.DigestA, "content")
 
-	neverCalledVerifier := func(_ context.Context, _ string) (*cache.VerificationResult, error) {
+	neverCalledVerifier := func(_ context.Context, _ string, _ bool) (*cache.VerificationResult, error) {
 		t.Fatal("verifier must not be called when registryHost is empty")
 		return nil, nil
 	}

--- a/internal/cache/sync.go
+++ b/internal/cache/sync.go
@@ -69,6 +69,7 @@ type Sync struct {
 	source       PolicySource
 	verifier     VerifyFunc
 	registryHost string
+	insecure     bool
 	dataDir      string
 }
 
@@ -83,12 +84,17 @@ func NewSync(cache *Cache, state *State, source PolicySource, dataDir, registryH
 	for _, opt := range opts {
 		opt(cfg)
 	}
+	// Detect plain-HTTP registries from the raw scheme while normalizing the
+	// host, so signature verification (go-containerregistry) can be told to
+	// speak HTTP instead of defaulting to HTTPS, mirroring the oras-go pull path.
+	host, insecure := registry.SplitHostScheme(registryHost)
 	return &Sync{
 		cache:        cache,
 		state:        state,
 		source:       source,
 		verifier:     cfg.verifier,
-		registryHost: registryHost,
+		registryHost: host,
+		insecure:     insecure,
 		dataDir:      dataDir,
 	}
 }
@@ -139,7 +145,7 @@ func (s *Sync) SyncPolicy(ctx context.Context, policyID, version string) (bool, 
 	var verifyResult *VerificationResult
 	if s.verifier != nil {
 		registryRef := BuildLookupRef(s.registryHost, policyID, tag, digest)
-		vr, verifyErr := s.verifier(ctx, registryRef)
+		vr, verifyErr := s.verifier(ctx, registryRef, s.insecure)
 		if verifyErr != nil {
 			return false, fmt.Errorf("policy %s: verification failed: %w", policyID, verifyErr)
 		}

--- a/internal/cache/sync_test.go
+++ b/internal/cache/sync_test.go
@@ -476,7 +476,7 @@ func TestSync_VerificationFailure_AbortsCopy(t *testing.T) {
 	mock.SeedPolicy("registry.example.com/test-policy", "v1.0.0", cachetest.DigestA)
 	mock.SeedPolicy("test-policy", "v1.0.0", cachetest.DigestA)
 
-	failVerifier := func(_ context.Context, _ string) (*cache.VerificationResult, error) {
+	failVerifier := func(_ context.Context, _ string, _ bool) (*cache.VerificationResult, error) {
 		return nil, fmt.Errorf("signature verification failed: identity mismatch")
 	}
 
@@ -508,7 +508,7 @@ func TestSync_VerificationSuccess_RecordsMetadata(t *testing.T) {
 	mock.SeedPolicy("registry.example.com/test-policy", "v1.0.0", cachetest.DigestA)
 	mock.SeedPolicy("test-policy", "v1.0.0", cachetest.DigestA)
 
-	successVerifier := func(_ context.Context, _ string) (*cache.VerificationResult, error) {
+	successVerifier := func(_ context.Context, _ string, _ bool) (*cache.VerificationResult, error) {
 		return &cache.VerificationResult{
 			Verified:       true,
 			SignerIdentity: "workflow@github.com",
@@ -575,7 +575,7 @@ func TestSync_RegistryHost_PassedToVerifier(t *testing.T) {
 	mock.SeedPolicy("org/test-policy", "v1.0.0", cachetest.DigestA)
 
 	var capturedRef string
-	capturingVerifier := func(_ context.Context, registryRef string) (*cache.VerificationResult, error) {
+	capturingVerifier := func(_ context.Context, registryRef string, _ bool) (*cache.VerificationResult, error) {
 		capturedRef = registryRef
 		return &cache.VerificationResult{Verified: true}, nil
 	}
@@ -596,6 +596,49 @@ func TestSync_RegistryHost_PassedToVerifier(t *testing.T) {
 		"verifier ref must NOT resolve to Docker Hub")
 }
 
+// TestSync_RegistryHost_SchemeStripped verifies that an http:// (or https://)
+// scheme on the registry host is stripped before the verifier ref is built.
+// Policy URLs carry a scheme so the registry client can detect plain-HTTP
+// registries, but go-containerregistry's reference parser rejects a scheme
+// prefix, so the cosign lookup ref must be scheme-less. Regression test for
+// the "invalid OCI reference \"http://.../...\"" verification failure.
+func TestSync_RegistryHost_SchemeStripped(t *testing.T) {
+	tmpDir := t.TempDir()
+	cacheDir := filepath.Join(tmpDir, "cache")
+	require.NoError(t, os.MkdirAll(cacheDir, 0755))
+
+	mock := cachetest.NewMockPolicySource()
+	mock.SeedPolicy("zot:5000/org/test-policy", "v1.0.0", cachetest.DigestA)
+	mock.SeedPolicy("org/test-policy", "v1.0.0", cachetest.DigestA)
+
+	var capturedRef string
+	var capturedInsecure bool
+	capturingVerifier := func(_ context.Context, registryRef string, insecure bool) (*cache.VerificationResult, error) {
+		capturedRef = registryRef
+		capturedInsecure = insecure
+		return &cache.VerificationResult{Verified: true}, nil
+	}
+
+	cacheMgr := cache.NewCache(cacheDir)
+	state, err := cache.LoadState(cacheDir)
+	require.NoError(t, err)
+
+	sync := cache.NewSync(cacheMgr, state, mock, cacheDir, "http://zot:5000/",
+		cache.WithVerifier(capturingVerifier))
+
+	_, err = sync.SyncPolicy(context.Background(), "org/test-policy", "latest")
+	require.NoError(t, err)
+
+	assert.NotContains(t, capturedRef, "http://",
+		"verifier ref must not carry an http:// scheme, got: %s", capturedRef)
+	assert.NotContains(t, capturedRef, "https://",
+		"verifier ref must not carry an https:// scheme, got: %s", capturedRef)
+	assert.Equal(t, "zot:5000/org/test-policy", capturedRef,
+		"verifier ref must be a bare host-qualified reference")
+	assert.True(t, capturedInsecure,
+		"verifier must receive insecure=true for an http:// registry host")
+}
+
 // TestSync_EmptyRegistryHost_FailClosed verifies that when a verifier is
 // configured but registryHost is empty, SyncPolicy returns a fail-closed
 // error rather than silently resolving against Docker Hub.
@@ -607,7 +650,7 @@ func TestSync_EmptyRegistryHost_FailClosed(t *testing.T) {
 	mock := cachetest.NewMockPolicySource()
 	mock.SeedPolicy("org/test-policy", "v1.0.0", cachetest.DigestA)
 
-	neverCalledVerifier := func(_ context.Context, _ string) (*cache.VerificationResult, error) {
+	neverCalledVerifier := func(_ context.Context, _ string, _ bool) (*cache.VerificationResult, error) {
 		t.Fatal("verifier must not be called when registryHost is empty")
 		return nil, nil
 	}

--- a/internal/cache/verify.go
+++ b/internal/cache/verify.go
@@ -32,8 +32,22 @@ import (
 
 // VerifyFunc verifies an OCI artifact identified by a registry reference.
 // Returns a VerificationResult on success or an error on failure.
-// A nil VerifyFunc means verification is disabled.
-type VerifyFunc func(ctx context.Context, registryRef string) (*VerificationResult, error)
+// A nil VerifyFunc means verification is disabled. The insecure flag selects
+// plain-HTTP registry access (mirroring the pull path) so signature resolution
+// works against http:// registries; go-containerregistry defaults to HTTPS
+// otherwise.
+type VerifyFunc func(ctx context.Context, registryRef string, insecure bool) (*VerificationResult, error)
+
+// nameOptions returns the go-containerregistry name options for reference
+// parsing. When insecure is true it adds name.Insecure so remote access uses
+// plain HTTP instead of the HTTPS default, matching the oras-go pull path for
+// http:// registries.
+func nameOptions(insecure bool) []name.Option {
+	if insecure {
+		return []name.Option{name.Insecure}
+	}
+	return nil
+}
 
 // VerificationResult captures sigstore-go verification output.
 type VerificationResult struct {
@@ -112,8 +126,8 @@ func NewKeylessVerifier(issuer, identity, trustedRootPath string) (VerifyFunc, e
 		return nil, fmt.Errorf("failed to create sigstore verifier: %w", err)
 	}
 
-	return func(ctx context.Context, registryRef string) (*VerificationResult, error) {
-		bun, artifactDigest, err := bundleFromCosignOCI(ctx, registryRef)
+	return func(ctx context.Context, registryRef string, insecure bool) (*VerificationResult, error) {
+		bun, artifactDigest, err := bundleFromCosignOCI(ctx, registryRef, insecure)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve cosign signature for %s: %w", registryRef, err)
 		}
@@ -168,8 +182,8 @@ func NewKeyedVerifier(keyPath string) (VerifyFunc, error) {
 		return nil, fmt.Errorf("failed to create keyed verifier: %w", err)
 	}
 
-	return func(ctx context.Context, registryRef string) (*VerificationResult, error) {
-		bun, artifactDigest, err := bundleFromCosignOCI(ctx, registryRef)
+	return func(ctx context.Context, registryRef string, insecure bool) (*VerificationResult, error) {
+		bun, artifactDigest, err := bundleFromCosignOCI(ctx, registryRef, insecure)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve cosign signature for %s: %w", registryRef, err)
 		}
@@ -194,18 +208,26 @@ func NewKeyedVerifier(keyPath string) (VerifyFunc, error) {
 // bundleFromCosignOCI resolves a cosign signature from the OCI registry for the
 // given image reference, constructs a sigstore-go bundle, and returns it along
 // with the artifact digest bytes.
-func bundleFromCosignOCI(ctx context.Context, registryRef string) (*bundle.Bundle, []byte, error) {
-	ref, digestHex, err := resolveArtifactDigest(ctx, registryRef)
+func bundleFromCosignOCI(ctx context.Context, registryRef string, insecure bool) (*bundle.Bundle, []byte, error) {
+	ref, digestHex, err := resolveArtifactDigest(ctx, registryRef, insecure)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	sigLayer, err := fetchCosignSignature(ctx, ref, digestHex, registryRef)
+	sigLayer, err := fetchCosignSignature(ctx, ref, digestHex, registryRef, insecure)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	pb, err := buildProtobufBundle(sigLayer)
+	// cosign signs the simple signing payload, not the policy manifest. The
+	// signature layer's own OCI descriptor digest is the SHA-256 of that
+	// payload and is exactly the value recorded in the Rekor hashedrekord
+	// entry, so it is what both the message-signature bundle and the verifier
+	// policy must reference. The manifest digest (digestHex) is used only to
+	// locate the signature via the sha256-<hex>.sig tag convention.
+	signedDigestHex := sigLayer.Digest.Hex
+
+	pb, err := buildProtobufBundle(sigLayer, signedDigestHex)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to build sigstore bundle from cosign annotations: %w", err)
 	}
@@ -215,7 +237,7 @@ func bundleFromCosignOCI(ctx context.Context, registryRef string) (*bundle.Bundl
 		return nil, nil, fmt.Errorf("failed to create sigstore bundle: %w", err)
 	}
 
-	artifactDigest, err := hex.DecodeString(digestHex)
+	artifactDigest, err := hex.DecodeString(signedDigestHex)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to decode artifact digest: %w", err)
 	}
@@ -225,8 +247,8 @@ func bundleFromCosignOCI(ctx context.Context, registryRef string) (*bundle.Bundl
 
 // resolveArtifactDigest parses the OCI reference and resolves the image
 // manifest digest from the registry.
-func resolveArtifactDigest(ctx context.Context, registryRef string) (name.Reference, string, error) {
-	ref, err := name.ParseReference(registryRef)
+func resolveArtifactDigest(ctx context.Context, registryRef string, insecure bool) (name.Reference, string, error) {
+	ref, err := name.ParseReference(registryRef, nameOptions(insecure)...)
 	if err != nil {
 		return nil, "", fmt.Errorf("invalid OCI reference %q: %w", registryRef, err)
 	}
@@ -245,9 +267,9 @@ func resolveArtifactDigest(ctx context.Context, registryRef string) (name.Refere
 // fetchCosignSignature resolves the cosign signature manifest from the
 // registry using the tag convention (sha256-<hex>.sig) and returns the
 // simple signing layer descriptor containing verification annotations.
-func fetchCosignSignature(ctx context.Context, ref name.Reference, digestHex, registryRef string) (*v1.Descriptor, error) {
+func fetchCosignSignature(ctx context.Context, ref name.Reference, digestHex, registryRef string, insecure bool) (*v1.Descriptor, error) {
 	sigTagStr := fmt.Sprintf("%s:sha256-%s.sig", ref.Context().Name(), digestHex)
-	sigTag, err := name.NewTag(sigTagStr)
+	sigTag, err := name.NewTag(sigTagStr, nameOptions(insecure)...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct cosign signature tag: %w", err)
 	}
@@ -286,8 +308,12 @@ func findSigningLayer(sigImage v1.Image) (*v1.Descriptor, error) {
 }
 
 // buildProtobufBundle constructs a sigstore protobuf bundle from cosign
-// layer descriptor annotations.
-func buildProtobufBundle(layer *v1.Descriptor) (*protobundle.Bundle, error) {
+// layer descriptor annotations. artifactDigestHex is the hex-encoded digest of
+// the signed payload (the cosign simple signing blob, i.e. the signature
+// layer's own OCI descriptor digest). It is the value cosign signed and
+// recorded in Rekor, and it must match the digest the verifier is given via
+// WithArtifactDigest.
+func buildProtobufBundle(layer *v1.Descriptor, artifactDigestHex string) (*protobundle.Bundle, error) {
 	annotations := layer.Annotations
 	if annotations == nil {
 		return nil, fmt.Errorf("cosign layer has no annotations")
@@ -314,9 +340,9 @@ func buildProtobufBundle(layer *v1.Descriptor) (*protobundle.Bundle, error) {
 		return nil, fmt.Errorf("failed to decode cosign signature: %w", err)
 	}
 
-	digestBytes, err := hex.DecodeString(layer.Digest.Hex)
+	digestBytes, err := hex.DecodeString(artifactDigestHex)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode layer digest: %w", err)
+		return nil, fmt.Errorf("failed to decode artifact digest: %w", err)
 	}
 
 	pb.Content = &protobundle.Bundle_MessageSignature{
@@ -357,6 +383,18 @@ func buildVerificationMaterial(annotations map[string]string) (*protobundle.Veri
 			return nil, fmt.Errorf("failed to parse cosign Rekor bundle: %w", err)
 		}
 		vm.TlogEntries = entries
+	}
+
+	// A keyed cosign signature (cosign sign --key --tlog-upload=false) carries
+	// neither a certificate nor a Rekor bundle annotation. sigstore-go rejects a
+	// bundle with empty VerificationMaterial ("missing verification material"),
+	// so emit a PublicKey identifier: the trust anchor is the out-of-band public
+	// key supplied to NewKeyedVerifier, and the trusted key material's lookup
+	// ignores the hint and returns the single configured key.
+	if !hasCert {
+		vm.Content = &protobundle.VerificationMaterial_PublicKey{
+			PublicKey: &protocommon.PublicKeyIdentifier{},
+		}
 	}
 
 	return vm, nil
@@ -402,7 +440,12 @@ func parseRekorBundle(bundleJSON string) ([]*protorekor.TransparencyLogEntry, er
 		return nil, fmt.Errorf("failed to decode SignedEntryTimestamp: %w", err)
 	}
 
-	logIDBytes, err := base64.StdEncoding.DecodeString(payload.Payload.LogID)
+	// cosign writes the Rekor bundle logID as a hex string (the SHA-256 of the
+	// log's DER public key), not base64. The trusted root stores the same value
+	// as tlog logId.keyId; decoding it as base64 yields the wrong bytes, so the
+	// entry's LogId.KeyId never matches a trusted tlog and sigstore-go drops it
+	// ("not enough verified log entries"). Hex-decode to match.
+	logIDBytes, err := hex.DecodeString(payload.Payload.LogID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode logID: %w", err)
 	}

--- a/internal/cache/verify_test.go
+++ b/internal/cache/verify_test.go
@@ -10,6 +10,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
@@ -19,8 +20,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/types"
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
 	"github.com/sigstore/sigstore-go/pkg/fulcio/certificate"
 	"github.com/sigstore/sigstore-go/pkg/verify"
 	"github.com/stretchr/testify/assert"
@@ -35,7 +38,7 @@ func TestVerifyFunc_NilSkipsVerification(t *testing.T) {
 }
 
 func TestVerifyFunc_MockSuccess(t *testing.T) {
-	mockVerifier := func(_ context.Context, ref string) (*VerificationResult, error) {
+	mockVerifier := func(_ context.Context, ref string, _ bool) (*VerificationResult, error) {
 		return &VerificationResult{
 			Verified:       true,
 			SignerIdentity: "test@example.com",
@@ -44,7 +47,7 @@ func TestVerifyFunc_MockSuccess(t *testing.T) {
 		}, nil
 	}
 
-	result, err := mockVerifier(context.Background(), "registry.com/repo:v1.0")
+	result, err := mockVerifier(context.Background(), "registry.com/repo:v1.0", false)
 	require.NoError(t, err)
 	assert.True(t, result.Verified)
 	assert.Equal(t, "test@example.com", result.SignerIdentity)
@@ -53,14 +56,46 @@ func TestVerifyFunc_MockSuccess(t *testing.T) {
 }
 
 func TestVerifyFunc_MockFailure(t *testing.T) {
-	mockVerifier := func(_ context.Context, ref string) (*VerificationResult, error) {
+	mockVerifier := func(_ context.Context, ref string, _ bool) (*VerificationResult, error) {
 		return nil, fmt.Errorf("signature verification failed for %s: identity mismatch", ref)
 	}
 
-	result, err := mockVerifier(context.Background(), "registry.com/repo:v1.0")
+	result, err := mockVerifier(context.Background(), "registry.com/repo:v1.0", false)
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "identity mismatch")
+}
+
+func TestNameOptions_InsecureSelectsPlainHTTP(t *testing.T) {
+	// nameOptions is the crux of the plain-HTTP verification fix: when
+	// insecure is true it must add name.Insecure so signature resolution
+	// uses HTTP; when false it must return no options so the HTTPS default
+	// (the security-relevant default) is preserved. A regression that
+	// inverts this branch would silently downgrade all registries to HTTP
+	// or break http:// registry verification, so both branches are asserted.
+	tests := []struct {
+		name       string
+		insecure   bool
+		wantLen    int
+		wantScheme string
+	}{
+		{name: "insecure true -> plain HTTP", insecure: true, wantLen: 1, wantScheme: "http"},
+		{name: "insecure false -> HTTPS default", insecure: false, wantLen: 0, wantScheme: "https"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := nameOptions(tc.insecure)
+			assert.Len(t, opts, tc.wantLen,
+				"nameOptions(%v) option count", tc.insecure)
+
+			// Functionally confirm the option changes reference resolution:
+			// the returned options must yield the expected registry scheme.
+			ref, err := name.ParseReference("zot:5000/policies/x:v1", opts...)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantScheme, ref.Context().Scheme(),
+				"nameOptions(%v) must yield %s registry scheme", tc.insecure, tc.wantScheme)
+		})
+	}
 }
 
 func TestParseCertificateChain_InvalidPEM(t *testing.T) {
@@ -78,7 +113,8 @@ func TestParseCertificateChain_EmptyPEM(t *testing.T) {
 func TestParseRekorBundle_ValidJSON(t *testing.T) {
 	bodyB64 := base64.StdEncoding.EncodeToString([]byte(`{"test": "body"}`))
 	setB64 := base64.StdEncoding.EncodeToString([]byte("signed-timestamp"))
-	logIDB64 := base64.StdEncoding.EncodeToString([]byte("log-id-bytes"))
+	// cosign writes the Rekor logID as a hex string (SHA-256 of the log key).
+	logIDHex := hex.EncodeToString([]byte("log-id-bytes"))
 
 	payload := rekorBundlePayload{
 		SignedEntryTimestamp: setB64,
@@ -86,7 +122,7 @@ func TestParseRekorBundle_ValidJSON(t *testing.T) {
 	payload.Payload.Body = bodyB64
 	payload.Payload.IntegratedTime = 1701205628
 	payload.Payload.LogIndex = 12345
-	payload.Payload.LogID = logIDB64
+	payload.Payload.LogID = logIDHex
 
 	jsonBytes, err := json.Marshal(payload)
 	require.NoError(t, err)
@@ -98,6 +134,8 @@ func TestParseRekorBundle_ValidJSON(t *testing.T) {
 	assert.Equal(t, int64(1701205628), entries[0].IntegratedTime)
 	assert.Equal(t, "hashedrekord", entries[0].KindVersion.Kind)
 	assert.NotNil(t, entries[0].InclusionPromise)
+	assert.Equal(t, []byte("log-id-bytes"), entries[0].LogId.KeyId,
+		"logID must be hex-decoded to match the trusted-root tlog keyId")
 }
 
 func TestParseRekorBundle_InvalidJSON(t *testing.T) {
@@ -110,7 +148,7 @@ func TestBuildProtobufBundle_MissingAnnotations(t *testing.T) {
 	layer := &v1.Descriptor{
 		MediaType: types.MediaType(cosignSimpleSigningMediaType),
 	}
-	_, err := buildProtobufBundle(layer)
+	_, err := buildProtobufBundle(layer, "")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no annotations")
 }
@@ -123,7 +161,7 @@ func TestBuildProtobufBundle_MissingSignature(t *testing.T) {
 			"some-annotation": "some-value",
 		},
 	}
-	_, err := buildProtobufBundle(layer)
+	_, err := buildProtobufBundle(layer, "")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "missing signature annotation")
 }
@@ -279,13 +317,13 @@ func TestBuildProtobufBundle_ValidAnnotations(t *testing.T) {
 
 	bodyB64 := base64.StdEncoding.EncodeToString([]byte(`{"test":"body"}`))
 	setB64 := base64.StdEncoding.EncodeToString([]byte("signed-entry-timestamp"))
-	logIDB64 := base64.StdEncoding.EncodeToString([]byte("log-id"))
+	logIDHex := hex.EncodeToString([]byte("log-id"))
 
 	rekorBundle := rekorBundlePayload{SignedEntryTimestamp: setB64}
 	rekorBundle.Payload.Body = bodyB64
 	rekorBundle.Payload.IntegratedTime = 1701205628
 	rekorBundle.Payload.LogIndex = 42
-	rekorBundle.Payload.LogID = logIDB64
+	rekorBundle.Payload.LogID = logIDHex
 	rekorJSON, err := json.Marshal(rekorBundle)
 	require.NoError(t, err)
 
@@ -302,7 +340,11 @@ func TestBuildProtobufBundle_ValidAnnotations(t *testing.T) {
 		},
 	}
 
-	pb, err := buildProtobufBundle(layer)
+	// The signed-artifact digest (policy manifest digest) is distinct from the
+	// signature layer's own OCI descriptor digest; the message digest in the
+	// bundle must carry the artifact digest so it matches WithArtifactDigest.
+	artifactDigestHex := "1111111111111111111111111111111111111111111111111111111111111111"
+	pb, err := buildProtobufBundle(layer, artifactDigestHex)
 	require.NoError(t, err)
 	assert.Equal(t, "application/vnd.dev.sigstore.bundle+json;version=0.1", pb.MediaType)
 	require.NotNil(t, pb.VerificationMaterial)
@@ -312,6 +354,12 @@ func TestBuildProtobufBundle_ValidAnnotations(t *testing.T) {
 	msgSig := pb.GetMessageSignature()
 	require.NotNil(t, msgSig)
 	assert.Equal(t, sigBytes, msgSig.Signature)
+
+	// The message digest must be the artifact digest, not the layer digest.
+	wantDigest, err := hex.DecodeString(artifactDigestHex)
+	require.NoError(t, err)
+	assert.Equal(t, wantDigest, msgSig.MessageDigest.Digest,
+		"message digest must be the signed artifact digest")
 
 	// Verify certificate chain is present
 	certChain := pb.VerificationMaterial.GetX509CertificateChain()
@@ -323,13 +371,51 @@ func TestBuildProtobufBundle_ValidAnnotations(t *testing.T) {
 	assert.Equal(t, int64(42), pb.VerificationMaterial.TlogEntries[0].LogIndex)
 }
 
+func TestBuildProtobufBundle_ArtifactDigestInvariant(t *testing.T) {
+	// bundleFromCosignOCI derives a single signedDigestHex (the signature
+	// layer's OCI descriptor digest) and feeds it to TWO sinks: the bundle's
+	// message digest (via buildProtobufBundle) and the returned artifact
+	// digest (via hex.DecodeString). Those two outputs MUST be byte-identical
+	// or sigstore-go's WithArtifactDigest check fails. bundleFromCosignOCI
+	// itself needs a live registry, so this locks the invariant at the two
+	// pure sinks it wires together, guarding against a regression that reverts
+	// signedDigestHex to the manifest digest (the original bug).
+	sigB64 := base64.StdEncoding.EncodeToString([]byte("sig"))
+	signedDigestHex := "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+
+	layer := &v1.Descriptor{
+		MediaType: types.MediaType(cosignSimpleSigningMediaType),
+		Digest:    v1.Hash{Algorithm: "sha256", Hex: signedDigestHex},
+		Annotations: map[string]string{
+			cosignAnnotationSignature: sigB64,
+		},
+	}
+
+	// Sink 1: the message digest inside the bundle.
+	pb, err := buildProtobufBundle(layer, signedDigestHex)
+	require.NoError(t, err)
+	msgDigest := pb.GetMessageSignature().MessageDigest.Digest
+
+	// Sink 2: the artifact digest returned by bundleFromCosignOCI.
+	artifactDigest, err := hex.DecodeString(signedDigestHex)
+	require.NoError(t, err)
+
+	assert.Equal(t, artifactDigest, msgDigest,
+		"returned artifact digest must equal the bundle message digest")
+}
+
 func TestBuildVerificationMaterial_NoCertNoBundle(t *testing.T) {
 	annotations := map[string]string{
 		"unrelated": "value",
 	}
 	vm, err := buildVerificationMaterial(annotations)
 	require.NoError(t, err)
-	assert.Nil(t, vm.Content)
+	// A keyed signature carries neither cert nor Rekor bundle; the verification
+	// material must still be non-empty (a PublicKey identifier) so sigstore-go
+	// accepts the bundle. The trust anchor is the out-of-band keyed verifier.
+	pubKey, ok := vm.Content.(*protobundle.VerificationMaterial_PublicKey)
+	require.True(t, ok, "keyed material must be a PublicKey identifier")
+	assert.NotNil(t, pubKey.PublicKey)
 	assert.Empty(t, vm.TlogEntries)
 }
 

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -83,10 +83,26 @@ func (c *Client) NewRemoteRepository(ctx context.Context, policyID string) (*rem
 }
 
 func (c *Client) registryHost() string {
-	host := c.registryURL
+	return NormalizeHost(c.registryURL)
+}
+
+// NormalizeHost strips an optional http:// or https:// scheme and any trailing
+// slash from a registry host, yielding a bare host suitable for OCI reference
+// construction. Policy URLs may carry a scheme so callers can detect plain-HTTP
+// registries, but go-containerregistry's reference parser (used by signature
+// verification) rejects a scheme prefix, so the bare host is stored.
+func NormalizeHost(host string) string {
 	host = strings.TrimPrefix(host, "http://")
 	host = strings.TrimPrefix(host, "https://")
 	return strings.TrimSuffix(host, "/")
+}
+
+// SplitHostScheme normalizes a registry host and reports whether it used a
+// plain-HTTP scheme. insecure is true only when the raw host carried an
+// explicit "http://" prefix, so HTTPS remains the secure default and plain-HTTP
+// is opt-in per configured URL.
+func SplitHostScheme(host string) (normalized string, insecure bool) {
+	return NormalizeHost(host), strings.HasPrefix(host, "http://")
 }
 
 // buildRef constructs a fully qualified OCI reference from a registry host and

--- a/openspec/changes/678-policy-complypack-acceptance-tests/design.md
+++ b/openspec/changes/678-policy-complypack-acceptance-tests/design.md
@@ -1,0 +1,190 @@
+## Context
+
+`complyctl get` implements OCI artifact signature verification via
+`sigstore-go` with keyed (cosign keypair) and keyless (Fulcio+Rekor) modes.
+Unit tests cover config parsing, state tracking, and resolver logic. The
+existing acceptance test stack (`tests/acceptance/`) validates the lifecycle
+profile (get/scan/report) against a real zot OCI registry but does not
+exercise signature verification.
+
+Issue #678 requires end-to-end acceptance tests that verify the full
+verification pipeline against a real OCI registry with real cosign
+signatures. This builds on PR #670 (sigstore-go verification) and
+PR #667 (utility function tests).
+
+## Goals / Non-Goals
+
+> **Superseded (see IMPLEMENTATION RECONCILIATION in tasks.md):** the
+> witness service was dropped, keyless tests are no longer skip-gated
+> (they run against a committed-fileca Fulcio + Trillian CTFE log), and
+> `trusted_root` was implemented and is exercised here. The Goals,
+> Non-Goals, Container Image Sources table, Decision #6, Decision #7,
+> and Risks below record the interim plan for historical context.
+
+### Goals
+- Acceptance-test keyed verification (cosign keypair) end-to-end
+- Stand up Sigstore infrastructure (Fulcio, Rekor, Dex, witness) for
+  keyless verification; keyless tests skip-gated pending `trusted_root`
+- Test configuration behaviors: `--skip-verify`, per-entry `skip_verify`,
+  per-entry verification override, unsigned artifact rejection
+- Validate user-facing surfaces: `complyctl list` VERIFIED column,
+  `complyctl doctor` verification diagnostics
+- Reuse existing compose-based acceptance test pattern
+
+### Non-Goals
+- Re-testing sigstore-go's internal verification correctness
+- Testing complypack verification (same code path as policies)
+- Implementing `trusted_root` field (follow-on issue)
+- TLS between containers (test stack uses plain HTTP)
+
+## Decisions
+
+### Container Image Sources
+
+> **Superseded:** the shipped stack drops witness and uses
+> `gcr.io/projectsigstore/*` (fulcio, rekor-server) plus
+> `gcr.io/trillian-opensource-ci/*` (db_server, log_server, log_signer,
+> ctfe) rather than the `ghcr.io/sigstore/*` images below, and adds a
+> `ctfe` CT log + `createtree-init`. See the reconciliation note in
+> tasks.md for the authoritative committed digests.
+
+The verification profile uses the following container images (pin by
+digest in compose.yaml, not floating tags):
+
+| Service    | Image                                        | Healthcheck                              |
+|------------|----------------------------------------------|------------------------------------------|
+| dex-idp    | `ghcr.io/dexidp/dex`                         | OIDC discovery: `/.well-known/openid-configuration` |
+| fulcio     | `ghcr.io/sigstore/fulcio`                    | `curl -f http://localhost:5555/healthz`  |
+| rekor      | `ghcr.io/sigstore/rekor/rekor-server`          | `curl -f http://localhost:3000/api/v1/log` |
+| witness    | `ghcr.io/transparency-dev/witness/omniwitness` | `curl -sf http://localhost:8100/healthz` or file check `test -s /data/witness.log` |
+
+Resolve current digests at implementation time from each project's
+releases page. Pin the exact `@sha256:` digest in compose.yaml.
+
+### 1. Separate compose profile
+
+**Decision**: Add a `verification` profile to the existing `compose.yaml`
+rather than a separate compose file.
+
+**Rationale**: The `zot` service is shared between profiles, avoiding
+duplicate registry configuration. Docker Compose profile semantics allow
+`test-acceptance` and `test-acceptance-verify` to run independently. A
+separate compose file would duplicate the zot service definition and
+network configuration. When both profiles are activated simultaneously
+(e.g., `--profile lifecycle --profile verification`), the zot service
+starts once and both seed containers push to separate repository paths
+(`acceptance-test` vs `verify-*`), so no conflict occurs.
+
+### 2. Committed test PKI (fileca + CTFE)
+
+> **Reconciliation note**: an interim implementation used a Fulcio
+> ephemeral in-memory CA with no committed PKI. That was superseded
+> once keyless verification had to satisfy the production sigstore-go
+> verifier's SCT requirement, which needs a real CT log sharing a
+> committed root with Fulcio. See the IMPLEMENTATION RECONCILIATION
+> note at the top of `tasks.md` for the full delta.
+
+**Decision**: Check committed PKI material into
+`tests/acceptance/testdata/sigstore/`: the Fulcio fileca root
+(`root.pem`+`root.key`) and the CTFE signing key
+(`privkey.pem`+`ctfe.pub`). Fulcio runs `--ca=fileca` and the CTFE
+CT log signs SCTs with the CTFE key; both trust the committed root.
+`sign-seed.sh` assembles `trusted_root.json` at runtime from these
+committed keys plus the live Rekor public key. Dex/Fulcio config
+live at `tests/acceptance/`.
+
+**Rationale**: The keyless verifier requires an embedded SCT from a
+CT log, and the CT log's `--roots_pem_file` must match the CA Fulcio
+issues from, so Fulcio and the CT log must share a stable committed
+root. Runtime key generation cannot satisfy that chicken-and-egg
+ordering deterministically. The material is test-only with zero
+security value.
+
+### 3. sign-seed init container
+
+**Decision**: Use a dedicated `sign-seed` container (UBI-minimal +
+cosign + oras) to push testdata, sign artifacts, and generate
+`trusted_root.json`, rather than signing at image build time.
+
+**Rationale**: Signing requires a running Fulcio and Rekor for keyless
+mode. The sign-seed container runs after all Sigstore services are
+healthy, ensuring correct dependency ordering. Cosign keypair signing
+(keyed mode) also happens here for consistency, even though it does not
+require Fulcio/Rekor.
+
+### 4. Three repository paths
+
+**Decision**: Push identical Gemara testdata to three zot repository
+paths with different signing treatments:
+- `policies/verify-keyed` -- cosign keypair
+- `policies/verify-keyless` -- Fulcio + Rekor keyless
+- `policies/verify-unsigned` -- no signing
+
+**Rationale**: Isolating signing modes by repository path allows tests
+to use different `complytime.yaml` configurations per test case without
+re-pushing or re-signing content.
+
+### 5. Shared acceptance binary
+
+**Decision**: Verification tests use the same `acceptance.test` binary
+and `//go:build acceptance` tag as the existing lifecycle tests. The
+`verify-sut` container filters with `-test.run=TestVerification`.
+
+**Rationale**: Avoids a second compile target and keeps all acceptance
+tests in one package. Test filtering via `-test.run` is the standard
+Go mechanism for partitioning test execution. To ensure lifecycle
+isolation, verification tests include a `skipIfNoVerificationEnv(t)`
+guard that skips when `COSIGN_KEY_PATH` is not set, preventing them
+from running in the lifecycle profile's `sut` container.
+
+### 6. Keyless tests skip-gated
+
+> **Superseded:** keyless tests are NOT skip-gated in the shipped
+> implementation. `trusted_root` was added to `VerificationConfig` and
+> the keyless scenarios run live against a committed-fileca Fulcio and a
+> Trillian-backed CTFE log, with `trusted_root.json` assembled at
+> runtime from the committed CA + CTFE keys plus the live Rekor key.
+
+**Decision**: Keyless test scenarios (`TestVerification_Keyless_*`) use
+`t.Skip("requires trusted_root support")` until the `trusted_root`
+field is added to `VerificationConfig`.
+
+**Rationale**: The current `NewKeylessVerifier` uses Sigstore's public
+good TUF root, which does not trust the local Fulcio/Rekor instances.
+A `trusted_root` field is needed to point verification at the local
+infrastructure. Standing up the infrastructure now ensures the tests
+can be unblocked with a single field addition rather than a large
+infrastructure change.
+
+### 7. Separate CI workflow
+
+**Decision**: New `.github/workflows/acceptance_verify_test.yml`
+separate from `acceptance_test.yml`.
+
+**Rationale**: Sigstore infrastructure (5+ containers) is heavier and
+more failure-prone than the lifecycle stack (zot + seed + sut). Keeping
+workflows separate prevents Sigstore flakiness from blocking core
+acceptance CI.
+
+## Risks / Trade-offs
+
+- **[Container image stability]** Rekor-tiles and omniwitness use
+  rolling tags or `main` branches. Mitigated by digest-pinning in
+  compose.yaml.
+
+- **[Compose stack complexity]** The verification profile adds 6 new
+  services (dex, fulcio, rekor, witness, sign-seed, verify-sut).
+  Mitigated by profile isolation -- lifecycle tests never start these
+  services.
+
+- **[Keyless test coverage deferred]** Keyless tests skip until
+  `trusted_root` lands. Mitigated by standing up full infrastructure
+  now so the unblock is a single config field addition.
+
+- **[CI resource usage]** Sigstore stack requires more memory/CPU than
+  lifecycle tests. Estimated peak memory: ~4 GB for combined stack
+  (7 containers). GitHub Actions `ubuntu-latest` provides 7 GB RAM /
+  2 CPUs, which should be sufficient. If CI OOM-kills occur, consider
+  adding `mem_limit` to compose services or switching to a larger
+  runner. Mitigated by separate workflow with independent timeout
+  (15 minutes).

--- a/openspec/changes/678-policy-complypack-acceptance-tests/proposal.md
+++ b/openspec/changes/678-policy-complypack-acceptance-tests/proposal.md
@@ -1,0 +1,100 @@
+## Why
+
+`complyctl get` implements OCI artifact signature verification via `sigstore-go`
+(keyed and keyless modes). Unit tests cover parsing, state tracking, and resolver
+logic, but no end-to-end acceptance test exercises the full verification flow
+against a real OCI registry with real cosign signatures. Without acceptance
+coverage, regressions in the verification pipeline (pre-copy timing, state
+persistence, CLI surfaces) would go undetected until manual testing.
+
+## What Changes
+
+> **Note**: the bullets below record the original proposal. The shipped
+> implementation dropped the witness service, added a real CTFE CT log
+> (Fulcio `--ca=fileca` with committed PKI), and un-skipped the keyless
+> tests. See the IMPLEMENTATION RECONCILIATION note at the top of
+> `tasks.md` and Decision #2 in `design.md` for the full delta.
+
+- Extend `tests/acceptance/compose.yaml` with a `verification` profile that
+  stands up Sigstore infrastructure (Dex, Fulcio, Rekor, witness) alongside
+  the existing zot registry.
+- Add a `sign-seed` init container that pushes Gemara testdata to zot under
+  three repository paths with different signing treatments: cosign keypair,
+  Fulcio+Rekor keyless, and unsigned.
+- Add a `verify-sut` container that runs verification acceptance tests against
+  the seeded registry.
+- Pre-generate all test PKI material in `tests/acceptance/testdata/sigstore/`
+  for deterministic container startup.
+- Implement 8 test scenarios across keyed, keyless, and configuration behavior
+  groups. Keyless tests are skip-gated pending `trusted_root` support.
+- Add `make test-acceptance-verify` and `make test-acceptance-all` targets.
+- Add `.github/workflows/acceptance_verify_test.yml` CI workflow, separate
+  from existing acceptance tests to isolate Sigstore infrastructure failures.
+
+## Capabilities
+
+### New Capabilities
+- `verification-acceptance-tests`: End-to-end acceptance tests for OCI
+  artifact signature verification covering keyed mode, keyless mode
+  (skip-gated), skip-verify flag, per-entry overrides, and unsigned
+  artifact rejection against a real OCI registry with real cosign
+  signatures.
+
+### Modified Capabilities
+- `acceptance-tests`: Extended compose stack gains `verification` profile
+  with Sigstore services; existing `lifecycle` profile unchanged.
+
+## Impact
+
+- **New files**: `Dockerfile.sign-seed`, `Dockerfile.verify-sut`,
+  `verification_test.go`, `verification_helpers_test.go`, `sign-seed.sh`,
+  `testdata/sigstore/*` (9 PKI/config files), CI workflow
+- **Modified files**: `compose.yaml` (new profile + services), `Makefile`
+  (new targets), `AGENTS.md` (CI table, test commands, project structure,
+  recent changes)
+- **Production code**: `internal/cache/verify.go`, `sync.go`, and
+  `complypack_sync.go` gain plain-HTTP (`http://`) registry scheme
+  support and keyed/keyless bundle fixes surfaced by the live stack
+  (see the tasks.md IMPLEMENTATION RECONCILIATION note). The
+  `VerifyFunc` signature gains an `insecure bool` parameter, threaded
+  through all call sites.
+- **Dependencies**: Sigstore container images (dex, fulcio, rekor-tiles,
+  omniwitness) digest-pinned in compose.yaml; cosign CLI in sign-seed
+  container
+
+## Constitution Alignment
+
+Assessed against the Unbound Force org constitution.
+
+### I. Autonomous Collaboration
+
+**Assessment**: PASS
+
+Acceptance tests are self-contained in the compose stack. All
+artifacts (PKI, configs, test binaries) are committed and
+self-describing. No external service dependencies at runtime.
+
+### II. Composability First
+
+**Assessment**: PASS
+
+Verification tests use a separate compose profile (`verification`)
+and a separate Makefile target (`test-acceptance-verify`). The
+existing `lifecycle` profile and `test-acceptance` target are
+unchanged. Each profile can run independently.
+
+### III. Observable Quality
+
+**Assessment**: PASS
+
+Test output follows Go test conventions with machine-parseable
+results. Container logs are captured on failure for debugging.
+State files are inspected programmatically for verification
+assertions.
+
+### IV. Testability
+
+**Assessment**: PASS
+
+This change is itself a test infrastructure addition. All
+components are testable in isolation via compose profiles.

--- a/openspec/changes/678-policy-complypack-acceptance-tests/tasks.md
+++ b/openspec/changes/678-policy-complypack-acceptance-tests/tasks.md
@@ -1,0 +1,184 @@
+<!-- spec-review: passed -->
+<!--
+  [P] marks tasks eligible for parallel execution.
+  Add [P] when a task: (a) touches different files from
+  other [P] tasks in the group, (b) has no dependency
+  on prior tasks in the group, (c) can safely execute
+  without ordering constraints.
+  Do NOT add [P] when tasks modify the same file --
+  parallel workers will cause merge conflicts.
+  Tasks without [P] run sequentially first, then [P]
+  tasks run in parallel.
+-->
+
+<!--
+  IMPLEMENTATION RECONCILIATION (2026-08-05)
+
+  The tasks below record the ORIGINAL plan. The shipped
+  implementation diverged in several ways once the real
+  Sigstore trust chain was wired end-to-end. This note
+  reconciles task text with what was actually delivered;
+  the checkboxes are left as the historical record.
+
+  - PKI (section 1). NOTE: an interim design used a Fulcio
+    ephemeral in-memory CA with no committed PKI; that was
+    SUPERSEDED once keyless verification had to satisfy the
+    production sigstore-go verifier's SCT requirement. The
+    shipped design provisions a real RFC6962 CT log so keyless
+    signatures carry a genuine SCT, which requires Fulcio and
+    the CT log to share a committed root. Committed test PKI
+    now lives at `tests/acceptance/testdata/sigstore/`:
+    `root.pem`+`root.key` (Fulcio fileca CA, `--ca=fileca`
+    `--fileca-key-passwd=fulcio`), `privkey.pem`+`ctfe.pub`
+    (CTFE signing key, PEM legacy-encrypted, passphrase
+    `ctfe`). `dex-config.yaml` and `fulcio-config.yaml` live
+    at `tests/acceptance/`. `sign-seed.sh` still builds
+    `trusted_root.json` at RUNTIME via `cosign trusted-root
+    create`, now from the committed CA + CTFE keys plus the
+    live Rekor key. Rekor/witness keys were NOT needed
+    (see below); the keys have zero security value.
+
+  - Witness dropped entirely (tasks 1.3, 1.6, 2.1). complyctl's
+    verify path (`NewKeylessVerifier`) checks a Fulcio cert +
+    SCT + Rekor transparency-log entry only; cosign keyless
+    signing contacts Fulcio and Rekor exclusively. No code
+    path contacts a witness, so a witness service would test
+    infrastructure nothing exercises (zero-waste).
+
+  - Rekor requires Trillian + MySQL (section 2). Rekor has no
+    in-memory storage mode, so the verification profile adds
+    `mysql`, `trillian-log-server`, and `trillian-log-signer`
+    alongside `rekor-server`, mirroring Sigstore's own
+    reference docker-compose. The CT log (`ctfe`,
+    `gcr.io/trillian-opensource-ci/ctfe`) reuses that same
+    mysql+trillian backend; a `createtree-init` service
+    (`Dockerfile.createtree`, `createtree@v1.6.1`) provisions
+    the Trillian tree and renders `ct_server.cfg` before
+    `ctfe` starts. Fulcio's `--ct-log-url` points at
+    `http://ctfe:6962/testlog`.
+
+  - Image registries: `gcr.io/projectsigstore/*` (fulcio,
+    rekor-server), `gcr.io/trillian-opensource-ci/*` (db_server,
+    log_server, log_signer), `ghcr.io/dexidp/dex` -- not the
+    `ghcr.io/sigstore/*` / transparency-dev paths named in
+    task 2.1. All are digest-pinned.
+
+  - `Dockerfile.sign-seed` runs as ROOT, not `USER nobody`
+    (task 3.1). It writes to the root-owned `/shared` named
+    volume and generates keys under `/tmp`; private keys never
+    leave the container. It also installs `curl` + `jq` for
+    the OIDC token exchange and trust-root assembly.
+
+  - Keyless signing is REQUIRED, not skip-on-failure (task 4.3).
+    With the trust chain present, `sign-seed.sh` fails closed
+    (`set -euo pipefail`, empty/null token guard) rather than
+    silently skipping keyless signing.
+
+  - Keyless tests are no longer skip-gated (section 7). Both
+    `TestVerification_Keyless_HappyPath` and
+    `TestVerification_Keyless_WrongIdentity` are un-skipped and
+    thread a `trusted_root` path (from `TRUSTED_ROOT_PATH`,
+    default `/shared/trusted_root.json`) into
+    `withKeylessVerification(issuer, identity, trustedRootPath)`.
+    `WrongIdentity` asserts the stable wrap prefix
+    `"signature verification failed"` plus an `"identity"`
+    substring to distinguish an identity mismatch from a
+    wrong-key failure.
+
+  - `WrongKey`/`UnsignedWithVerification` cache-absence
+    assertions now resolve the policy cache via
+    `complytime.ResolveCacheDir()` (XDG) instead of the legacy
+    `~/.complytime/...` path.
+
+  - Makefile `test-acceptance-verify` dumps `ps -a` and logs
+    for ALL verification-profile services (via
+    `$(VERIFICATION_COMPOSE) logs`) on both the up-failure
+    branch and the post-wait failure path before teardown,
+    satisfying task 9.1's all-services log-capture intent
+    (the witness service itself was dropped).
+
+  - Verification code fixes surfaced by the live stack
+    (`internal/cache/verify.go`): honor the `http://`
+    plain-HTTP registry scheme for cosign-signature
+    resolution; emit a PublicKey verification material for
+    keyed (no-cert) bundles; hex-decode the Rekor bundle
+    logID (cosign writes it as hex); use the signature-layer
+    (simplesigning payload) digest as both the
+    message-signature digest and the verifier artifact
+    digest. Every verification test clears the global policy
+    cache so the incremental-digest skip cannot mask a
+    re-verification; the keyed happy-path assertion is
+    decoupled from the `doctor` providers check.
+-->
+
+## 1. Pre-Generated Test PKI
+
+- [x] 1.1 [P] Generate Fulcio root CA certificate and private key (`fulcio-root.pem`, `fulcio-root.key`) using `openssl ecparam -genkey -name prime256v1` (EC P-256), self-signed with CA:TRUE basic constraint, write to `tests/acceptance/testdata/sigstore/`
+- [x] 1.2 [P] Generate Rekor Ed25519 signing keypair (`rekor-signing-key.pem`, `rekor-signing-pub.pem`) using `openssl genpkey -algorithm ed25519`, write to `tests/acceptance/testdata/sigstore/`
+- [x] 1.3 [P] Generate witness private key (`witness-private.key`) using `openssl genpkey -algorithm ed25519`, write to `tests/acceptance/testdata/sigstore/`
+- [x] 1.4 [P] Create Dex OIDC configuration (`dex-config.yaml`) with `mockCallback` connector, issuer `http://dex-idp:5556/dex`, `web: { http: "0.0.0.0:5556" }`, static client `complyctl-test` with secret `test-secret` (test-only mock credential, matches task 4.3), test user `admin@example.com` with password `password` (test-only); write to `tests/acceptance/testdata/sigstore/`
+- [x] 1.5 [P] Create Fulcio identity configuration (`fulcio-identity.yaml`) trusting local Dex issuer, write to `tests/acceptance/testdata/sigstore/`
+- [x] 1.6 [P] Create witness policy configuration (`witness-policy.yaml`) and witness log configuration (`witness-config.yaml`), write to `tests/acceptance/testdata/sigstore/`
+- [x] 1.7 [P] Create `tests/acceptance/testdata/sigstore/README.md` with header `# TEST-ONLY PKI -- DO NOT REUSE` explaining these keys have zero security value and MUST NOT be used outside the acceptance test stack
+
+## 2. Compose Stack
+
+- [x] 2.1 Extend `tests/acceptance/compose.yaml` with `verification` profile: update the existing `zot` service profiles from `[lifecycle]` to `[lifecycle, verification]` to share the registry across both profiles; add `dex-idp` (`ghcr.io/dexidp/dex`, healthcheck: `curl -sf http://localhost:5556/dex/.well-known/openid-configuration`), `fulcio` (`ghcr.io/sigstore/fulcio`, healthcheck: `curl -f http://localhost:5555/healthz`), `rekor` (`ghcr.io/sigstore/rekor/rekor-server`, healthcheck: `curl -f http://localhost:3000/api/v1/log`), `witness` (`ghcr.io/transparency-dev/witness/omniwitness`, healthcheck: `curl -sf http://localhost:8100/healthz || test -s /data/witness.log`) services with digest-pinned images (pin specific sha256 digests, not floating tags), healthchecks, and correct dependency ordering
+- [x] 2.2 Add `sign-seed` service to compose.yaml (verification profile): depends on dex-idp, fulcio, rekor, zot healthy; runs `sign-seed.sh`; mounts testdata and shared volume
+- [x] 2.3 Add `verify-sut` service to compose.yaml (verification profile): depends on sign-seed completed; runs `acceptance.test -test.run=TestVerification`; mounts shared volume for cosign keys and trusted_root; environment variables: `REGISTRY_URL` (zot address), `COSIGN_KEY_PATH` (path to cosign.pub in shared volume), `COSIGN_WRONG_KEY_PATH` (path to wrong.pub), `TRUSTED_ROOT_PATH` (path to trusted_root.json), `VERIFY_KEYED_POLICY_ID`, `VERIFY_KEYLESS_POLICY_ID`, `VERIFY_UNSIGNED_POLICY_ID`
+
+## 3. Container Images
+
+- [x] 3.1 [P] Create `tests/acceptance/Dockerfile.sign-seed` (UBI-minimal base, install oras CLI version-pinned with SHA256 checksum matching `Dockerfile.seed` pattern, install cosign CLI version-pinned with SHA256 checksum -- e.g., `ARG COSIGN_VERSION=2.4.3` / `ARG COSIGN_SHA256=<checksum>` from cosign releases checksums.txt, copy sign-seed.sh, `USER nobody` matching `Dockerfile.seed` security pattern); only mount `cosign.pub` and `wrong.pub` into shared volume (private keys stay in sign-seed container)
+- [x] 3.2 [P] Create `tests/acceptance/Dockerfile.verify-sut` (same pattern as existing `Dockerfile.sut`, copy acceptance binary and complyctl binary)
+
+## 4. Signing Script
+
+- [x] 4.1 Create `tests/acceptance/sign-seed.sh` with `set -euo pipefail` (matching `seed.sh` error handling pattern): push Gemara testdata (`catalog.yaml:application/vnd.gemara.catalog.v1+yaml` and `policy.yaml:application/vnd.gemara.policy.v1+yaml` from mounted `/testdata`, matching `seed.sh` media types) to three zot repository paths (`policies/verify-keyed`, `policies/verify-keyless`, `policies/verify-unsigned`); verify each push succeeded before proceeding
+- [x] 4.2 In `sign-seed.sh`: set `COSIGN_PASSWORD=""` for non-interactive key generation (empty passphrase, acceptable for test-only keys), generate cosign keypair with `cosign generate-key-pair`, sign `policies/verify-keyed` with retry (up to 3 attempts with 2s backoff on transient failure) using `cosign sign --key --tlog-upload=false --allow-http-registry`
+- [x] 4.3 In `sign-seed.sh`: obtain OIDC token from Dex via direct HTTP token exchange (`curl -s -d 'grant_type=password&username=admin@example.com&password=password&scope=openid email&client_id=complyctl-test&client_secret=test-secret' http://dex-idp:5556/dex/token` -- credentials MUST match those configured in `dex-config.yaml` from task 1.4; these are test-only mock credentials with no security value), sign `policies/verify-keyless` with retry (up to 3 attempts with 2s backoff on transient failure) using `cosign sign --fulcio-url --rekor-url --identity-token=$TOKEN --allow-http-registry`; if OIDC token acquisition fails, log warning and skip keyless signing (allow keyed tests to proceed independently)
+- [x] 4.4 In `sign-seed.sh`: generate `trusted_root.json` from local Fulcio root cert and Rekor public key, write to shared volume
+- [x] 4.5 In `sign-seed.sh`: generate a second cosign keypair ("wrong key") for negative test cases, write to shared volume
+
+## 5. Verification Test Helpers
+
+- [x] 5.1 Create `tests/acceptance/verification_helpers_test.go` with `//go:build acceptance` tag: `writeVerificationConfig(t *testing.T, dir string, registryURL string, opts ...verifyOption)` helper using functional options pattern -- options: `withKeyedVerification(keyPath string)`, `withKeylessVerification(issuer, identity string)`, `withSkipVerify()`, `withPolicyEntries(entries []policyEntryConfig)` for multi-entry scenarios; writes `complytime.yaml` with appropriate `verification:` and `policies:` blocks
+- [x] 5.2 In `verification_helpers_test.go`: `readPolicyState()` helper that reads and unmarshals `state.json` for verification assertions
+- [x] 5.3 In `verification_helpers_test.go`: `runComplyctlExpectError()` helper that runs complyctl and returns combined output + error without calling `t.Fatalf`, enabling assertion on stderr content and exit code for negative tests
+
+- [x] 5.4 In `verification_test.go`: add a package-level `skipIfNoVerificationEnv(t)` guard that calls `t.Skip("verification env vars not set")` when `COSIGN_KEY_PATH` is not set; call this guard at the start of every `TestVerification_*` function (sections 6-8) to prevent verification tests from running in the lifecycle profile's `sut` container, which does not set these env vars
+
+## 6. Verification Tests -- Keyed
+
+- [x] 6.1 Implement `TestVerification_Keyed_HappyPath` in `tests/acceptance/verification_test.go`: configure keyed verification with correct cosign.pub, run `complyctl get`, assert `verified: true` in state, assert `complyctl list` shows VERIFIED=Yes, assert `complyctl doctor` reports verified
+- [x] 6.2 Implement `TestVerification_Keyed_WrongKey` in `tests/acceptance/verification_test.go`: configure keyed verification with wrong.pub, run `complyctl get`, assert non-zero exit code, assert stderr contains `"signature verification failed"` (from `verify.go:171`), assert no policy content in cache
+
+## 7. Verification Tests -- Keyless (Skip-Gated)
+
+- [x] 7.1 Implement `TestVerification_Keyless_HappyPath` in `tests/acceptance/verification_test.go`: configure keyless verification with Dex issuer and identity, `t.Skip("requires trusted_root support")`, assert `verified: true` with signer_identity and issuer populated
+- [x] 7.2 Implement `TestVerification_Keyless_WrongIdentity` in `tests/acceptance/verification_test.go`: configure keyless with wrong identity, `t.Skip("requires trusted_root support")`, assert failure with identity mismatch error
+
+## 8. Verification Tests -- Configuration Behavior
+
+- [x] 8.1 Implement `TestVerification_SkipVerifyFlag` in `tests/acceptance/verification_test.go`: configure keyed verification, run `complyctl get --skip-verify`, assert success with `verified: false`, assert stderr contains `"WARNING: signature verification skipped"` (from `get.go:107`) and `"NOTE: policy"` followed by `"was fetched without"` (from `get.go:402`)
+- [x] 8.2 Implement `TestVerification_PerEntrySkipVerify` in `tests/acceptance/verification_test.go`: workspace-level keyed verification, two policy entries (verify-keyed inherits workspace verification, verify-unsigned with `skip_verify: true`); expected YAML structure: `verification: { key: <cosign.pub> }` at workspace level, `policies: [{ url: .../verify-keyed }, { url: .../verify-unsigned, skip_verify: true }]`; assert verify-keyed `verified=true` in state, verify-unsigned `verified=false` in state
+- [x] 8.3 Implement `TestVerification_PerEntryOverride` in `tests/acceptance/verification_test.go`: workspace-level keyless (will not work without trusted_root), one entry overrides with per-entry keyed verification (`verification: { key: <cosign.pub> }`), second entry uses `skip_verify: true` to avoid keyless failure; assert keyed entry `verified=true`, skipped entry `verified=false`; this tests per-entry override precedence without requiring working keyless infrastructure
+- [x] 8.4 Implement `TestVerification_UnsignedWithVerification` in `tests/acceptance/verification_test.go`: keyed verification configured, policy points to verify-unsigned, assert non-zero exit code, assert stderr contains `"no cosign signature found"` (from `verify.go:247`), assert `state.json` does not contain an entry for verify-unsigned policy, assert no OCI layout directory exists for verify-unsigned under the cache
+
+## 9. Build and CI
+
+- [x] 9.1 [P] Add `test-acceptance-verify`, `test-acceptance-verify-clean`, and `test-acceptance-all` targets to `Makefile`; add `VERIFICATION_COMPOSE` variable with `--profile verification` (matching `ACCEPTANCE_COMPOSE` pattern); `test-acceptance-verify` depends on `build build-test-provider build-acceptance-test` (matching `test-acceptance` prerequisite pattern); `test-acceptance-verify` MUST capture container logs from all verification-profile services (sign-seed, dex-idp, fulcio, rekor, witness, verify-sut) on failure before teardown, matching the existing log capture pattern in `test-acceptance`; `test-acceptance-verify-clean` tears down verification profile containers and volumes; `test-acceptance-all` depends on `test-acceptance` and `test-acceptance-verify`, running them sequentially (lifecycle profile first, then verification profile)
+- [x] 9.2 [P] Create `.github/workflows/acceptance_verify_test.yml` (triggers: push to main, `pull_request: types: [opened, synchronize]` matching `acceptance_test.yml` pattern; runner: ubuntu-latest; timeout: 15m; steps: checkout, setup Go, `make test-acceptance-verify COMPOSE="docker compose"`)
+
+## 10. Documentation
+
+- [x] 10.1 Update `AGENTS.md` CI Workflow Structure table with `acceptance_verify_test.yml` entry
+- [x] 10.2 Update `AGENTS.md` Test commands section with `make test-acceptance-verify` and `make test-acceptance-all`
+- [x] 10.3 Update `AGENTS.md` Project Structure with `testdata/sigstore/` under `tests/acceptance/`
+- [x] 10.4 Update `AGENTS.md` Recent Changes with verification acceptance tests entry
+- [x] 10.5 Update `docs/TESTING_ENVIRONMENT.md` "Container-Based Acceptance Tests" section with: verification profile architecture (Sigstore services + sign-seed + verify-sut), `make test-acceptance-verify` and `make test-acceptance-all` commands, new CI workflow reference, and verification profile prerequisites
+
+## 11. Regression Verification
+
+- [x] 11.1 Run `make test-acceptance` to confirm existing lifecycle profile is unaffected by compose.yaml changes
+- [x] 11.2 Run `make test-acceptance-verify` to confirm the new verification profile works end-to-end

--- a/tests/acceptance/Dockerfile.createtree
+++ b/tests/acceptance/Dockerfile.createtree
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# CTFE provisioning init image for the acceptance verification stack.
+#
+# Builds the Trillian `createtree` admin tool (no prebuilt image is published)
+# and ships it alongside a MySQL client and openssl on a slim Debian base so the
+# createtree-init.sh entrypoint can:
+#   1. wait for trillian-log-server admin gRPC,
+#   2. load the CTFE issuance-chain MySQL schema,
+#   3. provision a Trillian tree and capture its numeric tree id,
+#   4. render ct_server.cfg (tree id + CTFE public-key DER) into the shared
+#      config volume that ct_server (ctfe) reads.
+#
+# trivy:ignore:DS001 base images below are digest-pinned; suppression covers the tag portion
+# trivy:ignore:DS026 ephemeral test-only init container, no HEALTHCHECK needed
+
+# Pin the Go toolchain by digest (global constraint: all images digest-pinned).
+FROM docker.io/library/golang:1.24-bookworm@sha256:1a6d4452c65dea36aac2e2d606b01b4a029ec90cc1ae53890540ce6173ea77ac AS build
+
+# createtree is not published as a standalone image, so build it from the
+# pinned Trillian module version that matches our log_server/log_signer images.
+ARG TRILLIAN_VERSION=v1.6.1
+ENV CGO_ENABLED=0
+RUN go install "github.com/google/trillian/cmd/createtree@${TRILLIAN_VERSION}"
+
+FROM docker.io/library/debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241
+
+# default-mysql-client: load the CTFE schema. openssl: derive the CTFE public
+# key DER for the ct_server.cfg render. netcat: probe the Trillian admin port.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    default-mysql-client \
+    openssl \
+    netcat-openbsd \
+    ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /go/bin/createtree /usr/local/bin/createtree
+COPY createtree-init.sh /usr/local/bin/createtree-init.sh
+RUN chmod +x /usr/local/bin/createtree-init.sh
+
+ENTRYPOINT ["/usr/local/bin/createtree-init.sh"]

--- a/tests/acceptance/Dockerfile.generate-pki
+++ b/tests/acceptance/Dockerfile.generate-pki
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# trivy:ignore:DS001 -- test container, intentionally floats on latest UBI
+# trivy:ignore:DS026 -- ephemeral init container, exits after generating PKI material
+# scorecard:pinned-dependencies -- intentionally unpinned; UBI images track latest for errata coverage
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest
+
+RUN microdnf install -y openssl && microdnf clean all
+
+COPY generate-pki.sh /generate-pki.sh
+RUN chmod +x /generate-pki.sh
+
+ENTRYPOINT ["/generate-pki.sh"]

--- a/tests/acceptance/Dockerfile.sign-seed
+++ b/tests/acceptance/Dockerfile.sign-seed
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# trivy:ignore:DS001 -- test container, intentionally floats on latest UBI
+# trivy:ignore:DS026 -- ephemeral seed container, exits after signing artifacts
+# scorecard:pinned-dependencies -- intentionally unpinned; UBI images track latest for errata coverage
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest
+
+ARG ORAS_VERSION=1.2.2
+# sha256 from https://github.com/oras-project/oras/releases/tag/v1.2.2 checksums.txt
+ARG ORAS_SHA256=bff970346470e5ef888e9f2c0bf7f8ee47283f5a45207d6e7a037da1fb0eae0d
+
+ARG COSIGN_VERSION=2.4.3
+# sha256 from https://github.com/sigstore/cosign/releases/tag/v2.4.3 cosign_checksums.txt
+ARG COSIGN_SHA256=caaad125acef1cb81d58dcdc454a1e429d09a750d1e9e2b3ed1aed8964454708
+
+RUN microdnf install -y tar gzip curl jq && microdnf clean all
+
+ADD https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz /tmp/oras.tar.gz
+RUN echo "${ORAS_SHA256}  /tmp/oras.tar.gz" | sha256sum -c - && \
+    tar -xzf /tmp/oras.tar.gz -C /usr/local/bin oras && \
+    rm /tmp/oras.tar.gz && \
+    chmod +x /usr/local/bin/oras
+
+ADD https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-linux-amd64 /tmp/cosign
+RUN echo "${COSIGN_SHA256}  /tmp/cosign" | sha256sum -c - && \
+    mv /tmp/cosign /usr/local/bin/cosign && \
+    chmod +x /usr/local/bin/cosign
+
+COPY sign-seed.sh /sign-seed.sh
+RUN chmod +x /sign-seed.sh
+
+# Note: unlike Dockerfile.seed which runs as USER nobody (read-only
+# network writes only), sign-seed writes to /shared volume and /tmp
+# for cosign key generation. Named Docker volumes default to root
+# ownership, so running as root is required. This container is
+# ephemeral test infrastructure — it exits after signing artifacts.
+ENTRYPOINT ["/sign-seed.sh"]

--- a/tests/acceptance/Dockerfile.verify-sut
+++ b/tests/acceptance/Dockerfile.verify-sut
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Runtime-only container for verification acceptance tests.
+# All binaries are built locally and injected from bin/.
+# trivy:ignore:DS001 -- test container, intentionally floats on latest UBI
+# trivy:ignore:DS026 -- ephemeral test container, compose healthcheck covers readiness
+# scorecard:pinned-dependencies -- intentionally unpinned; UBI images track latest for errata coverage
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest
+
+RUN microdnf install -y shadow-utils && microdnf clean all && \
+    useradd -m testuser
+
+COPY bin/acceptance.test /usr/local/bin/acceptance.test
+COPY bin/complyctl /usr/local/bin/complyctl
+COPY tests/acceptance/verify-sut-entrypoint.sh /usr/local/bin/verify-sut-entrypoint.sh
+
+USER testuser
+WORKDIR /home/testuser
+
+# The entrypoint wrapper waits for sign-seed artifacts (/shared/cosign.pub
+# etc.) before exec-ing the test binary.  docker compose enforces
+# depends_on service_completed_successfully but podman-compose does not,
+# so this provides defence-in-depth for local runs.
+ENTRYPOINT ["/usr/local/bin/verify-sut-entrypoint.sh"]
+CMD ["-test.v", "-test.timeout=3m", "-test.run=TestVerification"]

--- a/tests/acceptance/Dockerfile.verify-sut.dockerignore
+++ b/tests/acceptance/Dockerfile.verify-sut.dockerignore
@@ -1,0 +1,6 @@
+# Verify-SUT container only needs pre-built binaries from bin/.
+# Exclude everything else.
+*
+!bin/acceptance.test
+!bin/complyctl
+!tests/acceptance/verify-sut-entrypoint.sh

--- a/tests/acceptance/acceptance_test.go
+++ b/tests/acceptance/acceptance_test.go
@@ -34,12 +34,15 @@ import (
 // TestMain runs a preflight check to verify the registry is reachable and
 // seeded before executing any tests. This gives a clear error message when
 // the seed container failed silently.
+//
+// The preflight seed check only runs when TEST_POLICY_ID is set (lifecycle
+// profile). Verification tests use their own env vars (COSIGN_KEY_PATH,
+// VERIFY_*_POLICY_ID) and skip via skipIfNoVerificationEnv when the
+// verification profile is not active.
 func TestMain(m *testing.M) {
 	registryURL := os.Getenv("REGISTRY_URL")
-	policyID := os.Getenv("TEST_POLICY_ID")
-	targetID := os.Getenv("TEST_TARGET_ID")
-	if registryURL == "" || policyID == "" || targetID == "" {
-		fmt.Fprintln(os.Stderr, "FATAL: REGISTRY_URL, TEST_POLICY_ID, and TEST_TARGET_ID must be set")
+	if registryURL == "" {
+		fmt.Fprintln(os.Stderr, "FATAL: REGISTRY_URL must be set")
 		os.Exit(1)
 	}
 
@@ -52,16 +55,21 @@ func TestMain(m *testing.M) {
 	}
 	resp.Body.Close()
 
-	// Verify policy was seeded (check tags endpoint)
-	resp, err = client.Get(registryURL + "/v2/policies/" + policyID + "/tags/list")
-	if err != nil || resp.StatusCode != http.StatusOK {
-		fmt.Fprintf(os.Stderr, "FATAL: policy policies/%s not found in registry — seed container likely failed\n", policyID)
-		if err == nil {
-			resp.Body.Close()
+	// Lifecycle profile preflight: verify the seeded policy exists.
+	// Skip this check in the verification profile where TEST_POLICY_ID
+	// is not set — verification tests have their own assertions.
+	policyID := os.Getenv("TEST_POLICY_ID")
+	if policyID != "" {
+		resp, err = client.Get(registryURL + "/v2/policies/" + policyID + "/tags/list")
+		if err != nil || resp.StatusCode != http.StatusOK {
+			fmt.Fprintf(os.Stderr, "FATAL: policy policies/%s not found in registry — seed container likely failed\n", policyID)
+			if err == nil {
+				resp.Body.Close()
+			}
+			os.Exit(1)
 		}
-		os.Exit(1)
+		resp.Body.Close()
 	}
-	resp.Body.Close()
 
 	os.Exit(m.Run())
 }

--- a/tests/acceptance/compose.yaml
+++ b/tests/acceptance/compose.yaml
@@ -1,17 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Container-based acceptance tests for complyctl.
-# Usage: make test-acceptance
+# Usage: make test-acceptance          (lifecycle profile)
+#        make test-acceptance-verify   (verification profile)
 #
 # Architecture:
-#   zot   — real OCI registry (CNCF zot-minimal)
-#   seed  — init container that pushes Gemara testdata into zot via oras CLI
-#   sut   — compiled Go test binary exercising complyctl against zot
+#   zot       — real OCI registry (CNCF zot-minimal), shared across profiles
+#   seed      — init container that pushes Gemara testdata into zot via oras CLI
+#   sut       — compiled Go test binary exercising complyctl against zot
+#   sign-seed — init container that pushes and cosign-signs artifacts (verification)
+#   verify-sut — test binary exercising verification against signed artifacts
 
 services:
   zot:
     image: ghcr.io/project-zot/zot-minimal-linux-amd64:v2.1.18@sha256:f1ffb7a5bbddc0feea83646e29c587ecf39b3193733b447749d4c9ead111a395
-    profiles: [lifecycle]
+    profiles: [lifecycle, verification]
     volumes:
       - ./zot-config.json:/etc/zot/config.json:ro
     command: ["serve", "/etc/zot/config.json"]
@@ -41,3 +44,253 @@ services:
       REGISTRY_URL: "http://zot:5000"
       TEST_POLICY_ID: "acceptance-test"
       TEST_TARGET_ID: "acceptance-target"
+
+  sign-seed:
+    build:
+      context: .
+      dockerfile: Dockerfile.sign-seed
+    profiles: [verification]
+    # fulcio and rekor-server have no compose healthcheck (distroless, no curl),
+    # so gate on service_started; sign-seed.sh wait_http polls dex/fulcio/rekor
+    # readiness (with its own curl) before signing.
+    depends_on:
+      zot:
+        condition: service_started
+      dex-idp:
+        condition: service_healthy
+      fulcio:
+        condition: service_started
+      rekor-server:
+        condition: service_started
+    volumes:
+      - ./testdata:/testdata:ro
+      - verification-shared:/shared
+      - pki-material:/pki:ro
+    environment:
+      REGISTRY_URL: "zot:5000"
+
+  verify-sut:
+    build:
+      context: ../../
+      dockerfile: tests/acceptance/Dockerfile.verify-sut
+    profiles: [verification]
+    depends_on:
+      sign-seed:
+        condition: service_completed_successfully
+    volumes:
+      - verification-shared:/shared:ro
+    environment:
+      REGISTRY_URL: "http://zot:5000"
+      COSIGN_KEY_PATH: "/shared/cosign.pub"
+      COSIGN_WRONG_KEY_PATH: "/shared/wrong.pub"
+      VERIFY_KEYED_POLICY_ID: "verify-keyed"
+      VERIFY_UNSIGNED_POLICY_ID: "verify-unsigned"
+      TEST_TARGET_ID: "verify-target"
+      VERIFY_KEYLESS_POLICY_ID: verify-keyless
+      TRUSTED_ROOT_PATH: /shared/trusted_root.json
+      OIDC_ISSUER: http://dex-idp:5556/dex
+      OIDC_IDENTITY: admin@example.com
+    entrypoint: ["/usr/local/bin/verify-sut-entrypoint.sh"]
+    command: ["-test.v", "-test.timeout=3m", "-test.run=TestVerification"]
+
+  # --- Private Sigstore stack (verification profile only) ---------------------
+  # Keyless signing/verification requires a full private Sigstore: an OIDC
+  # issuer (Dex), a certificate authority (Fulcio), a Certificate Transparency
+  # log (CTFE) so issued certs carry an SCT, and a transparency log (Rekor).
+  # CTFE and Rekor both use a Trillian backend + MySQL. There is no in-memory
+  # Rekor storage path, and Fulcio must share its root with CTFE, so the root
+  # is generated at runtime (pki-material volume) rather than committed.
+  #
+  # Service topology, command flags, healthchecks, and startup ordering follow
+  # Sigstore's reference compose (which BUILDS Trillian+Rekor from source; we
+  # substitute published, digest-pinned images):
+  #   https://github.com/sigstore/rekor/blob/main/docker-compose.yml
+  # Image sources: gcr.io/projectsigstore/*, gcr.io/trillian-opensource-ci/*,
+  # ghcr.io/dexidp/dex. To bump versions, resolve a new tag from those
+  # registries and re-pin the digest. The `latest`-tagged Trillian images are
+  # digest-pinned and therefore immutable despite the floating tag.
+  dex-idp:
+    image: ghcr.io/dexidp/dex:v2.44.0@sha256:5d0656fce7d453c0e3b2706abf40c0d0ce5b371fb0b73b3cf714d05f35fa5f86
+    profiles: [verification]
+    command: ["dex", "serve", "/etc/dex/config.yaml"]
+    volumes:
+      - ./dex-config.yaml:/etc/dex/config.yaml:ro
+    healthcheck:
+      test:
+        ["CMD", "wget", "-q", "-O", "-", "http://localhost:5556/dex/healthz"]
+      interval: 5s
+      timeout: 3s
+      retries: 15
+      start_period: 10s
+
+  fulcio:
+    image: gcr.io/projectsigstore/fulcio:v1.6.6@sha256:d543032eb2d905acffae26e2cb9c9961abc962510cef23af6f133d2c5118d4b5
+    profiles: [verification]
+    # File-based CA: a generated root (pki-material volume) is shared with the
+    # CT log (ctfe) so issued certs verify against it, and
+    # --ct-log-url points Fulcio at ctfe so every leaf embeds a Signed
+    # Certificate Timestamp. sigstore-go verification requires >=1 SCT, so an
+    # SCT-less ephemeral CA would fail the keyless path.
+    command:
+      - "serve"
+      - "--port=5555"
+      - "--ca=fileca"
+      - "--fileca-cert=/pki/root.pem"
+      - "--fileca-key=/pki/root.key"
+      - "--fileca-key-passwd=fulcio"
+      - "--ct-log-url=http://ctfe:6962/testlog"
+      - "--config-path=/etc/fulcio-config/config.yaml"
+    volumes:
+      - pki-material:/pki:ro
+      - ./fulcio-config.yaml:/etc/fulcio-config/config.yaml:ro
+    # No healthcheck: the fulcio image is distroless and ships no curl/wget, so
+    # any HTTP probe here can never run. sign-seed.sh waits on Fulcio via its own
+    # curl (it runs in a UBI image that has curl) before signing.
+    depends_on:
+      dex-idp:
+        condition: service_healthy
+      ctfe:
+        condition: service_started
+
+  mysql:
+    image: gcr.io/trillian-opensource-ci/db_server:v1.4.0@sha256:0794abd3bdf44a567f5d6ef18a0b76802f388611b63aae33eaf28c3b0c5964d8
+    profiles: [verification]
+    environment:
+      MYSQL_ROOT_PASSWORD: zaphod
+      MYSQL_DATABASE: test
+      MYSQL_USER: test
+      MYSQL_PASSWORD: zaphod
+    healthcheck:
+      # Credentials are hardcoded (matching the environment block above) rather
+      # than referencing $MYSQL_USER/$MYSQL_ROOT_PASSWORD: podman-compose runs
+      # the healthcheck as a direct argv exec (no shell), so $$-escaped vars are
+      # not expanded and would authenticate as the literal user "$MYSQL_USER".
+      test:
+        [
+          "CMD",
+          "mysqladmin",
+          "-h",
+          "127.0.0.1",
+          "--user=test",
+          "--password=zaphod",
+          "-s",
+          "ping",
+        ]
+      interval: 5s
+      timeout: 3s
+      retries: 15
+      start_period: 90s
+
+  trillian-log-server:
+    image: gcr.io/trillian-opensource-ci/log_server:latest@sha256:b39e1c19162c43473985fbc0ee4ec1edc1db2f3699a2c2afeabcc49a64423d82
+    profiles: [verification]
+    command:
+      - "--quota_system=noop"
+      - "--storage_system=mysql"
+      - "--mysql_uri=test:zaphod@tcp(mysql:3306)/test?parseTime=true&interpolateParams=true"
+      - "--rpc_endpoint=0.0.0.0:8090"
+      - "--http_endpoint=0.0.0.0:8091"
+      - "--alsologtostderr"
+    # No healthcheck: the trillian log_server image is distroless (no curl/wget),
+    # so an HTTP probe cannot run. Dependents wait via app-level readiness
+    # (createtree-init nc-waits :8090; sign-seed waits on downstream services).
+    depends_on:
+      mysql:
+        condition: service_healthy
+
+  trillian-log-signer:
+    image: gcr.io/trillian-opensource-ci/log_signer:latest@sha256:e76b1643e5a5cb6a28977ddadac6a2caecde94b9ee2f1416ac28803e2aa6afb8
+    profiles: [verification]
+    command:
+      - "--quota_system=noop"
+      - "--storage_system=mysql"
+      - "--mysql_uri=test:zaphod@tcp(mysql:3306)/test?parseTime=true&interpolateParams=true"
+      - "--rpc_endpoint=0.0.0.0:8090"
+      - "--http_endpoint=0.0.0.0:8091"
+      - "--force_master"
+      - "--alsologtostderr"
+    # No healthcheck: distroless log_signer image ships no curl/wget.
+    depends_on:
+      mysql:
+        condition: service_healthy
+
+  # Provisions the CT log: builds createtree (no published image exists), loads
+  # the CTFE issuance-chain schema into MySQL, creates a Trillian tree, and
+  # renders ct_server.cfg (with the runtime-generated CTFE public key) into the
+  # shared ctfe-config volume. Runs once and exits 0.
+  createtree-init:
+    build:
+      context: .
+      dockerfile: Dockerfile.createtree
+    profiles: [verification]
+    depends_on:
+      mysql:
+        condition: service_healthy
+      trillian-log-server:
+        condition: service_started
+    volumes:
+      - ./ct_server.cfg.template:/input/ct_server.cfg.template:ro
+      - ./ctfe-schema.sql:/input/ctfe-schema.sql:ro
+      # pki-material is mounted at /pki (not /input) so that Docker can
+      # create the file bind-mount points above inside /input. Docker does
+      # not allow file bind-mounts inside a read-only volume mount at the
+      # same path; createtree-init.sh reads PKI files from PKI_DIR (/pki).
+      - pki-material:/pki:ro
+      - ctfe-config:/ctfe-config
+    environment:
+      PKI_DIR: /pki
+
+  # Certificate Transparency Front End (classic Trillian-backed). Serves the CT
+  # log at /testlog that Fulcio writes to, embedding an SCT in each cert. Reads
+  # the tree id + keys rendered by createtree-init from the shared volume.
+  ctfe:
+    image: gcr.io/trillian-opensource-ci/ctfe:latest@sha256:162fdf473f9bd777866b9314ab4a6eea1e83c35f29a04ef6310c56e604b0be0b
+    profiles: [verification]
+    command:
+      - "--log_rpc_server=trillian-log-server:8090"
+      - "--log_config=/ctfe-config/ct_server.cfg"
+      - "--http_endpoint=0.0.0.0:6962"
+      - "--alsologtostderr"
+    volumes:
+      - ctfe-config:/ctfe-config:ro
+    # No healthcheck: the ctfe image is distroless (no curl/wget). Ordering is
+    # enforced by createtree-init (which renders the config this reads) and by
+    # sign-seed.sh, which does not sign until Fulcio -> ctfe is reachable.
+    depends_on:
+      trillian-log-server:
+        condition: service_started
+      createtree-init:
+        condition: service_completed_successfully
+
+  rekor-server:
+    image: gcr.io/projectsigstore/rekor-server:v1.4.2@sha256:a8052cbed56cdfc6e134c5d405bce83458005cf9f8a9f627bc50b183785f1cbd
+    profiles: [verification]
+    # The image ENTRYPOINT is already "rekor-server"; the command must start
+    # with the "serve" subcommand (not repeat the binary name).
+    command:
+      - "serve"
+      - "--trillian_log_server.address=trillian-log-server"
+      - "--trillian_log_server.port=8090"
+      - "--rekor_server.address=0.0.0.0"
+      - "--rekor_server.signer=memory"
+      # Attestation (DSSE) storage is intentionally disabled: the keyless verify
+      # path only needs Rekor tlog inclusion for the signature, and the
+      # distroless image has no /var/run/attestations dir (rekor panics if
+      # --enable_attestation_storage points at a missing bucket path).
+      - "--search_index.storage_provider=mysql"
+      - "--search_index.mysql.dsn=test:zaphod@tcp(mysql:3306)/test?parseTime=true&interpolateParams=true"
+    depends_on:
+      mysql:
+        condition: service_healthy
+      trillian-log-server:
+        condition: service_started
+    ports:
+      - "3000:3000"
+      - "2112:2112"
+    # No healthcheck: the rekor-server image is distroless (no curl/wget).
+    # sign-seed.sh waits on Rekor via its own curl before signing.
+
+volumes:
+  verification-shared:
+  ctfe-config:
+  pki-material:

--- a/tests/acceptance/createtree-init.sh
+++ b/tests/acceptance/createtree-init.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# createtree-init.sh provisions the CTFE (Certificate Transparency Front End)
+# for the acceptance verification stack. It runs once as a compose init service
+# and exits 0 on success so ctfe (and Fulcio) can start.
+#
+# Steps:
+#   1. Wait for the trillian-log-server admin gRPC endpoint.
+#   2. Load the CTFE issuance-chain schema into MySQL (idempotent).
+#   3. Provision a Trillian tree and capture its numeric tree id.
+#   4. Render ct_server.cfg from the template, substituting the tree id, into
+#      the shared /ctfe-config volume alongside copies of the committed Fulcio
+#      root and CTFE private key that ct_server reads.
+#
+# Inputs (mounted read-only):
+#   /input/ct_server.cfg.template  config template with @TREE_ID@
+#   /input/ctfe-schema.sql         CTFE MySQL schema (idempotent)
+#   /pki/root.pem                  Fulcio fileca root (shared trust anchor)
+#   /pki/privkey.pem               CTFE EC signing key (legacy-PEM-encrypted,
+#                                  passphrase "ctfe"; see ct_server.cfg.template)
+# Output (shared volume, read by ctfe):
+#   /ctfe-config/ct_server.cfg
+#   /ctfe-config/root.pem
+#   /ctfe-config/privkey.pem
+set -euo pipefail
+
+TRILLIAN_ADMIN="${TRILLIAN_ADMIN:-trillian-log-server:8090}"
+MYSQL_HOST="${MYSQL_HOST:-mysql}"
+MYSQL_USER="${MYSQL_USER:-test}"
+MYSQL_PASSWORD="${MYSQL_PASSWORD:-zaphod}"
+MYSQL_DATABASE="${MYSQL_DATABASE:-test}"
+INPUT_DIR="${INPUT_DIR:-/input}"
+# PKI_DIR is separate from INPUT_DIR so that ct_server.cfg.template and
+# ctfe-schema.sql can be file bind-mounts at /input while the pki-material
+# volume is mounted at /pki — Docker does not allow file bind-mounts inside
+# a read-only volume mount at the same path.
+PKI_DIR="${PKI_DIR:-/pki}"
+CONFIG_DIR="${CONFIG_DIR:-/ctfe-config}"
+
+log() { printf '[createtree-init] %s\n' "$*"; }
+
+# 1. Wait for the Trillian admin gRPC port to accept connections.
+admin_host="${TRILLIAN_ADMIN%%:*}"
+admin_port="${TRILLIAN_ADMIN##*:}"
+log "waiting for Trillian admin at ${TRILLIAN_ADMIN}"
+for _ in $(seq 1 60); do
+	if nc -z "${admin_host}" "${admin_port}" 2>/dev/null; then
+		break
+	fi
+	sleep 2
+done
+if ! nc -z "${admin_host}" "${admin_port}" 2>/dev/null; then
+	log "ERROR: Trillian admin ${TRILLIAN_ADMIN} not reachable"
+	exit 1
+fi
+
+# 2. Load the CTFE issuance-chain schema (idempotent: CREATE TABLE IF NOT EXISTS).
+log "loading CTFE schema into ${MYSQL_HOST}/${MYSQL_DATABASE}"
+for _ in $(seq 1 30); do
+	if mysql -h "${MYSQL_HOST}" -u "${MYSQL_USER}" "-p${MYSQL_PASSWORD}" \
+		"${MYSQL_DATABASE}" <"${INPUT_DIR}/ctfe-schema.sql" 2>/dev/null; then
+		break
+	fi
+	sleep 2
+done
+
+# 3. Provision a Trillian tree for the CT log. createtree prints the tree id.
+log "provisioning Trillian tree via createtree"
+tree_id=""
+for _ in $(seq 1 30); do
+	if tree_id="$(createtree --admin_server="${TRILLIAN_ADMIN}" 2>/dev/null)"; then
+		if [[ -n "${tree_id}" ]]; then
+			break
+		fi
+	fi
+	sleep 2
+done
+if [[ -z "${tree_id}" ]]; then
+	log "ERROR: createtree did not return a tree id"
+	exit 1
+fi
+log "provisioned tree id ${tree_id}"
+
+# 4. Render the config. Only @TREE_ID@ (numeric) is substituted; ct_server
+#    derives its public key from privkey.pem, so no DER escaping is needed.
+#    awk with index()/substr() performs a purely literal replacement.
+mkdir -p "${CONFIG_DIR}"
+awk -v tree_id="${tree_id}" '
+  {
+    line = $0
+    p = index(line, "@TREE_ID@")
+    if (p > 0) {
+      line = substr(line, 1, p - 1) tree_id substr(line, p + length("@TREE_ID@"))
+    }
+    print line
+  }
+' "${INPUT_DIR}/ct_server.cfg.template" >"${CONFIG_DIR}/ct_server.cfg"
+
+if ! grep -q "log_id: ${tree_id}" "${CONFIG_DIR}/ct_server.cfg"; then
+	log "ERROR: rendered ct_server.cfg missing tree id ${tree_id}"
+	exit 1
+fi
+
+# ct_server reads the root and private key from the shared config volume.
+cp "${PKI_DIR}/root.pem" "${CONFIG_DIR}/root.pem"
+cp "${PKI_DIR}/privkey.pem" "${CONFIG_DIR}/privkey.pem"
+
+log "wrote ${CONFIG_DIR}/ct_server.cfg (tree id ${tree_id})"
+log "done"

--- a/tests/acceptance/ct_server.cfg.template
+++ b/tests/acceptance/ct_server.cfg.template
@@ -1,0 +1,37 @@
+# CTFE (ct_server) configuration template for the acceptance verification stack.
+#
+# Proto-text form of configpb.LogConfig (single log). @TREE_ID@ is replaced at
+# runtime by createtree-init with the numeric Trillian tree id it provisions.
+#
+# The private key references the runtime-generated (pki-material volume) CTFE PEM key via keyspb.PEMKeyFile.
+# The key is legacy-PEM-encrypted (Proc-Type/DEK-Info, AES-256-CBC) with the
+# passphrase "ctfe": the ctfe image ships an older Trillian whose pemfile loader
+# rejects an empty password, so an unencrypted key fails with "empty password
+# for file". CTFE derives its public key from this private key, so no public_key
+# field is set here: a proto-text bytes field
+# cannot carry the raw DER of an EC key without tripping the parser's UTF-8
+# check. The derived key is the same EC key represented by
+# /pki/ctfe.pub (both come from privkey.pem), which is fed to
+# `cosign trusted-root create --ctfe-key` so SCTs still verify. public_key is
+# only required for mirror logs or a frozen STH, neither of which applies here
+# (see ctfe/config.go ValidateLogConfig).
+#
+# roots_pem_file points at the shared Fulcio fileca root so CTFE accepts the
+# certificates Fulcio issues. Issuance-chain ExtraData is stored in MySQL
+# (CTFE backend) rather than Trillian GRPC.
+config {
+  log_id: @TREE_ID@
+  prefix: "testlog"
+  roots_pem_file: "/ctfe-config/root.pem"
+  private_key: {
+    [type.googleapis.com/keyspb.PEMKeyFile] {
+      path: "/ctfe-config/privkey.pem"
+      password: "ctfe"
+    }
+  }
+  ext_key_usages: "CodeSigning"
+  max_merge_delay_sec: 86400
+  expected_merge_delay_sec: 120
+  ctfe_storage_connection_string: "mysql://test:zaphod@tcp(mysql:3306)/test"
+  extra_data_issuance_chain_storage_backend: ISSUANCE_CHAIN_STORAGE_BACKEND_CTFE
+}

--- a/tests/acceptance/ctfe-schema.sql
+++ b/tests/acceptance/ctfe-schema.sql
@@ -1,0 +1,28 @@
+-- Copyright 2024 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- MySQL / MariaDB version of the CTFE issuance-chain database schema.
+-- Vendored from certificate-transparency-go
+-- (trillian/ctfe/storage/mysql/schema.sql) because the CTFE log is configured
+-- with extra_data_issuance_chain_storage_backend = CTFE, which stores the
+-- issuance chain in MySQL rather than Trillian GRPC.
+
+-- "IssuanceChain" table contains the hash and value pairs of the issuance chain.
+CREATE TABLE IF NOT EXISTS `IssuanceChain` (
+  -- Hash of the chain of intermediate certificates and root certificates.
+  `IdentityHash` VARBINARY(255) NOT NULL,
+  -- Chain data of intermediate certificates and root certificates.
+  `ChainValue`   LONGBLOB NOT NULL,
+  PRIMARY KEY (`IdentityHash`)
+);

--- a/tests/acceptance/dex-config.yaml
+++ b/tests/acceptance/dex-config.yaml
@@ -1,0 +1,31 @@
+# Dex OIDC configuration for keyless-signing acceptance tests.
+# Issuer must match the URL clients reach Dex at (compose service DNS).
+issuer: http://dex-idp:5556/dex
+
+storage:
+  type: memory
+
+web:
+  http: 0.0.0.0:5556
+
+# Static OIDC client used by sign-seed to obtain an id_token.
+staticClients:
+  - id: complyctl-test
+    secret: test-secret
+    name: complyctl test client
+    # Redirect URIs are unused for the password grant but Dex requires the field.
+    redirectURIs:
+      - http://localhost/callback
+
+# Enable the resource-owner password grant so sign-seed can fetch a token
+# non-interactively via curl.
+oauth2:
+  passwordConnector: local
+
+enablePasswordDB: true
+staticPasswords:
+  # Password is "password"; hash is bcrypt of that literal.
+  - email: admin@example.com
+    hash: "$2a$10$QiWH8f8Ty152VnCcmYp0aucPu2UUfMt6C4AxZS7ZE1YLpNOZ5ymNq"
+    username: admin
+    userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"

--- a/tests/acceptance/fulcio-config.yaml
+++ b/tests/acceptance/fulcio-config.yaml
@@ -1,0 +1,13 @@
+# Fulcio OIDC issuer configuration for the acceptance verification stack.
+#
+# Maps the private Dex issuer (dex-idp service) to a Fulcio client so keyless
+# signing tokens minted by Dex are accepted. Schema mirrors the upstream
+# reference at https://github.com/sigstore/fulcio/blob/main/config/identity/config.yaml
+# (email issuer type: SAN is the token email claim).
+oidc-issuers:
+  http://dex-idp:5556/dex:
+    issuer-url: http://dex-idp:5556/dex
+    client-id: complyctl-test
+    type: email
+    contact: complyctl-acceptance@invalid
+    description: "Private Dex issuer for complyctl keyless acceptance tests"

--- a/tests/acceptance/generate-pki.sh
+++ b/tests/acceptance/generate-pki.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+
+# generate-pki.sh — generate test PKI material at runtime into PKI_DIR.
+# Produces a Fulcio CA keypair (root.key + root.pem) and a CTFE keypair
+# (privkey.pem + ctfe.pub). All credentials are test-only values with no
+# security value outside this acceptance-test environment.
+
+PKI_DIR="${PKI_DIR:-/pki}"
+
+mkdir -p "${PKI_DIR}"
+umask 0077
+
+# --- Fulcio CA key (EC P-256, AES-256-CBC, passphrase: fulcio) ---------------
+echo "Generating Fulcio CA private key..."
+openssl ecparam -name prime256v1 -genkey -noout |
+	openssl ec -aes256 -passout pass:fulcio -out "${PKI_DIR}/root.key"
+# 0644: Fulcio and other services run as nonroot in distroless images.
+# The key is AES-256-CBC encrypted; world-readable is acceptable for test-only material.
+chmod 0644 "${PKI_DIR}/root.key"
+echo "  wrote ${PKI_DIR}/root.key"
+
+# --- Fulcio CA certificate (self-signed, 10-year validity) --------------------
+echo "Generating Fulcio CA certificate..."
+openssl req -new -x509 \
+	-key "${PKI_DIR}/root.key" \
+	-passin pass:fulcio \
+	-out "${PKI_DIR}/root.pem" \
+	-days 3650 \
+	-subj "/CN=Test Fulcio CA/O=complyctl-test/C=US" \
+	-addext "basicConstraints=critical,CA:true" \
+	-addext "keyUsage=critical,keyCertSign,cRLSign"
+chmod 0644 "${PKI_DIR}/root.pem"
+echo "  wrote ${PKI_DIR}/root.pem"
+
+# --- CTFE private key (EC P-256, legacy AES-256-CBC, passphrase: ctfe) -------
+echo "Generating CTFE private key..."
+openssl ecparam -name prime256v1 -genkey -noout |
+	openssl ec -aes256 -passout pass:ctfe -out "${PKI_DIR}/privkey.pem"
+chmod 0644 "${PKI_DIR}/privkey.pem"
+echo "  wrote ${PKI_DIR}/privkey.pem"
+
+# --- CTFE public key (PEM PKIX/SubjectPublicKeyInfo format) -------------------
+echo "Deriving CTFE public key..."
+openssl ec -in "${PKI_DIR}/privkey.pem" -passin pass:ctfe \
+	-pubout -out "${PKI_DIR}/ctfe.pub"
+chmod 0644 "${PKI_DIR}/ctfe.pub"
+echo "  wrote ${PKI_DIR}/ctfe.pub"
+
+echo "PKI material generation complete in ${PKI_DIR}"

--- a/tests/acceptance/sign-seed.sh
+++ b/tests/acceptance/sign-seed.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+
+# sign-seed.sh — push Gemara policy artifacts to zot and sign them
+# with cosign (keyed and keyless) for verification acceptance tests.
+# All credentials in this script are test-only mock values with no
+# security value.
+#
+# Keyless signing is performed against the private Sigstore stack
+# (dex/fulcio/rekor) and a trusted_root.json is emitted to the shared
+# volume for the verify-sut container to consume.
+
+REGISTRY="${REGISTRY_URL:-zot:5000}"
+
+# --- idempotency guard ------------------------------------------------------
+# podman-compose 1.6.0 can invoke this entrypoint more than once for the same
+# container (a `podman start` on the already-exited container re-runs the
+# entrypoint). This script is destructive at its start (it clears the shared
+# outputs it regenerates) and cosign's key generation is interactive on a
+# pre-existing key, so a naive second run would delete run #1's good artifacts
+# and then abort on cosign's "File cosign.key already exists" prompt — leaving
+# verify-sut with no artifacts. Guard against that: if the completion sentinel
+# is already present, a prior invocation in THIS run finished successfully, so
+# exit 0 without touching anything. This is safe against the historical
+# stale-sentinel race because the Makefile removes the named shared volume
+# before every run, so any sentinel seen here was written by this run.
+if [[ -f /shared/.sign-seed-complete ]]; then
+	echo "Sign-seed already complete for this run (sentinel present); skipping."
+	exit 0
+fi
+
+# --- helpers ----------------------------------------------------------------
+
+retry() {
+	local max_attempts=3
+	local delay=2
+	local attempt=1
+	local cmd=("$@")
+
+	# Progress messages go to stderr so callers can safely capture the
+	# wrapped command's stdout, e.g. `id_token="$(retry curl ... | jq ...)"`.
+	while [[ ${attempt} -le ${max_attempts} ]]; do
+		echo "  attempt ${attempt}/${max_attempts}: ${cmd[*]}" >&2
+		if "${cmd[@]}"; then
+			return 0
+		fi
+		if [[ ${attempt} -eq ${max_attempts} ]]; then
+			echo "ERROR: command failed after ${max_attempts} attempts: ${cmd[*]}" >&2
+			return 1
+		fi
+		echo "  retrying in ${delay}s..." >&2
+		sleep "${delay}"
+		attempt=$((attempt + 1))
+	done
+}
+
+verify_push() {
+	local repo="$1"
+	local tag="$2"
+	local tags
+	tags=$(oras repo tags --plain-http "${REGISTRY}/${repo}")
+	if ! echo "${tags}" | grep -q "${tag}"; then
+		echo "ERROR: tag ${tag} not found in ${repo} after push." >&2
+		exit 1
+	fi
+	echo "  verified: ${repo}:${tag}"
+}
+
+# verify_signature REPO — assert cosign persisted the sha256-<digest>.sig
+# tag for the given repo's :v1.0.0 manifest.  cosign's retry wrapper can
+# report success even when the signature manifest did not land in the
+# registry; without this check a silent push failure surfaces later as a
+# confusing MANIFEST_UNKNOWN from the verifier instead of a loud sign-seed
+# abort here.
+verify_signature() {
+	local repo="$1"
+	local digest sig_tag tags
+	digest=$(oras manifest fetch --plain-http --descriptor \
+		"${REGISTRY}/${repo}:v1.0.0" | jq -r '.digest')
+	if [[ -z "${digest}" || "${digest}" == "null" ]]; then
+		echo "ERROR: could not resolve manifest digest for ${repo}." >&2
+		exit 1
+	fi
+	sig_tag="sha256-${digest#sha256:}.sig"
+	tags=$(oras repo tags --plain-http "${REGISTRY}/${repo}")
+	if ! echo "${tags}" | grep -q "${sig_tag}"; then
+		echo "ERROR: cosign signature ${sig_tag} not found in ${repo}" \
+			"after signing." >&2
+		exit 1
+	fi
+	echo "  signature verified: ${repo} -> ${sig_tag}"
+}
+
+# manifest_digest REPO — print the registry-stored digest of REPO:v1.0.0.
+# cosign must sign by this digest (not the :v1.0.0 tag): oras stamps a
+# wall-clock org.opencontainers.image.created annotation on every push, and
+# signing by tag makes cosign resolve/re-serialize a manifest whose digest can
+# diverge from the stored bytes, so the sha256-<digest>.sig tag it writes no
+# longer matches the digest the verifier resolves — surfacing as MANIFEST_UNKNOWN.
+manifest_digest() {
+	local repo="$1"
+	local digest
+	digest=$(oras manifest fetch --plain-http --descriptor \
+		"${REGISTRY}/${repo}:v1.0.0" | jq -r '.digest')
+	if [[ -z "${digest}" || "${digest}" == "null" ]]; then
+		echo "ERROR: could not resolve manifest digest for ${repo}." >&2
+		exit 1
+	fi
+	echo "${digest}"
+}
+
+# wait_http URL DESCRIPTION — poll an HTTP endpoint until it responds 2xx/3xx.
+# podman-compose ignores `depends_on: condition`, so poll defensively.
+wait_http() {
+	local url="$1"
+	local desc="$2"
+	local max=60
+	local i=0
+	echo "Waiting for ${desc} at ${url}..."
+	while [[ "${i}" -lt "${max}" ]]; do
+		if curl -fsS -o /dev/null "${url}"; then
+			echo "${desc} is ready."
+			return 0
+		fi
+		i=$((i + 1))
+		sleep 2
+	done
+	echo "ERROR: ${desc} not ready at ${url} after $((max * 2))s" >&2
+	return 1
+}
+
+# --- clear stale shared artifacts -------------------------------------------
+# The shared volume can survive a prior run: podman-compose 1.6.0 does not
+# reliably remove named volumes on `down -v`, so a previous run's
+# .sign-seed-complete sentinel (and public keys / trusted root) may still be
+# present when this container starts. verify-sut gates on that sentinel, so a
+# stale one lets the test suite start before this run has finished signing,
+# producing MANIFEST_UNKNOWN for the not-yet-pushed .sig artifacts. Remove the
+# sentinel FIRST (before any producer output) so the gate is only satisfied by
+# this run, then clear the remaining outputs we regenerate below.
+echo "Clearing stale shared artifacts from /shared..."
+rm -f /shared/.sign-seed-complete
+rm -f /shared/cosign.pub /shared/wrong.pub /shared/trusted_root.json
+
+# --- wait for registry ------------------------------------------------------
+
+echo "Waiting for registry at ${REGISTRY}..."
+for i in $(seq 1 30); do
+	if oras repo list --plain-http "${REGISTRY}" >/dev/null 2>&1; then
+		echo "Registry is ready."
+		break
+	fi
+	if [[ "$i" -eq 30 ]]; then
+		echo "ERROR: Registry not ready after 30 attempts." >&2
+		exit 1
+	fi
+	sleep 1
+done
+
+# --- push artifacts to repository paths --------------------------------------
+
+cd /testdata
+
+for repo in policies/verify-keyed policies/verify-unsigned policies/verify-keyless; do
+	echo "Pushing Gemara policy bundle to ${repo}..."
+	oras push --plain-http "${REGISTRY}/${repo}:v1.0.0" \
+		catalog.yaml:application/vnd.gemara.catalog.v1+yaml \
+		policy.yaml:application/vnd.gemara.policy.v1+yaml
+
+	oras tag --plain-http "${REGISTRY}/${repo}:v1.0.0" latest
+	verify_push "${repo}" "v1.0.0"
+	verify_push "${repo}" "latest"
+done
+
+echo "All artifacts pushed."
+
+# --- keyed signing -----------------------------------------------------------
+
+echo "Generating cosign keypair for keyed signing..."
+cd /tmp
+export COSIGN_PASSWORD=""
+# Remove any key files left by a previous entrypoint invocation: cosign's
+# generate-key-pair prompts interactively (and aborts under -euo pipefail) if
+# cosign.key already exists.
+rm -f /tmp/cosign.key /tmp/cosign.pub
+cosign generate-key-pair
+
+echo "Signing policies/verify-keyed with cosign (keyed)..."
+keyed_digest="$(manifest_digest policies/verify-keyed)"
+retry cosign sign \
+	--key /tmp/cosign.key \
+	--tlog-upload=false \
+	--allow-http-registry \
+	--yes \
+	"${REGISTRY}/policies/verify-keyed@${keyed_digest}"
+
+verify_signature "policies/verify-keyed"
+
+echo "Copying public key to shared volume..."
+cp /tmp/cosign.pub /shared/cosign.pub
+# verify-sut runs as an unprivileged user and mounts /shared read-only, so the
+# artifacts must be world-readable (this container runs as root).
+chmod 0644 /shared/cosign.pub
+
+# --- wrong keypair for negative tests ----------------------------------------
+
+echo "Generating wrong keypair for negative test cases..."
+cd /tmp
+mkdir -p wrong-key
+cd wrong-key
+rm -f /tmp/wrong-key/cosign.key /tmp/wrong-key/cosign.pub
+cosign generate-key-pair
+
+cp /tmp/wrong-key/cosign.pub /shared/wrong.pub
+chmod 0644 /shared/wrong.pub
+# Private key stays in /tmp — not written to shared volume.
+
+echo "Wrong public key written to /shared/wrong.pub."
+
+# --- keyless signing against the private Sigstore ----------------------------
+
+DEX_ISSUER="http://dex-idp:5556/dex"
+FULCIO_URL="http://fulcio:5555"
+REKOR_URL="http://rekor-server:3000"
+CTFE_URL="http://ctfe:6962/testlog"
+
+# The Sigstore images (fulcio, rekor-server, ctfe) are distroless and ship no
+# curl, so they have no compose healthcheck; readiness is polled here instead.
+# Wait for the CT log before signing so Fulcio can embed a Signed Certificate
+# Timestamp in the issued cert (sigstore-go verification requires >=1 SCT).
+wait_http "${DEX_ISSUER}/healthz" "Dex"
+wait_http "${CTFE_URL}/ct/v1/get-sth" "CTFE"
+wait_http "${FULCIO_URL}/api/v1/rootCert" "Fulcio"
+wait_http "${REKOR_URL}/ping" "Rekor"
+
+echo "Requesting OIDC token from Dex..."
+id_token="$(retry curl -fsS \
+	-d 'grant_type=password' \
+	-d 'username=admin@example.com' \
+	-d 'password=password' \
+	-d 'scope=openid email' \
+	-d 'client_id=complyctl-test' \
+	-d 'client_secret=test-secret' \
+	"${DEX_ISSUER}/token" | jq -r '.id_token')"
+
+if [[ -z "${id_token}" || "${id_token}" == "null" ]]; then
+	echo "ERROR: failed to obtain OIDC id_token from Dex" >&2
+	exit 1
+fi
+
+echo "Keyless-signing policies/verify-keyless..."
+# After Fulcio issues the cert, cosign verifies the embedded SCT against a known
+# CT-log public key. Our private CTFE is not in cosign's TUF root, so point
+# cosign at the generated CTFE public key to verify the SCT it signed.
+export SIGSTORE_CT_LOG_PUBLIC_KEY_FILE="/pki/ctfe.pub"
+keyless_digest="$(manifest_digest policies/verify-keyless)"
+retry cosign sign \
+	--fulcio-url="${FULCIO_URL}" \
+	--rekor-url="${REKOR_URL}" \
+	--identity-token="${id_token}" \
+	--allow-http-registry \
+	--yes \
+	"${REGISTRY}/policies/verify-keyless@${keyless_digest}"
+
+verify_signature "policies/verify-keyless"
+
+# --- trusted-root generation -------------------------------------------------
+
+echo "Generating trusted_root.json..."
+tmp_root="$(mktemp /shared/trusted_root.json.XXXXXX)"
+
+# cosign is pinned to v2.4.3 in Dockerfile.sign-seed, which ships
+# `trusted-root create`. In v2.4.3 that subcommand accepts only file inputs
+# (--certificate-chain / --ctfe-key / --rekor-key), NOT --fulcio-url/--rekor-url,
+# so we assemble the trust root from the generated Fulcio root, the generated
+# CTFE public key, and the Rekor public key fetched at runtime. Fail closed if
+# a future pin drops the subcommand.
+if ! cosign trusted-root create --help >/dev/null 2>&1; then
+	echo "ERROR: cosign lacks 'trusted-root create' (pinned v2.4.3 must provide it)" >&2
+	rm -f "${tmp_root}"
+	exit 1
+fi
+
+# Rekor's public key is served over its API; the generated Fulcio root and CTFE
+# public key are mounted from the pki-material volume at /pki/.
+rekor_key="$(mktemp /tmp/rekor-pub.XXXXXX.pem)"
+retry curl -fsS "${REKOR_URL}/api/v1/log/publicKey" -o "${rekor_key}"
+
+cosign trusted-root create \
+	--certificate-chain=/pki/root.pem \
+	--ctfe-key=/pki/ctfe.pub \
+	--rekor-key="${rekor_key}" \
+	--out="${tmp_root}"
+
+rm -f "${rekor_key}"
+
+# mktemp creates the file 0600 (root-only); verify-sut runs unprivileged and
+# mounts /shared read-only, so make it world-readable before publishing.
+chmod 0644 "${tmp_root}"
+
+# Atomic publish so verify-sut never reads a half-written file.
+mv -f "${tmp_root}" /shared/trusted_root.json
+echo "trusted_root.json written."
+
+# --- done --------------------------------------------------------------------
+
+# Completion sentinel — written last, after every artifact is signed and
+# published, so verify-sut-entrypoint.sh can gate on it rather than on the
+# individual artifact files (which can persist as stale copies on a reused
+# shared volume under podman-compose).  world-readable for the unprivileged
+# verify-sut container that mounts /shared read-only.
+touch /shared/.sign-seed-complete
+chmod 0644 /shared/.sign-seed-complete
+
+echo "Sign-seed complete."

--- a/tests/acceptance/testdata/sigstore/README.md
+++ b/tests/acceptance/testdata/sigstore/README.md
@@ -1,0 +1,18 @@
+# TEST PKI — GENERATED AT RUNTIME
+
+The key material for the `complyctl` verification acceptance test stack
+(`tests/acceptance/`, `make test-acceptance-verify`) is generated on every
+test run by the `generate-pki` Docker Compose init service into the
+`pki-material` volume.
+
+No key material is committed to this repository.
+
+| File          | Purpose                                                           | Location     |
+|---------------|-------------------------------------------------------------------|--------------|
+| `root.pem`    | Fulcio `fileca` self-signed CA certificate (EC P-256, 10 yr)      | pki-material |
+| `root.key`    | The CA private key (PEM, AES-256-CBC, passphrase `fulcio`)        | pki-material |
+| `privkey.pem` | CTFE log signing key (PEM, legacy AES-256-CBC, passphrase `ctfe`) | pki-material |
+| `ctfe.pub`    | CTFE log public key (used for `cosign trusted-root --ctfe-key`)   | pki-material |
+
+These keys are ephemeral test fixtures with zero security value. They are
+generated fresh each time the verification test suite runs.

--- a/tests/acceptance/verification_helpers_test.go
+++ b/tests/acceptance/verification_helpers_test.go
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build acceptance
+
+package acceptance
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/complytime/complyctl/internal/cache"
+	"github.com/complytime/complyctl/internal/complytime"
+
+	"github.com/goccy/go-yaml"
+)
+
+// policyEntryConfig captures per-entry configuration for
+// writeVerificationConfig. URL, PolicyID, and TargetID are required.
+// Verification and SkipVerify allow per-entry overrides.
+type policyEntryConfig struct {
+	URL          string
+	PolicyID     string
+	TargetID     string
+	Verification *complytime.VerificationConfig
+	SkipVerify   bool
+}
+
+// verifyOption is a functional option for writeVerificationConfig.
+type verifyOption func(*verifyConfig)
+
+// verifyConfig aggregates all options for writeVerificationConfig.
+type verifyConfig struct {
+	verification *complytime.VerificationConfig
+	entries      []policyEntryConfig
+}
+
+// withKeyedVerification sets workspace-level keyed (public key)
+// verification.
+func withKeyedVerification(keyPath string) verifyOption {
+	return func(vc *verifyConfig) {
+		vc.verification = &complytime.VerificationConfig{
+			Key: keyPath,
+		}
+	}
+}
+
+// withKeylessVerification sets workspace-level keyless (OIDC issuer +
+// identity) verification.
+func withKeylessVerification(issuer, identity, trustedRootPath string) verifyOption {
+	return func(vc *verifyConfig) {
+		vc.verification = &complytime.VerificationConfig{
+			Issuer:      issuer,
+			Identity:    identity,
+			TrustedRoot: trustedRootPath,
+		}
+	}
+}
+
+// withPolicyEntries provides explicit policy entries for multi-entry
+// scenarios. When set, the default single-entry policy is not generated.
+func withPolicyEntries(entries []policyEntryConfig) verifyOption {
+	return func(vc *verifyConfig) {
+		vc.entries = entries
+	}
+}
+
+// writeVerificationConfig creates .complytime/complytime.yaml in dir
+// with verification settings and policy entries. When no explicit
+// entries are provided via withPolicyEntries, a single default policy
+// entry is created using registryURL.
+func writeVerificationConfig(t *testing.T, dir string, registryURL string, opts ...verifyOption) {
+	t.Helper()
+
+	vc := &verifyConfig{}
+	for _, opt := range opts {
+		opt(vc)
+	}
+
+	// All verification tests must provide explicit entries via
+	// withPolicyEntries. There is no default fallback because
+	// verification tests use their own env vars (VERIFY_*_POLICY_ID),
+	// not the lifecycle TEST_POLICY_ID.
+	entries := vc.entries
+	require.NotEmpty(t, entries,
+		"writeVerificationConfig requires withPolicyEntries")
+
+	// Assemble the workspace config struct.
+	wsCfg := complytime.WorkspaceConfig{
+		Verification: vc.verification,
+	}
+
+	for _, e := range entries {
+		pe := complytime.PolicyEntry{
+			URL:          e.URL,
+			ID:           e.PolicyID,
+			Verification: e.Verification,
+			SkipVerify:   e.SkipVerify,
+		}
+		wsCfg.Policies = append(wsCfg.Policies, pe)
+	}
+
+	// Build targets from unique target IDs across entries.
+	targetSeen := make(map[string][]string)
+	for _, e := range entries {
+		require.NotEmpty(t, e.TargetID,
+			"policyEntryConfig.TargetID must be set for %s", e.PolicyID)
+		targetSeen[e.TargetID] = append(targetSeen[e.TargetID], e.PolicyID)
+	}
+	for tid, pids := range targetSeen {
+		wsCfg.Targets = append(wsCfg.Targets, complytime.TargetConfig{
+			ID:       tid,
+			Policies: pids,
+		})
+	}
+
+	data, err := yaml.Marshal(&wsCfg)
+	require.NoError(t, err, "marshal workspace config")
+
+	configDir := filepath.Join(dir, complytime.WorkspaceDir)
+	require.NoError(t, os.MkdirAll(configDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(configDir, complytime.WorkspaceConfigFile),
+		data, 0o644))
+}
+
+// readPolicyState reads and unmarshals state.json from the XDG data
+// directory. This matches where complyctl get persists sync state via
+// cache.SaveState (which writes to the data dir, not the cache dir).
+// Fails the test if the file cannot be read or parsed.
+func readPolicyState(t *testing.T) *cache.State {
+	t.Helper()
+
+	dataDir, err := complytime.ResolveDataDir()
+	require.NoError(t, err, "resolve data directory")
+
+	statePath := filepath.Join(dataDir, complytime.StateFileName)
+
+	data, err := os.ReadFile(statePath)
+	require.NoError(t, err, "read state.json from %s", statePath)
+
+	var state cache.State
+	require.NoError(t, json.Unmarshal(data, &state), "unmarshal state.json")
+
+	return &state
+}
+
+// runComplyctlExpectError executes the complyctl binary and returns the
+// combined stdout+stderr output along with any error. Unlike runComplyctl,
+// it does not call t.Fatalf on non-zero exit, allowing the caller to
+// assert on stderr content and exit code for negative tests.
+func runComplyctlExpectError(t *testing.T, workDir string, args ...string) (string, error) {
+	t.Helper()
+	return runComplyctlCapture(t, workDir, args...)
+}
+
+// runComplyctlCapture executes the complyctl binary and returns the combined
+// stdout+stderr output along with any error, without calling t.Fatalf on a
+// non-zero exit. Unlike runComplyctl (which fatals on error) it lets the caller
+// decide how to treat the exit code, so it suits both negative tests asserting
+// on failure output and success paths that still need to inspect stderr (e.g.
+// --skip-verify warnings).
+func runComplyctlCapture(t *testing.T, workDir string, args ...string) (string, error) {
+	t.Helper()
+	cmd := exec.Command(complyctlBinary, args...)
+	cmd.Dir = workDir
+	out, err := cmd.CombinedOutput()
+	t.Logf("complyctl %s output:\n%s", strings.Join(args, " "), string(out))
+	return string(out), err
+}
+
+// clearPolicyCache removes the global OCI policy cache directory and
+// state.json so that negative tests (e.g., wrong key, unsigned artifact)
+// are not affected by cache entries from prior positive tests.
+func clearPolicyCache(t *testing.T) {
+	t.Helper()
+
+	cacheDir, err := complytime.ResolveCacheDir()
+	require.NoError(t, err, "resolve cache directory")
+
+	policiesDir := filepath.Join(cacheDir, "policies")
+	if err := os.RemoveAll(policiesDir); err != nil {
+		t.Logf("warning: failed to remove policies cache: %v", err)
+	}
+
+	// state.json lives in the XDG data directory (where cache.SaveState
+	// writes it), not the cache directory that holds the OCI layouts.
+	dataDir, err := complytime.ResolveDataDir()
+	require.NoError(t, err, "resolve data directory")
+
+	statePath := filepath.Join(dataDir, complytime.StateFileName)
+	if err := os.Remove(statePath); err != nil && !os.IsNotExist(err) {
+		t.Logf("warning: failed to remove state.json: %v", err)
+	}
+}
+
+// keylessTrustedRootPath returns the trusted-root path from the
+// TRUSTED_ROOT_PATH env var wired by the verify-sut compose service,
+// falling back to the shared-volume default when unset.
+func keylessTrustedRootPath() string {
+	if p := os.Getenv("TRUSTED_ROOT_PATH"); p != "" {
+		return p
+	}
+	return "/shared/trusted_root.json"
+}
+
+// keylessIssuer returns the OIDC issuer from the OIDC_ISSUER env var
+// wired by the verify-sut compose service, falling back to the Dex
+// issuer default when unset.
+func keylessIssuer() string {
+	if v := os.Getenv("OIDC_ISSUER"); v != "" {
+		return v
+	}
+	return "http://dex-idp:5556/dex"
+}
+
+// keylessIdentity returns the expected signer identity from the
+// OIDC_IDENTITY env var wired by the verify-sut compose service,
+// falling back to the Dex static-user default when unset.
+func keylessIdentity() string {
+	if v := os.Getenv("OIDC_IDENTITY"); v != "" {
+		return v
+	}
+	return "admin@example.com"
+}
+
+// findTableRow returns the first line in out that contains needle. It
+// fails the test when no such line exists. Callers use it to scope a
+// column assertion to a specific policy's row rather than the whole
+// table, so a value in an unrelated row or column cannot mask a
+// regression.
+func findTableRow(t *testing.T, out, needle string) string {
+	t.Helper()
+
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, needle) {
+			return line
+		}
+	}
+
+	require.Failf(t, "table row not found",
+		"no row containing %q in output:\n%s", needle, out)
+	return ""
+}

--- a/tests/acceptance/verification_test.go
+++ b/tests/acceptance/verification_test.go
@@ -1,0 +1,510 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build acceptance
+
+package acceptance
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/complytime/complyctl/internal/complytime"
+)
+
+// skipIfNoVerificationEnv skips the calling test when verification
+// environment variables are not set. Verification tests require
+// COSIGN_KEY_PATH to be configured, which is only available in the
+// verify-sut container profile — not in the lifecycle sut container.
+func skipIfNoVerificationEnv(t *testing.T) {
+	t.Helper()
+	if os.Getenv("COSIGN_KEY_PATH") == "" {
+		t.Skip("verification env vars not set")
+	}
+}
+
+// TestVerification_Keyed_HappyPath verifies that complyctl get with a
+// correct cosign public key succeeds and marks the policy as verified in
+// state.json. It also checks that complyctl list shows VERIFIED=Yes and
+// complyctl doctor reports the verification status.
+func TestVerification_Keyed_HappyPath(t *testing.T) {
+	skipIfNoVerificationEnv(t)
+	clearPolicyCache(t)
+
+	workDir := t.TempDir()
+
+	registryURL := os.Getenv("REGISTRY_URL")
+	require.NotEmpty(t, registryURL, "REGISTRY_URL must be set")
+
+	keyPath := os.Getenv("COSIGN_KEY_PATH")
+	require.NotEmpty(t, keyPath, "COSIGN_KEY_PATH must be set")
+
+	policyID := os.Getenv("VERIFY_KEYED_POLICY_ID")
+	require.NotEmpty(t, policyID, "VERIFY_KEYED_POLICY_ID must be set")
+
+	targetID := os.Getenv("TEST_TARGET_ID")
+	require.NotEmpty(t, targetID, "TEST_TARGET_ID must be set")
+
+	policyURL := registryURL + "/policies/" + policyID
+
+	writeVerificationConfig(t, workDir, registryURL,
+		withKeyedVerification(keyPath),
+		withPolicyEntries([]policyEntryConfig{{
+			URL:      policyURL,
+			PolicyID: policyID,
+			TargetID: targetID,
+		}}),
+	)
+
+	// get: fetch and verify the signed policy
+	runComplyctl(t, workDir, "get", "--workspace", workDir)
+
+	// Assert state.json records the policy as verified
+	state := readPolicyState(t)
+	policyKey := "policies/" + policyID
+	require.Contains(t, state.Policies, policyKey,
+		"state must contain an entry for %s", policyKey)
+	assert.True(t, state.Policies[policyKey].Verified,
+		"policy %s must be marked as verified", policyKey)
+
+	// list: the policy's row must show VERIFIED=Yes. Assert on the row
+	// that names this policy so a stray "Yes" elsewhere in the table
+	// (a different column or unrelated policy) cannot mask a regression.
+	listOut := runComplyctl(t, workDir, "list", "--workspace", workDir)
+	policyRow := findTableRow(t, listOut, policyID)
+	assert.Contains(t, policyRow, "Yes",
+		"complyctl list row for %s must show VERIFIED=Yes", policyID)
+
+	// doctor: must report verification status. doctor exits non-zero when
+	// any blocking check fails (e.g. no provider is installed in the
+	// verify-sut container), which is unrelated to verification, so capture
+	// the output without gating on the exit code and assert on the
+	// verification status it reports.
+	doctorOut, _ := runComplyctlExpectError(t, workDir, "doctor", "--workspace", workDir)
+	// doctor's verification check emits an aggregate summary line (see
+	// doctor.CheckVerification), not a per-policy row, so scope the assertion
+	// to that summary line and require it reports the artifact as verified
+	// (not unverified). A bare "verified" substring would also match the
+	// "N/M cached artifacts unverified" warning and mask a regression.
+	doctorRow := findTableRow(t, doctorOut, "cached artifacts")
+	doctorRowLower := strings.ToLower(doctorRow)
+	assert.Contains(t, doctorRowLower, "verified",
+		"complyctl doctor must report the artifact as verified")
+	assert.NotContains(t, doctorRowLower, "unverified",
+		"complyctl doctor must not report the artifact as unverified")
+}
+
+// TestVerification_Keyed_WrongKey verifies that complyctl get fails with
+// a non-zero exit code when configured with an incorrect cosign public
+// key and that the error output contains the expected verification
+// failure message.
+func TestVerification_Keyed_WrongKey(t *testing.T) {
+	skipIfNoVerificationEnv(t)
+	clearPolicyCache(t)
+
+	workDir := t.TempDir()
+
+	registryURL := os.Getenv("REGISTRY_URL")
+	require.NotEmpty(t, registryURL, "REGISTRY_URL must be set")
+
+	wrongKeyPath := os.Getenv("COSIGN_WRONG_KEY_PATH")
+	require.NotEmpty(t, wrongKeyPath, "COSIGN_WRONG_KEY_PATH must be set")
+
+	policyID := os.Getenv("VERIFY_KEYED_POLICY_ID")
+	require.NotEmpty(t, policyID, "VERIFY_KEYED_POLICY_ID must be set")
+
+	targetID := os.Getenv("TEST_TARGET_ID")
+	require.NotEmpty(t, targetID, "TEST_TARGET_ID must be set")
+
+	policyURL := registryURL + "/policies/" + policyID
+
+	writeVerificationConfig(t, workDir, registryURL,
+		withKeyedVerification(wrongKeyPath),
+		withPolicyEntries([]policyEntryConfig{{
+			URL:      policyURL,
+			PolicyID: policyID,
+			TargetID: targetID,
+		}}),
+	)
+
+	// get: must fail because the key does not match the signature
+	out, err := runComplyctlExpectError(t, workDir, "get", "--workspace", workDir)
+	require.Error(t, err, "complyctl get must fail with wrong verification key")
+	assert.Contains(t, out, "signature verification failed",
+		"error output must indicate signature verification failure")
+	// Discriminate a key/signature mismatch from an identity mismatch: the
+	// wrong-key path must NOT reference certificate identity, which is the
+	// discriminator the wrong-identity test asserts on. Without this a
+	// regression that turned the key check into the identity path (or a
+	// generic bail-out that happened to fail closed) could pass silently.
+	assert.NotContains(t, strings.ToLower(out), "identity",
+		"wrong-key failure must not be an identity mismatch")
+
+	// Assert no policy content was cached for this policy.
+	// The cache stores OCI layouts under the XDG cache dir at
+	// policies/<repository> where repository is the full OCI path
+	// e.g. "policies/verify-keyed".
+	cacheDir, cacheErr := complytime.ResolveCacheDir()
+	require.NoError(t, cacheErr)
+	policyLayoutDir := filepath.Join(cacheDir, "policies", "policies", policyID)
+	assert.NoDirExists(t, policyLayoutDir,
+		"OCI layout directory must not exist for policy with failed verification")
+}
+
+// TestVerification_Keyless_HappyPath verifies that complyctl get with
+// keyless (OIDC) verification succeeds and records signer identity and
+// issuer in state.json. Keyless verification is active: the trusted root
+// is supplied via TRUSTED_ROOT_PATH (keylessTrustedRootPath). The test
+// runs only in the verification compose profile and is otherwise skipped
+// by skipIfNoVerificationEnv.
+func TestVerification_Keyless_HappyPath(t *testing.T) {
+	skipIfNoVerificationEnv(t)
+	clearPolicyCache(t)
+
+	workDir := t.TempDir()
+
+	registryURL := os.Getenv("REGISTRY_URL")
+	require.NotEmpty(t, registryURL, "REGISTRY_URL must be set")
+
+	policyID := os.Getenv("VERIFY_KEYLESS_POLICY_ID")
+	require.NotEmpty(t, policyID, "VERIFY_KEYLESS_POLICY_ID must be set")
+
+	targetID := os.Getenv("TEST_TARGET_ID")
+	require.NotEmpty(t, targetID, "TEST_TARGET_ID must be set")
+
+	trustedRootPath := keylessTrustedRootPath()
+
+	issuer := keylessIssuer()
+	identity := keylessIdentity()
+
+	policyURL := registryURL + "/policies/" + policyID
+
+	writeVerificationConfig(t, workDir, registryURL,
+		withKeylessVerification(issuer, identity, trustedRootPath),
+		withPolicyEntries([]policyEntryConfig{{
+			URL:      policyURL,
+			PolicyID: policyID,
+			TargetID: targetID,
+		}}),
+	)
+
+	// get: fetch and verify the keyless-signed policy
+	runComplyctl(t, workDir, "get", "--workspace", workDir)
+
+	// Assert state.json records the policy as verified with identity
+	state := readPolicyState(t)
+	policyKey := "policies/verify-keyless"
+	require.Contains(t, state.Policies, policyKey,
+		"state must contain an entry for %s", policyKey)
+	assert.True(t, state.Policies[policyKey].Verified,
+		"policy %s must be marked as verified", policyKey)
+	assert.Equal(t, identity, state.Policies[policyKey].SignerIdentity,
+		"signer identity must match configured OIDC identity")
+	assert.Equal(t, issuer, state.Policies[policyKey].Issuer,
+		"issuer must match configured OIDC issuer")
+}
+
+// TestVerification_Keyless_WrongIdentity verifies that complyctl get
+// fails when the configured OIDC identity does not match the signer
+// identity in the signature. Keyless verification is active: the trusted
+// root is supplied via TRUSTED_ROOT_PATH (keylessTrustedRootPath). The
+// test runs only in the verification compose profile and is otherwise
+// skipped by skipIfNoVerificationEnv.
+func TestVerification_Keyless_WrongIdentity(t *testing.T) {
+	skipIfNoVerificationEnv(t)
+	clearPolicyCache(t)
+
+	workDir := t.TempDir()
+
+	registryURL := os.Getenv("REGISTRY_URL")
+	require.NotEmpty(t, registryURL, "REGISTRY_URL must be set")
+
+	policyID := os.Getenv("VERIFY_KEYLESS_POLICY_ID")
+	require.NotEmpty(t, policyID, "VERIFY_KEYLESS_POLICY_ID must be set")
+
+	targetID := os.Getenv("TEST_TARGET_ID")
+	require.NotEmpty(t, targetID, "TEST_TARGET_ID must be set")
+
+	trustedRootPath := keylessTrustedRootPath()
+
+	policyURL := registryURL + "/policies/" + policyID
+
+	// Deliberately configure an identity that does not match the signer
+	// so verification must fail; the issuer still comes from the wired env.
+	writeVerificationConfig(t, workDir, registryURL,
+		withKeylessVerification(keylessIssuer(), "wrong@example.com", trustedRootPath),
+		withPolicyEntries([]policyEntryConfig{{
+			URL:      policyURL,
+			PolicyID: policyID,
+			TargetID: targetID,
+		}}),
+	)
+
+	// get: must fail because the identity does not match the signature
+	out, err := runComplyctlExpectError(t, workDir, "get", "--workspace", workDir)
+	require.Error(t, err, "complyctl get must fail with wrong OIDC identity")
+	assert.Contains(t, out, "signature verification failed",
+		"error output must indicate signature verification failure")
+	// Distinguish an identity mismatch from any other verification failure
+	// (e.g. a wrong key): the wrong-identity path must reference the
+	// certificate identity / SAN mismatch rather than only the generic
+	// verification-failed prefix shared with the wrong-key test.
+	assert.Contains(t, strings.ToLower(out), "identity",
+		"error output must indicate a certificate identity mismatch")
+}
+
+// TestVerification_SkipVerifyFlag verifies that complyctl get
+// --skip-verify bypasses signature verification, succeeds, and marks
+// the policy as unverified in state.json. The CLI must emit a WARNING
+// about skipping and a NOTE about the unverified fetch.
+func TestVerification_SkipVerifyFlag(t *testing.T) {
+	skipIfNoVerificationEnv(t)
+	clearPolicyCache(t)
+
+	workDir := t.TempDir()
+
+	registryURL := os.Getenv("REGISTRY_URL")
+	require.NotEmpty(t, registryURL, "REGISTRY_URL must be set")
+
+	keyPath := os.Getenv("COSIGN_KEY_PATH")
+	require.NotEmpty(t, keyPath, "COSIGN_KEY_PATH must be set")
+
+	policyID := os.Getenv("VERIFY_KEYED_POLICY_ID")
+	require.NotEmpty(t, policyID, "VERIFY_KEYED_POLICY_ID must be set")
+
+	targetID := os.Getenv("TEST_TARGET_ID")
+	require.NotEmpty(t, targetID, "TEST_TARGET_ID must be set")
+
+	policyURL := registryURL + "/policies/" + policyID
+
+	writeVerificationConfig(t, workDir, registryURL,
+		withKeyedVerification(keyPath),
+		withPolicyEntries([]policyEntryConfig{{
+			URL:      policyURL,
+			PolicyID: policyID,
+			TargetID: targetID,
+		}}),
+	)
+
+	// get --skip-verify: must succeed but skip verification.
+	// Use runComplyctlCapture to inspect combined output (stdout+stderr) on
+	// the success path without fataling, so the skip warning and unverified
+	// note can be asserted.
+	out, err := runComplyctlCapture(t, workDir,
+		"get", "--skip-verify", "--workspace", workDir)
+	require.NoError(t, err,
+		"complyctl get --skip-verify must succeed")
+
+	// Assert the CLI warned about skipping verification
+	assert.Contains(t, out, "WARNING: signature verification skipped",
+		"output must contain skip-verify warning")
+
+	// Assert the CLI noted the policy was fetched without verification
+	assert.Contains(t, out, "NOTE: policy",
+		"output must contain unverified fetch note prefix")
+	assert.Contains(t, out, "was fetched without",
+		"output must contain unverified fetch note body")
+
+	// Assert state.json records the policy as unverified
+	state := readPolicyState(t)
+	policyKey := "policies/" + policyID
+	require.Contains(t, state.Policies, policyKey,
+		"state must contain an entry for %s", policyKey)
+	assert.False(t, state.Policies[policyKey].Verified,
+		"policy %s must NOT be marked as verified when --skip-verify is used", policyKey)
+}
+
+// TestVerification_PerEntrySkipVerify verifies that per-entry
+// skip_verify allows one policy to bypass verification while another
+// policy in the same workspace inherits workspace-level keyed
+// verification and is verified normally.
+func TestVerification_PerEntrySkipVerify(t *testing.T) {
+	skipIfNoVerificationEnv(t)
+	clearPolicyCache(t)
+
+	workDir := t.TempDir()
+
+	registryURL := os.Getenv("REGISTRY_URL")
+	require.NotEmpty(t, registryURL, "REGISTRY_URL must be set")
+
+	keyPath := os.Getenv("COSIGN_KEY_PATH")
+	require.NotEmpty(t, keyPath, "COSIGN_KEY_PATH must be set")
+
+	keyedPolicyID := os.Getenv("VERIFY_KEYED_POLICY_ID")
+	require.NotEmpty(t, keyedPolicyID, "VERIFY_KEYED_POLICY_ID must be set")
+
+	unsignedPolicyID := os.Getenv("VERIFY_UNSIGNED_POLICY_ID")
+	require.NotEmpty(t, unsignedPolicyID, "VERIFY_UNSIGNED_POLICY_ID must be set")
+
+	targetID := os.Getenv("TEST_TARGET_ID")
+	require.NotEmpty(t, targetID, "TEST_TARGET_ID must be set")
+
+	writeVerificationConfig(t, workDir, registryURL,
+		withKeyedVerification(keyPath),
+		withPolicyEntries([]policyEntryConfig{
+			{
+				// Entry 1: inherits workspace-level keyed verification
+				URL:      registryURL + "/policies/" + keyedPolicyID,
+				PolicyID: keyedPolicyID,
+				TargetID: targetID,
+			},
+			{
+				// Entry 2: per-entry skip_verify bypasses verification
+				URL:        registryURL + "/policies/" + unsignedPolicyID,
+				PolicyID:   unsignedPolicyID,
+				TargetID:   targetID,
+				SkipVerify: true,
+			},
+		}),
+	)
+
+	// get: must succeed — keyed entry verifies, unsigned entry skips
+	runComplyctl(t, workDir, "get", "--workspace", workDir)
+
+	state := readPolicyState(t)
+
+	// Entry 1: verified via workspace-level keyed config
+	keyedKey := "policies/" + keyedPolicyID
+	require.Contains(t, state.Policies, keyedKey,
+		"state must contain an entry for %s", keyedKey)
+	assert.True(t, state.Policies[keyedKey].Verified,
+		"policy %s must be marked as verified", keyedKey)
+
+	// Entry 2: unverified due to per-entry skip_verify
+	unsignedKey := "policies/" + unsignedPolicyID
+	require.Contains(t, state.Policies, unsignedKey,
+		"state must contain an entry for %s", unsignedKey)
+	assert.False(t, state.Policies[unsignedKey].Verified,
+		"policy %s must NOT be verified when skip_verify is set", unsignedKey)
+}
+
+// TestVerification_PerEntryOverride verifies that a per-entry
+// verification config overrides the workspace-level config. The
+// workspace is configured with keyless verification (which would fail
+// without trusted_root), but the first entry overrides with keyed
+// verification that succeeds. The second entry uses skip_verify to
+// avoid the keyless failure.
+func TestVerification_PerEntryOverride(t *testing.T) {
+	skipIfNoVerificationEnv(t)
+	clearPolicyCache(t)
+
+	workDir := t.TempDir()
+
+	registryURL := os.Getenv("REGISTRY_URL")
+	require.NotEmpty(t, registryURL, "REGISTRY_URL must be set")
+
+	keyPath := os.Getenv("COSIGN_KEY_PATH")
+	require.NotEmpty(t, keyPath, "COSIGN_KEY_PATH must be set")
+
+	keyedPolicyID := os.Getenv("VERIFY_KEYED_POLICY_ID")
+	require.NotEmpty(t, keyedPolicyID, "VERIFY_KEYED_POLICY_ID must be set")
+
+	unsignedPolicyID := os.Getenv("VERIFY_UNSIGNED_POLICY_ID")
+	require.NotEmpty(t, unsignedPolicyID, "VERIFY_UNSIGNED_POLICY_ID must be set")
+
+	targetID := os.Getenv("TEST_TARGET_ID")
+	require.NotEmpty(t, targetID, "TEST_TARGET_ID must be set")
+
+	trustedRootPath := keylessTrustedRootPath()
+
+	writeVerificationConfig(t, workDir, registryURL,
+		// Workspace-level: keyless (would fail without trusted_root)
+		withKeylessVerification(keylessIssuer(), keylessIdentity(), trustedRootPath),
+		withPolicyEntries([]policyEntryConfig{
+			{
+				// Entry 1: per-entry keyed override supersedes workspace keyless
+				URL:      registryURL + "/policies/" + keyedPolicyID,
+				PolicyID: keyedPolicyID,
+				TargetID: targetID,
+				Verification: &complytime.VerificationConfig{
+					Key: keyPath,
+				},
+			},
+			{
+				// Entry 2: skip_verify avoids keyless failure
+				URL:        registryURL + "/policies/" + unsignedPolicyID,
+				PolicyID:   unsignedPolicyID,
+				TargetID:   targetID,
+				SkipVerify: true,
+			},
+		}),
+	)
+
+	// get: must succeed — entry 1 uses keyed override, entry 2 skips
+	runComplyctl(t, workDir, "get", "--workspace", workDir)
+
+	state := readPolicyState(t)
+
+	// Entry 1: verified via per-entry keyed override
+	keyedKey := "policies/" + keyedPolicyID
+	require.Contains(t, state.Policies, keyedKey,
+		"state must contain an entry for %s", keyedKey)
+	assert.True(t, state.Policies[keyedKey].Verified,
+		"policy %s must be verified via per-entry keyed override", keyedKey)
+
+	// Entry 2: unverified due to skip_verify
+	unsignedKey := "policies/" + unsignedPolicyID
+	require.Contains(t, state.Policies, unsignedKey,
+		"state must contain an entry for %s", unsignedKey)
+	assert.False(t, state.Policies[unsignedKey].Verified,
+		"policy %s must NOT be verified when skip_verify is set", unsignedKey)
+}
+
+// TestVerification_UnsignedWithVerification verifies that complyctl get
+// fails when keyed verification is configured but the target OCI
+// artifact has no cosign signature. The error must indicate no signature
+// was found, and no policy content should be cached.
+func TestVerification_UnsignedWithVerification(t *testing.T) {
+	skipIfNoVerificationEnv(t)
+	clearPolicyCache(t)
+
+	workDir := t.TempDir()
+
+	registryURL := os.Getenv("REGISTRY_URL")
+	require.NotEmpty(t, registryURL, "REGISTRY_URL must be set")
+
+	keyPath := os.Getenv("COSIGN_KEY_PATH")
+	require.NotEmpty(t, keyPath, "COSIGN_KEY_PATH must be set")
+
+	unsignedPolicyID := os.Getenv("VERIFY_UNSIGNED_POLICY_ID")
+	require.NotEmpty(t, unsignedPolicyID, "VERIFY_UNSIGNED_POLICY_ID must be set")
+
+	targetID := os.Getenv("TEST_TARGET_ID")
+	require.NotEmpty(t, targetID, "TEST_TARGET_ID must be set")
+
+	policyURL := registryURL + "/policies/" + unsignedPolicyID
+
+	writeVerificationConfig(t, workDir, registryURL,
+		withKeyedVerification(keyPath),
+		withPolicyEntries([]policyEntryConfig{{
+			URL:      policyURL,
+			PolicyID: unsignedPolicyID,
+			TargetID: targetID,
+		}}),
+	)
+
+	// get: must fail because the unsigned artifact has no cosign signature
+	out, err := runComplyctlExpectError(t, workDir, "get", "--workspace", workDir)
+	require.Error(t, err,
+		"complyctl get must fail when verifying an unsigned artifact")
+	assert.Contains(t, strings.ToLower(out), "no cosign signature found",
+		"error output must indicate no cosign signature was found")
+
+	// Assert state.json does NOT contain an entry for the unsigned policy
+	state := readPolicyState(t)
+	unsignedKey := "policies/" + unsignedPolicyID
+	assert.NotContains(t, state.Policies, unsignedKey,
+		"state must NOT contain an entry for unsigned policy %s", unsignedKey)
+
+	// Assert no OCI layout directory was cached for the unsigned policy
+	cacheDir, cacheErr := complytime.ResolveCacheDir()
+	require.NoError(t, cacheErr)
+	policyLayoutDir := filepath.Join(cacheDir, "policies",
+		"policies", unsignedPolicyID)
+	assert.NoDirExists(t, policyLayoutDir,
+		"OCI layout directory must not exist for unsigned policy")
+}

--- a/tests/acceptance/verify-sut-entrypoint.sh
+++ b/tests/acceptance/verify-sut-entrypoint.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+
+# verify-sut-entrypoint.sh — wait for sign-seed artifacts before
+# running verification tests.  docker compose enforces the
+# depends_on service_completed_successfully condition, but
+# podman-compose ignores it.  This wrapper provides defence-in-depth
+# so local runs succeed under either compose implementation.
+#
+# The gate is the completion sentinel that sign-seed writes as its
+# very last action, not the individual artifact files.  Under
+# podman-compose the shared volume can carry stale cosign.pub /
+# wrong.pub / trusted_root.json from a prior run, which would satisfy
+# a file-only gate "after 0s" and let the tests race a half-seeded
+# registry.  The Makefile removes the volume (down -v) before every
+# run, so the sentinel is guaranteed absent until this run's sign-seed
+# finishes.  It is listed last so its presence proves every artifact
+# written before it is also present.
+
+SHARED_DIR="/shared"
+MAX_WAIT=120
+INTERVAL=2
+
+required_files=(
+	"${SHARED_DIR}/cosign.pub"
+	"${SHARED_DIR}/wrong.pub"
+	"${SHARED_DIR}/trusted_root.json"
+	"${SHARED_DIR}/.sign-seed-complete"
+)
+
+echo "Waiting for sign-seed artifacts in ${SHARED_DIR}..."
+elapsed=0
+while true; do
+	all_present=true
+	for f in "${required_files[@]}"; do
+		if [[ ! -f "$f" ]]; then
+			all_present=false
+			break
+		fi
+	done
+
+	if $all_present; then
+		echo "All sign-seed artifacts present after ${elapsed}s."
+		break
+	fi
+
+	if [[ $elapsed -ge $MAX_WAIT ]]; then
+		echo "ERROR: sign-seed artifacts not found after ${MAX_WAIT}s." >&2
+		for f in "${required_files[@]}"; do
+			[[ -f "$f" ]] || echo "  missing: $f" >&2
+		done
+		exit 1
+	fi
+
+	sleep "$INTERVAL"
+	elapsed=$((elapsed + INTERVAL))
+done
+
+exec /usr/local/bin/acceptance.test "$@"


### PR DESCRIPTION

## Summary

- Add container-based acceptance tests for `complyctl get` signature verification against a real zot OCI registry with a full private Sigstore stack (Dex, Fulcio fileca, CTFE CT log, Rekor+Trillian+MySQL), covering 8 scenarios: keyed happy path, wrong key, keyless happy path, wrong identity, `--skip-verify`, per-entry `skip_verify`, per-entry override, and unsigned artifact rejection
- Fix four defects in `internal/cache/verify.go` exposed by the live stack: plain-HTTP registry scheme support (`insecure` flag), PublicKey verification material for keyed bundles, hex-decode of Rekor logID (was base64), and use of signature-layer digest (simplesigning payload) instead of manifest digest for the message-signature artifact digest
- Add Makefile targets (`test-acceptance-verify`, `test-acceptance-verify-clean`, `test-acceptance-all`), CI workflow (`acceptance_verify_test.yml`), and documentation updates (AGENTS.md, CHANGELOG.md, TESTING_ENVIRONMENT.md)

## Related Issues

- Fixes: #678

## Review Hints

- Start with `tests/acceptance/verification_test.go` for the 8 test scenarios and their assertions, then `tests/acceptance/verification_helpers_test.go` for the shared test utilities (`writeVerificationConfig`, `readPolicyState`, `clearPolicyCache`)

- Review `internal/cache/verify.go` for the four production bug fixes — each has an inline comment explaining the root cause. The corresponding unit test changes are in `internal/cache/verify_test.go` and `internal/cache/sync_test.go` (`TestSync_RegistryHost_SchemeStripped`)

- `tests/acceptance/compose.yaml` defines the Sigstore service topology under the `verification` profile — `sign-seed.sh` is the most complex new script (pushes, signs keyed+keyless, builds `trusted_root.json`)

- Test PKI under `tests/acceptance/testdata/sigstore/` is test-only with zero security value (see `README.md` there); passphrases are `fulcio` and `ctfe`

- The `VerifyFunc` signature changed from 2 to 3 parameters (added `insecure bool`), so all mock verifiers in `*_test.go` files were updated mechanically
