### PR TITLE
chore: add Fedora 45 and remove F43 Go version hack

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -26,6 +26,7 @@ jobs:
       trigger: pull_request
       targets:
           - fedora-rawhide-x86_64
+          - fedora-45-x86_64
           - fedora-44-x86_64
           - fedora-43-x86_64
           # CentOS Stream targets removed: go-vendor-tools is not
@@ -37,6 +38,7 @@ jobs:
       trigger: pull_request
       targets:
           - fedora-rawhide-x86_64
+          - fedora-45-x86_64
           - fedora-44-x86_64
           - fedora-43-x86_64
           # CentOS Stream targets removed: go-vendor-tools is not
@@ -49,6 +51,7 @@ jobs:
       trigger: release
       dist_git_branches:
           - rawhide
+          - f45
           - f44
           - f43
 
@@ -57,6 +60,7 @@ jobs:
       trigger: commit
       dist_git_branches:
           - rawhide
+          - f45
           - f44
           - f43
 
@@ -64,5 +68,6 @@ jobs:
     - job: bodhi_update
       trigger: commit
       dist_git_branches:
+          - f45
           - f44
           - f43

--- a/complyctl.spec
+++ b/complyctl.spec
@@ -38,16 +38,6 @@ Providers are distributed separately via the complytime-providers package.
 %setup -q -T -D -a1 %{forgesetupargs}
 %autopatch -p1
 
-# Fedora 43 ships Go 1.25 but go.mod may require Go 1.26+ due to
-# transitive dependency requirements. Lower the directive to the
-# system Go major.minor so rpmbuild succeeds with GOTOOLCHAIN=local.
-# Fedora 43 EOL: 2026-12-09 — remove this block after EOL.
-# Reference: https://packages.fedoraproject.org/pkgs/golang/golang/
-%if 0%{?fedora} == 43
-sed -i 's/^go [0-9].*/go 1.25/' go.mod
-sed -i '/^## explicit; go /s/go [0-9]\..*/go 1.25/' vendor/modules.txt
-%endif
-
 %generate_buildrequires
 %go_vendor_license_buildrequires -c %{S:2}
 


### PR DESCRIPTION
## Summary

Two packaging maintenance changes following the Fedora 45 branch creation.

### Add Fedora 45 to Packit configuration

Add `fedora-45` / `f45` to all Packit jobs: `copr_build`, `tests`, `propose_downstream`, `koji_build`, and `bodhi_update`. The `f45` branch already exists in Fedora dist-git for complyctl.

### Remove F43 Go version compatibility hack

The `%prep` sed hack that patched `go.mod` and `vendor/modules.txt` from Go 1.26.x to Go 1.25 is no longer needed. All active Fedora releases now ship Go 1.26.7+, which satisfies the `go.mod` requirement of `go 1.26.7`.