### PR TITLE
fix(doctor): discover RPM-installed providers in CheckProviders

### DIFF
--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -333,17 +333,10 @@ func CheckConfig(configPath string) CheckResult {
 // CheckProviders discovers providers and runs Describe on each.
 // Returns both diagnostic results and Describe data for variable validation (R51).
 // providerLogger is passed to the provider Manager for go-plugin client logging.
+// Discovery scans both the user directory (providerDir) and the system-wide
+// directory (complytime.SystemProviderDir) so RPM-installed providers are found
+// even when the user directory does not exist.
 func CheckProviders(providerDir string, providerLogger hclog.Logger) ([]CheckResult, []ProviderHealth) {
-	if _, err := os.Stat(providerDir); os.IsNotExist(err) {
-		return []CheckResult{{
-			Name:     "providers",
-			Group:    GroupProviders,
-			Status:   StatusFail,
-			Message:  fmt.Sprintf("provider directory %s not found", providerDir),
-			Blocking: true,
-		}}, nil
-	}
-
 	mgr, err := provider.NewManager(providerDir, providerLogger)
 	if err != nil {
 		return []CheckResult{{
@@ -369,10 +362,13 @@ func CheckProviders(providerDir string, providerLogger hclog.Logger) ([]CheckRes
 	providers := mgr.ListProviders()
 	if len(providers) == 0 {
 		return []CheckResult{{
-			Name:     "providers",
-			Group:    GroupProviders,
-			Status:   StatusWarn,
-			Message:  fmt.Sprintf("no providers found in %s", providerDir),
+			Name:   "providers",
+			Group:  GroupProviders,
+			Status: StatusWarn,
+			Message: fmt.Sprintf(
+				"no providers found in %s or %s",
+				providerDir, complytime.SystemProviderDir,
+			),
 			Blocking: false,
 		}}, nil
 	}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -100,6 +101,39 @@ func (m *mockPolicyGraphResolver) ResolvePolicyGraph(policyID, version string) (
 		return g, nil
 	}
 	return nil, fmt.Errorf("graph not found: %s", key)
+}
+
+// --- CheckProviders Tests ---
+
+func TestCheckProviders_NonExistentUserDir(t *testing.T) {
+	// Simulates RPM-only install where the user XDG provider directory
+	// does not exist. The discovery layer should tolerate the missing
+	// user directory and fall through to the system directory scan.
+	// On dev machines where /usr/libexec/complytime/providers also
+	// does not exist, the result should be a non-blocking WARN
+	// (not the previous blocking FAIL with "directory not found").
+	nonExistent := filepath.Join(t.TempDir(), "does-not-exist")
+	results, healthData := CheckProviders(nonExistent, hclog.NewNullLogger())
+
+	require.Len(t, results, 1)
+	assert.Equal(t, StatusWarn, results[0].Status)
+	assert.False(t, results[0].Blocking)
+	assert.Contains(t, results[0].Message, "no providers found")
+	assert.Contains(t, results[0].Message, complytime.SystemProviderDir)
+	assert.Nil(t, healthData)
+}
+
+func TestCheckProviders_EmptyUserDir(t *testing.T) {
+	// User directory exists but is empty. Same outcome: no providers
+	// discovered from either directory on a dev machine.
+	emptyDir := t.TempDir()
+	results, healthData := CheckProviders(emptyDir, hclog.NewNullLogger())
+
+	require.Len(t, results, 1)
+	assert.Equal(t, StatusWarn, results[0].Status)
+	assert.False(t, results[0].Blocking)
+	assert.Contains(t, results[0].Message, "no providers found")
+	assert.Nil(t, healthData)
 }
 
 // --- CheckPolicyVersions Tests ---


### PR DESCRIPTION
## Summary

`complyctl doctor` reported a blocking FAIL for provider discovery when providers
were installed via RPM at `/usr/libexec/complytime/providers` and the user XDG
directory (`~/.local/share/complytime/providers`) did not exist. Meanwhile,
`complyctl providers` correctly discovered the same providers.

## Root Cause

`CheckProviders` in `internal/doctor/doctor.go` had an `os.Stat(providerDir)`
early-exit guard that returned a blocking FAIL when the user directory was absent.
This short-circuited before `NewManager` / `LoadProviders` / `DiscoverProviders()`
ever ran, preventing the system directory fallback from being reached.

The `scanDir()` helper in `pkg/provider/discovery.go` already handles non-existent
directories gracefully (returns `nil, nil`), so the guard was both redundant and
harmful.

## Changes

- **Remove `os.Stat` early-exit guard** in `CheckProviders` — let the discovery
  layer handle missing directories as it already does for `complyctl providers`
- **Update "no providers found" message** to mention both the user directory and
  the system directory (`/usr/libexec/complytime/providers`) for better diagnostics
- **Add unit tests**: `TestCheckProviders_NonExistentUserDir` and
  `TestCheckProviders_EmptyUserDir` covering both scenarios

## Verification

- `make test-unit` — all tests pass
- `make lint` — zero issues

Fixes #844