### PR TITLE
test: add NotApplicable aggregation regression tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Fixed
+
+- Scans where all controls are not-applicable now report
+  `NotApplicable` aggregate result instead of `Passed`. This
+  corrects a semantic error in upstream `go-gemara` result
+  aggregation fixed in v0.9.0. (#813)
+
+### Security
+
+- Transitive `oras-go` bump via `go-gemara` v0.9.1 addresses
+  CVE-2026-50163. (#813)
+
 ### Changed
 
 - **BREAKING**: User-scoped paths now follow the

--- a/internal/output/evaluator_test.go
+++ b/internal/output/evaluator_test.go
@@ -74,6 +74,19 @@ func TestGemaraLog_AggregatesResult(t *testing.T) {
 			steps:    nil,
 			expected: gemara.NotRun,
 		},
+		{
+			name:     "all skipped yields NotApplicable",
+			steps:    []provider.Step{{Result: provider.ResultSkipped, Message: "n/a"}},
+			expected: gemara.NotApplicable,
+		},
+		{
+			name: "mixed passed and skipped yields Passed",
+			steps: []provider.Step{
+				{Result: provider.ResultPassed, Message: "ok"},
+				{Result: provider.ResultSkipped, Message: "n/a"},
+			},
+			expected: gemara.Passed,
+		},
 	}
 
 	for _, tt := range tests {
@@ -84,6 +97,21 @@ func TestGemaraLog_AggregatesResult(t *testing.T) {
 			})
 			assert.Equal(t, tt.expected, eval.GemaraLog().Result)
 		})
+	}
+}
+
+func TestGemaraLog_AllSkippedControlsYieldNotApplicable(t *testing.T) {
+	eval := output.NewEvaluator("pol", "tgt", nil, nil, nil)
+	eval.AddTarget([]provider.AssessmentLog{
+		{RequirementID: "R1", Steps: []provider.Step{{Result: provider.ResultSkipped, Message: "n/a"}}},
+		{RequirementID: "R2", Steps: []provider.Step{{Result: provider.ResultSkipped, Message: "n/a"}}},
+	})
+	log := eval.GemaraLog()
+	assert.Equal(t, gemara.NotApplicable, log.Result,
+		"overall result should be NotApplicable when all controls are skipped")
+	for _, ce := range log.Evaluations {
+		assert.Equal(t, gemara.NotApplicable, ce.Result,
+			"each control evaluation should be NotApplicable")
 	}
 }
 

--- a/internal/output/scan_summary_test.go
+++ b/internal/output/scan_summary_test.go
@@ -297,9 +297,9 @@ func TestFormatScanSummary_ShowPassingFalse(t *testing.T) {
 }
 
 func TestFormatScanSummary_SortOrder(t *testing.T) {
-	// ResultSkipped maps to gemara.NotApplicable, which aggregates to
-	// gemara.Passed via gemara.UpdateAggregateResult. An empty Steps
-	// slice produces gemara.NotRun (the skip/not-run branch).
+	// ResultSkipped maps to gemara.NotApplicable. When combined with
+	// other NotApplicable results, UpdateAggregateResult preserves
+	// NotApplicable. An empty Steps slice produces gemara.NotRun.
 	// ResultError maps to gemara.Unknown.
 	assessments := []provider.AssessmentLog{
 		{


### PR DESCRIPTION
## Summary

Adds regression test coverage and documentation for the`UpdateAggregateResult` behavioral change introduced in
go-gemara v0.9.0 (merged via #813, originally proposed in #801).

## Changes

1. **New tests** in `evaluator_test.go`:
   - All-skipped steps → `NotApplicable` (was `Passed` pre-v0.9.0)
   - Mixed passed + skipped → `Passed` (dominance preserved)
   - Multi-control all-skipped → overall `NotApplicable`
2. **Fixed stale comment** in `scan_summary_test.go:300-302`
3. **CHANGELOG entries** for behavioral change and CVE-2026-50163

## Context

The go-gemara v0.9.0+ `UpdateAggregateResult` fix correctly returns `NotApplicable` instead of `Passed` when all inputs are`NotApplicable`. This affects `evaluator.go:91,106` and `sarif.go:61`. These tests lock down the new semantics to
prevent silent regressions if upstream behavior changes again.