### PR TITLE
fix: do not create workspace directory as a side effect of logging

### DIFF
--- a/cmd/complyctl/cli/cli_test.go
+++ b/cmd/complyctl/cli/cli_test.go
@@ -1756,6 +1756,9 @@ func TestSaveGenerationAndPrint_NoComplypacks(t *testing.T) {
 
 func TestLazyLogWriter_Write_CreatesLogFile(t *testing.T) {
 	baseDir := t.TempDir()
+	// Pre-create the workspace directory to simulate an initialized workspace.
+	require.NoError(t, os.MkdirAll(filepath.Join(baseDir, complytime.WorkspaceDir), 0700))
+
 	w := &lazyLogWriter{}
 	w.SetWorkspace(baseDir)
 
@@ -1774,6 +1777,9 @@ func TestLazyLogWriter_Write_CreatesLogFile(t *testing.T) {
 
 func TestLazyLogWriter_Write_DefaultBaseDir(t *testing.T) {
 	chdirTemp(t)
+	// Pre-create the workspace directory to simulate an initialized workspace.
+	require.NoError(t, os.MkdirAll(complytime.WorkspaceDir, 0700))
+
 	w := &lazyLogWriter{}
 	// No SetWorkspace call — should default to "."
 
@@ -1797,6 +1803,9 @@ func TestLazyLogWriter_Close_NilFile(t *testing.T) {
 
 func TestLazyLogWriter_Write_MultipleWrites(t *testing.T) {
 	baseDir := t.TempDir()
+	// Pre-create the workspace directory to simulate an initialized workspace.
+	require.NoError(t, os.MkdirAll(filepath.Join(baseDir, complytime.WorkspaceDir), 0700))
+
 	w := &lazyLogWriter{}
 	w.SetWorkspace(baseDir)
 
@@ -1811,6 +1820,26 @@ func TestLazyLogWriter_Write_MultipleWrites(t *testing.T) {
 	content, err := os.ReadFile(logPath)
 	require.NoError(t, err)
 	assert.Equal(t, "first\nsecond\n", string(content))
+}
+
+func TestLazyLogWriter_Write_SkipsWhenDirNotExists(t *testing.T) {
+	baseDir := t.TempDir()
+	// Do NOT pre-create the workspace directory.
+	// The writer must not create it as a side effect.
+	w := &lazyLogWriter{}
+	w.SetWorkspace(baseDir)
+
+	n, err := w.Write([]byte("should be discarded\n"))
+
+	require.NoError(t, err)
+	assert.Equal(t, 20, n)
+
+	wsDir := filepath.Join(baseDir, complytime.WorkspaceDir)
+	_, statErr := os.Stat(wsDir)
+	assert.True(t, os.IsNotExist(statErr),
+		"workspace directory must not be created as a side effect of logging")
+
+	require.NoError(t, w.Close())
 }
 
 // --- New() tests ---
@@ -2599,19 +2628,16 @@ func TestDebugFlagDescription(t *testing.T) {
 	assert.Equal(t, "output debug logs to stderr and log file", f.Usage)
 }
 
-// TestEnableDebug_UnwritableLogDir verifies that when the log directory cannot
-// be created, debug output still appears on stderr and a warning about the log
-// directory failure is present.
-func TestEnableDebug_UnwritableLogDir(t *testing.T) {
+// TestEnableDebug_NonexistentLogDir verifies that when the workspace directory
+// does not exist, debug output still appears on stderr and the writer silently
+// skips log file creation without creating directories as a side effect.
+func TestEnableDebug_NonexistentLogDir(t *testing.T) {
 	saveLogger(t)
 
-	// Create a read-only directory so MkdirAll fails inside lazyLogWriter.
-	readOnlyDir := t.TempDir()
-	require.NoError(t, os.Chmod(readOnlyDir, 0o500))
-	t.Cleanup(func() { _ = os.Chmod(readOnlyDir, 0o700) })
-
+	// Use a path where the workspace directory does not exist.
+	baseDir := t.TempDir()
 	testLw := &lazyLogWriter{}
-	testLw.SetWorkspace(filepath.Join(readOnlyDir, "nested"))
+	testLw.SetWorkspace(filepath.Join(baseDir, "nonexistent"))
 	lw = testLw
 
 	// Capture stderr via pipe.
@@ -2623,7 +2649,7 @@ func TestEnableDebug_UnwritableLogDir(t *testing.T) {
 
 	opts := &Common{Debug: true}
 	enableDebug(opts, testLw, w)
-	logger.Debug("debug despite unwritable dir")
+	logger.Debug("debug despite missing dir")
 
 	// Trigger the lazyLogWriter to attempt file creation.
 	_, _ = testLw.Write([]byte("trigger\n"))
@@ -2637,10 +2663,13 @@ func TestEnableDebug_UnwritableLogDir(t *testing.T) {
 	// Debug output should still appear on stderr even though the log file
 	// could not be created.
 	assert.Contains(t, output, "DEBUG")
-	assert.Contains(t, output, "debug despite unwritable dir")
+	assert.Contains(t, output, "debug despite missing dir")
 
-	// The lazyLogWriter should have emitted a warning about the failure.
-	assert.Contains(t, output, "Warning:")
+	// No directory should have been created as a side effect.
+	wsDir := filepath.Join(baseDir, "nonexistent", complytime.WorkspaceDir)
+	_, statErr := os.Stat(wsDir)
+	assert.True(t, os.IsNotExist(statErr),
+		"workspace directory must not be created as a side effect")
 }
 
 // TestEnableDebug_NoColor verifies that with NO_COLOR=1, enableDebug does not

--- a/cmd/complyctl/cli/root.go
+++ b/cmd/complyctl/cli/root.go
@@ -54,8 +54,11 @@ func (w *lazyLogWriter) Write(p []byte) (int, error) {
 			baseDir = "."
 		}
 		logDir := filepath.Join(baseDir, complytime.WorkspaceDir)
-		if err := os.MkdirAll(logDir, 0700); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to create log directory: %v\n", err)
+		// Only write logs when the workspace directory already exists.
+		// Do not create it as a side effect of logging — creating
+		// ~/.complytime when workspace is $HOME would trigger a false
+		// legacy-directory deprecation warning from CheckLegacyDir().
+		if _, err := os.Stat(logDir); err != nil {
 			return
 		}
 		logPath := filepath.Join(logDir, complytime.LogFileName)


### PR DESCRIPTION
## Problem

When running any `complyctl` command from `$HOME` without a prior `complyctl init`, the `lazyLogWriter` creates `~/.complytime/` as a side effect of writing the log file. On subsequent runs, `CheckLegacyDir()` detects this directory and emits a false deprecation warning about migrating to XDG directories — even though no legacy data exists.

### Reproduction

```bash
# From a clean home directory (no ~/.complytime)
cd ~
complyctl list
# First run: creates ~/.complytime/ via error logging, shows only the error
# Second run: CheckLegacyDir() finds ~/.complytime/, shows false WARNING + error
```

### Root cause

`lazyLogWriter.Write()` in `cmd/complyctl/cli/root.go` called `os.MkdirAll()` to create `{workspace}/.complytime/` before writing the log file. When `workspace == $HOME`, this path (`~/.complytime`) collides with the legacy directory that `CheckLegacyDir()` warns about.

## Fix

Replace `os.MkdirAll` with `os.Stat` — the log writer now only writes when the workspace directory **already exists** (i.e., the user previously ran `complyctl init`). When the directory does not exist, log output is silently discarded.

This is safe because:
- Commands fail early without a workspace config, and the error is already printed to stderr
- Debug mode (`--debug`) tees all output to stderr via `teeWriter` regardless of log file creation
- In normal operation, `complyctl init` creates the workspace directory before any meaningful logging occurs

## Changes

| File | Change |
|---|---|
| `cmd/complyctl/cli/root.go` | Replace `os.MkdirAll` with `os.Stat` check in `lazyLogWriter.Write()` |
| `cmd/complyctl/cli/cli_test.go` | Update existing tests to pre-create workspace dir; add `TestLazyLogWriter_Write_SkipsWhenDirNotExists`; update `TestEnableDebug_UnwritableLogDir` → `TestEnableDebug_NonexistentLogDir` |

## Testing

```bash
go test -race ./...   # all pass
go vet ./...          # clean
```