### PR TITLE
fix: use git describe for version tag detection in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GO_BUILD_PACKAGES := ./cmd/...
 GO_BUILD_BINDIR :=./bin
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
-GIT_TAG ?= $(shell git tag | sort -V | tail -1 2>/dev/null || echo "v0.0.0")
+GIT_TAG ?= $(shell git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
 GIT_TREE_STATE ?= $(shell test -n "`git status --porcelain 2>/dev/null`" && echo "dirty" || echo "clean")
 BUILD_DATE ?= $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 


### PR DESCRIPTION
## Problem

`make build` injects the wrong version tag (`v1.0.0-rc.0`) instead of the correct release version (`v1.0.0`).

### Root cause

The Makefile resolves `GIT_TAG` via:
```makefile
GIT_TAG ?= $(shell git tag | sort -V | tail -1 2>/dev/null || echo "v0.0.0")
```

`sort -V` treats pre-release suffixes (`-alpha.0`, `-beta.0`, `-rc.0`) as additional components, sorting them **after** the base version:
```
v1.0.0           <- sort -V puts this first
v1.0.0-alpha.0
v1.0.0-beta.0
v1.0.0-rc.0      <- tail -1 picks this (wrong)
```

Per [semver spec item 11](https://semver.org/#spec-item-11), `v1.0.0` has **higher** precedence than any `v1.0.0-*` pre-release. This `sort -V` inversion was already identified and fixed in the release pipeline (org-infra reusable workflows), but the Makefile was never updated.

## Fix

Replace with `git describe --tags --abbrev=0`, which returns the most recent tag reachable from HEAD:

```makefile
GIT_TAG ?= $(shell git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
```

### Verification
```
# Before (old command)
git tag | sort -V | tail -1  =>  v1.0.0-rc.0

# After (new command)
git describe --tags --abbrev=0  =>  v1.0.0
```

## Scope

Single line change in `Makefile:4`. No other files affected. GoReleaser uses `{{ .Version }}` from the release tag independently.